### PR TITLE
Enable Dependabot again

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+- package-ecosystem: bundler
+  directory: "/"
+  schedule:
+    interval: daily
+    time: "04:00"
+    timezone: Etc/UTC
+  open-pull-requests-limit: 25


### PR DESCRIPTION
## References

* Dependabot was automatically enabled in pull request #4406, but we disabled it in pull request #4435 
* Dependabot  is now [disabled on forks by default](https://github.blog/changelog/2022-11-07-dependabot-pull-requests-off-by-default-for-forks/)

## Objectives

* Make it easier to maintain the dependencies of our project

## Release Notes

:information_source: We've enabled Dependabot in order to make it easier to maintain the project dependencies. Your Consul Democracy fork shouldn't be affected by this change, but if you've enabled Dependabot on your fork in the past, there's a chance Dependabot might be opening dozens of pull requests on your fork. If that's the case, you can disable Dependabot in the "Settings" section of your GitHub's fork, under "Code security and analysis".
