### PR TITLE
Rotate logs on production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -87,6 +87,11 @@ Rails.application.configure do
   # Use default logging formatter so that PID and timestamp are not suppressed.
   config.log_formatter = ::Logger::Formatter.new
 
+  # Rotate logger
+  logger = ActiveSupport::Logger.new(config.default_log_file, "daily")
+  logger.formatter = config.log_formatter
+  config.logger = ActiveSupport::TaggedLogging.new(logger)
+
   # Use a different logger for distributed setups.
   # require "syslog/logger"
   # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new "app-name")

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -86,6 +86,11 @@ Rails.application.configure do
   # Use default logging formatter so that PID and timestamp are not suppressed.
   config.log_formatter = ::Logger::Formatter.new
 
+  # Rotate logger
+  logger = ActiveSupport::Logger.new(config.default_log_file, "daily")
+  logger.formatter = config.log_formatter
+  config.logger = ActiveSupport::TaggedLogging.new(logger)
+
   # Use a different logger for distributed setups.
   # require "syslog/logger"
   # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new "app-name")


### PR DESCRIPTION
## References

* The code follows the recommendations in the [Rails configuration guide](https://guides.rubyonrails.org/v6.0/configuring.html)

## Objectives

* Make it easier to check the logs on production
* Make it easier to delete old log entries while keeping the newer ones

## Notes

Maybe we should create another pull request making it easier to get the log entries for a specific tenant :thinking:.

## Release notes

:warning: On production and staging environments, in order to avoid having log files with a size of several gigabytes, the log file will now keep the entries of the current day, and old log entries will automatically be moved to a different file under the same folder. If you were already implementing a similar system, you can either disable the system you were using or disable the changes we've done in [pull request 5105](https://github.com/consuldemocracy/consuldemocracy/pull/5105).