### PR TITLE
Fix Rubocop convention offenses

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -594,6 +594,8 @@ Style/StringLiteralsInInterpolation:
 
 Style/SymbolProc:
   Enabled: true
+  AllowedMethods:
+    - respond_to
 
 Style/TrailingCommaInArrayLiteral:
   Enabled: true


### PR DESCRIPTION
## Objectives

* Make sure running `rubocop --fail-level convention --display-only-fail-level-offenses` doesn't report any offenses