### PR TITLE
Order expired polls by ends date

### DIFF
--- a/app/models/poll.rb
+++ b/app/models/poll.rb
@@ -57,8 +57,25 @@ class Poll < ApplicationRecord
 
   def self.sort_for_list(user = nil)
     all.sort do |poll, another_poll|
-      [poll.weight(user), poll.starts_at, poll.name] <=>
-        [another_poll.weight(user), another_poll.starts_at, another_poll.name]
+      compare_polls(poll, another_poll, user)
+    end
+  end
+
+  def self.compare_polls(poll, another_poll, user)
+    weight_comparison = poll.weight(user) <=> another_poll.weight(user)
+    return weight_comparison unless weight_comparison.zero?
+
+    time_comparison = compare_times(poll, another_poll)
+    return time_comparison unless time_comparison.zero?
+
+    poll.name <=> another_poll.name
+  end
+
+  def self.compare_times(poll, another_poll)
+    if poll.expired? && another_poll.expired?
+      another_poll.ends_at <=> poll.ends_at
+    else
+      poll.starts_at <=> another_poll.starts_at
     end
   end
 

--- a/spec/system/polls/polls_spec.rb
+++ b/spec/system/polls/polls_spec.rb
@@ -34,6 +34,23 @@ describe "Polls" do
       end
     end
 
+    scenario "Expired polls are ordered by ends date" do
+      travel_to "01/07/2023".to_date do
+        create(:poll, starts_at: "03/05/2023", ends_at: "01/06/2023", name: "Expired poll one")
+        create(:poll, starts_at: "02/05/2023", ends_at: "02/06/2023", name: "Expired poll two")
+        create(:poll, starts_at: "01/05/2023", ends_at: "03/06/2023", name: "Expired poll three")
+        create(:poll, starts_at: "04/05/2023", ends_at: "04/06/2023", name: "Expired poll four")
+        create(:poll, starts_at: "05/05/2023", ends_at: "05/06/2023", name: "Expired poll five")
+
+        visit polls_path(filter: "expired")
+
+        expect("Expired poll five").to appear_before("Expired poll four")
+        expect("Expired poll four").to appear_before("Expired poll three")
+        expect("Expired poll three").to appear_before("Expired poll two")
+        expect("Expired poll two").to appear_before("Expired poll one")
+      end
+    end
+
     scenario "Proposal polls won't be listed" do
       proposal = create(:proposal)
       _poll = create(:poll, related: proposal)


### PR DESCRIPTION
## Objectives

When a user visits the polls that have already finished they appear sorted by date of creation.

This PR changes the order so that expired polls appear sorted by ends date. I think it's more interesting and better for the UX to see the most recent processes  especially for new users who want to explore the latest web activity. 😌 