### PR TITLE
Reduce the size of JavaScript code on most pages

### DIFF
--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -6,6 +6,7 @@
 //= link application-rtl.css
 //= link application.js
 //= link html_editor_loader.js
+//= link legislation_annotatable_loader.js
 //= link map_loader.js
 //= link markdown_editor_loader.js
 //

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -5,6 +5,7 @@
 //= link application.css
 //= link application-rtl.css
 //= link application.js
+//= link html_editor_loader.js
 //
 //= link ckeditor/config.js
 //= link stat_graphs.js

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -6,6 +6,7 @@
 //= link application-rtl.css
 //= link application.js
 //= link html_editor_loader.js
+//= link map_loader.js
 //
 //= link ckeditor/config.js
 //= link stat_graphs.js

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -7,6 +7,7 @@
 //= link application.js
 //= link html_editor_loader.js
 //= link map_loader.js
+//= link markdown_editor_loader.js
 //
 //= link ckeditor/config.js
 //= link stat_graphs.js

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -59,7 +59,6 @@
 //= require moderator_proposal_notifications
 //= require moderator_legislation_proposals
 //= require gettext
-//= require annotator
 //= require jquery.amsify.suggestags
 //= require tags
 //= require users
@@ -80,7 +79,6 @@
 //= require legislation_admin
 //= require legislation
 //= require legislation_allegations
-//= require legislation_annotatable
 //= require legislation_draft_versions
 //= require followable
 //= require flaggable
@@ -135,9 +133,6 @@ var initialize_modules = function() {
   App.CheckboxToggle.initialize();
   App.LegislationAdmin.initialize();
   App.Legislation.initialize();
-  if ($(".legislation-annotatable").length) {
-    App.LegislationAnnotatable.initialize();
-  }
   App.TreeNavigator.initialize();
   App.Documentable.initialize();
   App.Imageable.initialize();
@@ -171,7 +166,6 @@ var destroy_non_idempotent_modules = function() {
 
   App.ColumnsSelector.destroy();
   App.Datepicker.destroy();
-  App.LegislationAnnotatable.destroy();
   App.SocialShare.destroy();
 };
 

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -74,8 +74,6 @@
 //= require banners
 //= require social_share
 //= require checkbox_toggle
-//= require markdown-it
-//= require markdown_editor
 //= require cocoon
 //= require answers
 //= require questions
@@ -135,7 +133,6 @@ var initialize_modules = function() {
   App.Banners.initialize();
   App.SocialShare.initialize();
   App.CheckboxToggle.initialize();
-  App.MarkdownEditor.initialize();
   App.LegislationAdmin.initialize();
   App.Legislation.initialize();
   if ($(".legislation-annotatable").length) {

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -43,8 +43,6 @@
 //= require foundation
 //= require turbolinks
 //= require turbolinks_anchors
-//= require ckeditor/loader
-//= require_directory ./ckeditor
 //= require social-share-button
 //= require initial
 //= require ahoy
@@ -78,7 +76,6 @@
 //= require checkbox_toggle
 //= require markdown-it
 //= require markdown_editor
-//= require html_editor
 //= require cocoon
 //= require answers
 //= require questions
@@ -141,7 +138,6 @@ var initialize_modules = function() {
   App.SocialShare.initialize();
   App.CheckboxToggle.initialize();
   App.MarkdownEditor.initialize();
-  App.HTMLEditor.initialize();
   App.LegislationAdmin.initialize();
   App.Legislation.initialize();
   if ($(".legislation-annotatable").length) {
@@ -181,7 +177,6 @@ var destroy_non_idempotent_modules = function() {
 
   App.ColumnsSelector.destroy();
   App.Datepicker.destroy();
-  App.HTMLEditor.destroy();
   App.LegislationAnnotatable.destroy();
   App.Map.destroy();
   App.SocialShare.destroy();

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -91,8 +91,6 @@
 //= require tree_navigator
 //= require tag_autocomplete
 //= require polls_admin
-//= require leaflet
-//= require map
 //= require polls
 //= require sortable
 //= require table_sortable
@@ -148,7 +146,6 @@ var initialize_modules = function() {
   App.Imageable.initialize();
   App.TagAutocomplete.initialize();
   App.PollsAdmin.initialize();
-  App.Map.initialize();
   App.Polls.initialize();
   App.Sortable.initialize();
   App.TableSortable.initialize();
@@ -178,7 +175,6 @@ var destroy_non_idempotent_modules = function() {
   App.ColumnsSelector.destroy();
   App.Datepicker.destroy();
   App.LegislationAnnotatable.destroy();
-  App.Map.destroy();
   App.SocialShare.destroy();
 };
 

--- a/app/assets/javascripts/globalize.js
+++ b/app/assets/javascripts/globalize.js
@@ -46,7 +46,7 @@
       }
     },
     resetEditor: function(element) {
-      if (CKEDITOR.instances[$(element).attr("id")]) {
+      if (typeof CKEDITOR !== 'undefined' && CKEDITOR.instances[$(element).attr("id")]) {
         CKEDITOR.instances[$(element).attr("id")].setData("");
       }
     },

--- a/app/assets/javascripts/html_editor_loader.js
+++ b/app/assets/javascripts/html_editor_loader.js
@@ -1,0 +1,6 @@
+//= require ckeditor/loader
+//= require_directory ./ckeditor
+//= require html_editor
+
+$(document).on("turbolinks:load", App.HTMLEditor.initialize);
+$(document).on("turbolinks:before-cache", App.HTMLEditor.destroy);

--- a/app/assets/javascripts/legislation_annotatable_loader.js
+++ b/app/assets/javascripts/legislation_annotatable_loader.js
@@ -1,0 +1,12 @@
+//= require annotator
+
+var initialize_modules = function() {
+  "use strict";
+
+  if ($(".legislation-annotatable").length) {
+    App.LegislationAnnotatable.initialize();
+  }
+};
+
+$(document).on("turbolinks:load", initialize_modules);
+$(document).on("turbolinks:before-cache", App.LegislationAnnotatable.destroy);

--- a/app/assets/javascripts/map_loader.js
+++ b/app/assets/javascripts/map_loader.js
@@ -1,0 +1,5 @@
+//= require leaflet
+//= require map
+
+$(document).on("turbolinks:load", App.Map.initialize);
+$(document).on("turbolinks:before-cache", App.Map.destroy);

--- a/app/assets/javascripts/markdown_editor_loader.js
+++ b/app/assets/javascripts/markdown_editor_loader.js
@@ -1,0 +1,4 @@
+//= require markdown-it
+//= require markdown_editor
+
+$(document).on("turbolinks:load", App.MarkdownEditor.initialize);

--- a/app/components/admin/budget_phases/form_component.html.erb
+++ b/app/components/admin/budget_phases/form_component.html.erb
@@ -1,3 +1,4 @@
+<% include_html_editor %>
 <%= render "shared/globalize_locales", resource: phase %>
 
 <%= translatable_form_for [namespace, phase.budget, phase], html: { class: "budget-phases-form" } do |f| %>

--- a/app/components/admin/stats/budget_supporting_component.html.erb
+++ b/app/components/admin/stats/budget_supporting_component.html.erb
@@ -1,6 +1,4 @@
-<% content_for :head do %>
-  <%= javascript_include_tag "stat_graphs", "data-turbolinks-track" => "reload" %>
-<% end %>
+<% include_javascript_in_layout("stat_graphs") %>
 
 <%= back_link_to budgets_admin_stats_path %>
 

--- a/app/components/application_component.rb
+++ b/app/components/application_component.rb
@@ -1,5 +1,5 @@
 class ApplicationComponent < ViewComponent::Base
   include SettingsHelper
-  delegate :back_link_to, :t, to: :helpers
+  delegate :back_link_to, :t, :include_html_editor, to: :helpers
   delegate :default_form_builder, to: :controller
 end

--- a/app/components/budgets/investments/form_component.html.erb
+++ b/app/components/budgets/investments/form_component.html.erb
@@ -1,3 +1,4 @@
+<% include_html_editor %>
 <%= translatable_form_for(investment, url: url, html: { class: "budget-investment-form" }) do |f| %>
 
   <%= render "shared/errors", resource: investment %>

--- a/app/components/debates/form_component.html.erb
+++ b/app/components/debates/form_component.html.erb
@@ -1,3 +1,4 @@
+<% include_html_editor %>
 <%= translatable_form_for(debate, html: { class: "debate-form" }) do |f| %>
   <%= render "shared/errors", resource: debate %>
 

--- a/app/components/proposals/form_component.html.erb
+++ b/app/components/proposals/form_component.html.erb
@@ -1,3 +1,4 @@
+<% include_html_editor %>
 <%= translatable_form_for(proposal, url: url, html: { class: "proposal-form" }) do |f| %>
   <%= render "shared/errors", resource: proposal %>
 

--- a/app/components/shared/map_location_component.html.erb
+++ b/app/components/shared/map_location_component.html.erb
@@ -1,3 +1,5 @@
+<% include_javascript_in_layout("map_loader") %>
+
 <%= tag.div(id: dom_id(map_location), class: "map-location map", data: data) %>
 
 <% if editable? %>

--- a/app/components/shared/map_location_component.rb
+++ b/app/components/shared/map_location_component.rb
@@ -1,5 +1,6 @@
 class Shared::MapLocationComponent < ApplicationComponent
   attr_reader :investments_coordinates, :form, :geozones_data
+  delegate :include_javascript_in_layout, to: :helpers
 
   def initialize(map_location, investments_coordinates: nil, form: nil, geozones_data: nil)
     @map_location = map_location

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -18,6 +18,14 @@ module ApplicationHelper
     WYSIWYGSanitizer.new.sanitize(text)
   end
 
+  def include_html_editor
+    unless @html_editor_already_included
+      content_for :body do
+        javascript_include_tag("html_editor_loader", "data-turbolinks-track" => "reload")
+      end
+    end
+  end
+
   def author_of?(authorable, user)
     return false if authorable.blank? || user.blank?
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -19,10 +19,18 @@ module ApplicationHelper
   end
 
   def include_html_editor
-    unless @html_editor_already_included
+    include_javascript_in_layout("html_editor_loader")
+  end
+
+  def include_javascript_in_layout(filename)
+    @loaded_scripts ||= {}
+
+    unless @loaded_scripts[filename]
       content_for :body do
-        javascript_include_tag("html_editor_loader", "data-turbolinks-track" => "reload")
+        javascript_include_tag(filename, "data-turbolinks-track" => "reload")
       end
+
+      @loaded_scripts[filename] = true
     end
   end
 

--- a/app/views/admin/budget_investments/edit.html.erb
+++ b/app/views/admin/budget_investments/edit.html.erb
@@ -1,3 +1,4 @@
+<% include_html_editor %>
 <%= link_to admin_budget_budget_investment_path(@budget, @investment, Budget::Investment.filter_params(params).to_h), class: "back" do %>
   <span class="icon-angle-left"></span> <%= t("shared.back") %>
 <% end %>

--- a/app/views/admin/dashboard/actions/_form.html.erb
+++ b/app/views/admin/dashboard/actions/_form.html.erb
@@ -1,3 +1,4 @@
+<% include_html_editor %>
 <%= render "shared/errors" %>
 
 <div class="row expanded">

--- a/app/views/admin/legislation/draft_versions/_form.html.erb
+++ b/app/views/admin/legislation/draft_versions/_form.html.erb
@@ -1,3 +1,4 @@
+<% include_javascript_in_layout("markdown_editor_loader") %>
 <%= render "shared/globalize_locales", resource: @draft_version %>
 
 <%= translatable_form_for [:admin, @process, @draft_version], url: url,

--- a/app/views/admin/legislation/homepages/_form.html.erb
+++ b/app/views/admin/legislation/homepages/_form.html.erb
@@ -1,3 +1,4 @@
+<% include_html_editor %>
 <%= render "shared/globalize_locales",
            resource: @process,
            display_style: lambda { |locale| enable_translation_style(@process, locale) },

--- a/app/views/admin/legislation/milestones/_summary_form.html.erb
+++ b/app/views/admin/legislation/milestones/_summary_form.html.erb
@@ -1,3 +1,4 @@
+<% include_html_editor %>
 <%= render "shared/globalize_locales",
            resource: @process,
            display_style: lambda { |locale| enable_translation_style(@process, locale) },

--- a/app/views/admin/legislation/questions/_form.html.erb
+++ b/app/views/admin/legislation/questions/_form.html.erb
@@ -1,3 +1,4 @@
+<% include_html_editor %>
 <%= render "shared/globalize_locales", resource: @question %>
 
 <%= translatable_form_for [:admin, @process, @question], url: url do |f| %>

--- a/app/views/admin/newsletters/_form.html.erb
+++ b/app/views/admin/newsletters/_form.html.erb
@@ -1,3 +1,4 @@
+<% include_html_editor %>
 <%= form_for [:admin, @newsletter] do |f| %>
   <%= render "shared/errors", resource: @newsletter %>
 

--- a/app/views/admin/poll/active_polls/_form.html.erb
+++ b/app/views/admin/poll/active_polls/_form.html.erb
@@ -1,3 +1,4 @@
+<% include_html_editor %>
 <%= render "shared/globalize_locales", resource: @active_poll %>
 
 <%= translatable_form_for(@active_poll, url: form_url) do |f| %>

--- a/app/views/admin/poll/questions/answers/_form.html.erb
+++ b/app/views/admin/poll/questions/answers/_form.html.erb
@@ -1,3 +1,4 @@
+<% include_html_editor %>
 <%= render "shared/globalize_locales", resource: @answer %>
 
 <%= translatable_form_for(@answer, url: form_url) do |f| %>

--- a/app/views/admin/settings/_map_form.html.erb
+++ b/app/views/admin/settings/_map_form.html.erb
@@ -1,3 +1,5 @@
+<% include_javascript_in_layout("map_loader") %>
+
 <div class="row">
   <div class="small-12 column">
     <div id="admin-map" class="map"

--- a/app/views/admin/site_customization/pages/_form.html.erb
+++ b/app/views/admin/site_customization/pages/_form.html.erb
@@ -1,3 +1,4 @@
+<% include_html_editor %>
 <%= render "shared/globalize_locales", resource: @page %>
 
 <%= translatable_form_for [:admin, @page], html: { class: "edit_page" } do |f| %>

--- a/app/views/admin/stats/graph.html.erb
+++ b/app/views/admin/stats/graph.html.erb
@@ -1,6 +1,4 @@
-<% content_for :head do %>
-  <%= javascript_include_tag "stat_graphs", "data-turbolinks-track" => "reload" %>
-<% end %>
+<% include_javascript_in_layout("stat_graphs") %>
 
 <%= back_link_to admin_stats_path %>
 

--- a/app/views/dashboard/polls/_question_answer_fields.html.erb
+++ b/app/views/dashboard/polls/_question_answer_fields.html.erb
@@ -1,3 +1,4 @@
+<% include_html_editor %>
 <div class="nested-fields nested-answers small-12 medium-6 column">
   <div class="answer-fields">
     <%= f.hidden_field :given_order %>

--- a/app/views/layouts/_common_body.html.erb
+++ b/app/views/layouts/_common_body.html.erb
@@ -1,0 +1,1 @@
+<%= content_for :body %>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -30,5 +30,7 @@
         <%= yield %>
       </div>
     </div>
+
+    <%= render "layouts/common_body" %>
   </body>
 </html>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -45,5 +45,7 @@
     <div class="footer">
       <%= render Layout::FooterComponent.new %>
     </div>
+
+    <%= render "layouts/common_body" %>
   </body>
 </html>

--- a/app/views/layouts/dashboard.html.erb
+++ b/app/views/layouts/dashboard.html.erb
@@ -36,5 +36,7 @@
         <%= yield %>
       </div>
     </div>
+
+    <%= render "layouts/common_body" %>
   </body>
 </html>

--- a/app/views/layouts/devise.html.erb
+++ b/app/views/layouts/devise.html.erb
@@ -34,5 +34,7 @@
     <div class="footer">
       <%= render Layout::FooterComponent.new %>
     </div>
+
+    <%= render "layouts/common_body" %>
   </body>
 </html>

--- a/app/views/layouts/management.html.erb
+++ b/app/views/layouts/management.html.erb
@@ -25,5 +25,7 @@
         <%= yield %>
       </main>
     </div>
+
+    <%= render "layouts/common_body" %>
   </body>
 </html>

--- a/app/views/legislation/draft_versions/show.html.erb
+++ b/app/views/legislation/draft_versions/show.html.erb
@@ -1,3 +1,4 @@
+<% include_javascript_in_layout("legislation_annotatable_loader") %>
 <% provide :title do %><%= "#{@draft_version.title} - #{@process.title}" %><% end %>
 
 <%= render "legislation/processes/header", process: @process, header: :small %>

--- a/app/views/legislation/proposals/_form.html.erb
+++ b/app/views/legislation/proposals/_form.html.erb
@@ -1,3 +1,4 @@
+<% include_html_editor %>
 <%= form_for(@proposal, url: form_url) do |f| %>
   <%= render "shared/errors", resource: @proposal %>
 


### PR DESCRIPTION
:warning: Currently these changes seem to break the navigation with the browser's back button in some cases, probably due to an incompatibility with Turbolinks.

## Objectives

* Make the page load faster, particularly on devices with a slow internet connection

## Notes

With these changes, on production environments (where assets are compressed), the size of the JavaScript file in most of the pages is reduced from 461KB to 141KB. Overall, our [demo homepage](https://demo.consuldemocracy.org) is now 23% smaller (from 1.37MB to 1.05MB).