### PR TITLE
Do not validate the attachment when updating the name

### DIFF
--- a/app/models/concerns/attachable.rb
+++ b/app/models/concerns/attachable.rb
@@ -9,7 +9,7 @@ module Attachable
               presence: true,
               file_content_type: {
                 allow: ->(record) { record.accepted_content_types },
-                if: -> { association_class && attachment.attached? },
+                if: -> { association_class && attachment.attached? && attachment.new_record? },
                 message: ->(record, *) do
                   I18n.t("#{record.model_name.plural}.errors.messages.wrong_content_type",
                          content_type: record.attachment_content_type,

--- a/app/models/concerns/attachable.rb
+++ b/app/models/concerns/attachable.rb
@@ -18,7 +18,7 @@ module Attachable
               },
               file_size: {
                 less_than_or_equal_to: ->(record) { record.max_file_size.megabytes },
-                if: -> { association_class && attachment.attached? },
+                if: -> { association_class && attachment.attached? && attachment.new_record? },
                 message: ->(record, *) do
                   I18n.t("#{record.model_name.plural}.errors.messages.in_between",
                          min: "0 Bytes",

--- a/spec/models/attachable_spec.rb
+++ b/spec/models/attachable_spec.rb
@@ -14,4 +14,48 @@ describe Attachable do
 
     expect(build(:image).file_path).to include "storage/tenants/image-master/"
   end
+
+  context "file size validation" do
+    it "is not applied when the image attachment has not changed" do
+      image = create(:image, :proposal_image)
+
+      expect(image.valid?).to be(true)
+
+      Setting["uploads.images.max_size"] = 0.1
+
+      expect(image.valid?).to be(true)
+    end
+
+    it "is applied when the image attachment changes" do
+      image = create(:image, :proposal_image)
+
+      expect(image.valid?).to be(true)
+
+      Setting["uploads.images.max_size"] = 0.1
+      image.attachment = Rack::Test::UploadedFile.new("spec/fixtures/files/clippy.png")
+
+      expect(image.valid?).to be(false)
+    end
+
+    it "is not applied when the document attachment has not changed" do
+      document = create(:document, :proposal_document)
+
+      expect(document.valid?).to be(true)
+
+      Setting["uploads.documents.max_size"] = 0.1
+
+      expect(document.valid?).to be(true)
+    end
+
+    it "is applied when the document attachment changes" do
+      document = create(:document, :proposal_document)
+
+      expect(document.valid?).to be(true)
+
+      Setting["uploads.documents.max_size"] = 0.1
+      document.attachment = Rack::Test::UploadedFile.new("spec/fixtures/files/clippy.pdf")
+
+      expect(document.valid?).to be(false)
+    end
+  end
 end

--- a/spec/models/attachable_spec.rb
+++ b/spec/models/attachable_spec.rb
@@ -58,4 +58,48 @@ describe Attachable do
       expect(document.valid?).to be(false)
     end
   end
+
+  context "file content types validation" do
+    it "is not applied when the image attachment has not changed" do
+      image = create(:image, :proposal_image)
+
+      expect(image.valid?).to be(true)
+
+      Setting["uploads.images.content_types"] = "image/gif"
+
+      expect(image.valid?).to be(true)
+    end
+
+    it "is applied when the image attachment changes" do
+      image = create(:image, :proposal_image)
+
+      expect(image.valid?).to be(true)
+
+      Setting["uploads.images.content_types"] = "image/gif"
+      image.attachment = Rack::Test::UploadedFile.new("spec/fixtures/files/clippy.png")
+
+      expect(image.valid?).to be(false)
+    end
+
+    it "is not applied when the document attachment has not changed" do
+      document = create(:document, :proposal_document)
+
+      expect(document.valid?).to be(true)
+
+      Setting["uploads.documents.content_types"] = "text/csv"
+
+      expect(document.valid?).to be(true)
+    end
+
+    it "is applied when the document attachment changes" do
+      document = create(:document, :proposal_document)
+
+      expect(document.valid?).to be(true)
+
+      Setting["uploads.documents.content_types"] = "text/csv"
+      document.attachment = Rack::Test::UploadedFile.new("spec/fixtures/files/clippy.pdf")
+
+      expect(document.valid?).to be(false)
+    end
+  end
 end


### PR DESCRIPTION
## References

https://github.com/consuldemocracy/consuldemocracy/issues/5167

## Objective

Do not run file size and content type validations for already uploaded attachments.

This change solves the problem described in #5167. 

As the administrator may change the accepted mime types for documents or images through the application settings, applying the same to file content type validation makes sense.

## Notes

1. Feel free to refactor or add specs if you think it's needed. 😉 
2. I don't know if it makes sense to keep [this validation](https://github.com/consuldemocracy/consuldemocracy/blob/master/app/models/image.rb#L20). 🤔 
