### PR TITLE
Allow including images on newsletters

### DIFF
--- a/app/models/ckeditor/picture.rb
+++ b/app/models/ckeditor/picture.rb
@@ -5,7 +5,8 @@ class Ckeditor::Picture < Ckeditor::Asset
   validates :storage_data, file_content_type: { allow: /^image\/.*/ }, file_size: { less_than: 2.megabytes }
 
   def url_content
-    rails_representation_url(storage_data.variant(resize: "800>"), only_path: true)
+    url = root_url(ActionMailer::Base.default_url_options)
+    "#{url}#{rails_representation_url(storage_data.variant(resize: "800>"), only_path: true)}"
   end
 
   def url_thumb

--- a/app/views/admin/newsletters/_form.html.erb
+++ b/app/views/admin/newsletters/_form.html.erb
@@ -5,7 +5,7 @@
                                                       @newsletter[:segment_recipient]) %>
   <%= f.text_field :subject %>
   <%= f.text_field :from %>
-  <%= f.text_area :body, class: "html-area" %>
+  <%= f.text_area :body, class: "html-area admin" %>
 
   <div class="margin-top">
     <%= f.submit class: "button success" %>

--- a/app/views/mailer/newsletter.html.erb
+++ b/app/views/mailer/newsletter.html.erb
@@ -1,7 +1,7 @@
 <td style="<%= css_for_mailer_content %>">
 
   <p style="<%= css_for_mailer_text %>">
-    <%= auto_link_already_sanitized_html wysiwyg(@newsletter.body) %>
+    <%= auto_link_already_sanitized_html AdminWYSIWYGSanitizer.new.sanitize(@newsletter.body) %>
   </p>
 
   <p style="<%= css_for_mailer_text %>">

--- a/spec/system/admin/emails/newsletters_spec.rb
+++ b/spec/system/admin/emails/newsletters_spec.rb
@@ -139,6 +139,38 @@ describe "Admin newsletter emails", :admin do
       expect(page).to have_content "Newsletter sent successfully"
     end
 
+    scenario "Send newsletter with an image" do
+      html_content = "<p>This newsletter have an image <img src=\"/image.jpg\" alt=\"Image title\"></img></p>"
+      newsletter = create(:newsletter, body: html_content, segment_recipient: "administrators")
+
+      visit edit_admin_newsletter_path(newsletter)
+
+      within("#cke_newsletter_body") do
+        expect(page).to have_css(".cke_button__image_icon")
+      end
+
+      visit admin_newsletters_path
+      within("#newsletter_#{newsletter.id}") do
+        click_link "Preview"
+      end
+
+      within ".newsletter-body-content" do
+        expect(page).to have_css "img[src$=\"image.jpg\"]"
+        expect(page).to have_css "img[alt=\"Image title\"]"
+      end
+
+      visit admin_newsletter_path(newsletter)
+
+      accept_confirm { click_link "Send" }
+
+      expect(page).to have_content "Newsletter sent successfully"
+
+      email = open_last_email
+
+      expect(email).to have_css "img[src$=\"image.jpg\"]"
+      expect(email).to have_css "img[alt=\"Image title\"]"
+    end
+
     scenario "Invalid newsletter cannot be sent" do
       invalid_newsletter = create(:newsletter)
       invalid_newsletter.update_column(:segment_recipient, "invalid_segment")

--- a/spec/system/ckeditor_spec.rb
+++ b/spec/system/ckeditor_spec.rb
@@ -20,6 +20,8 @@ describe "CKEditor" do
 
   scenario "uploading an image through the upload tab", :admin do
     visit new_admin_site_customization_page_path
+    allow(ActionMailer::Base).to receive(:default_url_options).and_return({ host: Capybara.app_host, port: app_port })
+
     fill_in_ckeditor "Content", with: "Filling in to make sure CKEditor is loaded"
     find(".cke_button__image").click
 
@@ -38,7 +40,10 @@ describe "CKEditor" do
 
     click_link "Send it to the Server"
 
-    expect(page).to have_css "img[src$='clippy.jpg']"
+    within ".ImagePreviewBox" do
+      expect(page).to have_css "img[src^='#{Capybara.app_host}:#{app_port}']"
+      expect(page).to have_css "img[src$='clippy.jpg']"
+    end
   end
 
   scenario "cannot upload attachments through link tab", :admin do


### PR DESCRIPTION
## References

https://github.com/consul/consul/issues/4834

## Objectives

Allow include images on newsletters `admin/newsletters/new`.

## Visual Changes
![newsletter_image](https://user-images.githubusercontent.com/631897/176505876-05e4f644-3ee1-481f-9f68-3a562e46e472.png)

## Notes

I have added some specs to test that the image works, but I had to add a `Setting["url"] = ""` in `spec/system/ckeditor_spec.rb` because I have not been able to test an image with a full external URL 😅, and I think it should be added before merge to properly test these changes. 🙏🏻