### PR TITLE
Fix syntax in robots.txt

### DIFF
--- a/app/views/robots/index.text.erb
+++ b/app/views/robots/index.text.erb
@@ -12,6 +12,6 @@ Disallow: /*?*order
 Disallow: /*?*search
 Disallow: /*?*locale-switcher
 Disallow: /*?*filter
-Disallow: user_id
+Disallow: /*?*user_id
 
 Sitemap: <%= "#{root_url}#{Tenant.path_with_subfolder("sitemap.xml")}" %>


### PR DESCRIPTION
## References

* We added the `user_id` rule in commit edaf420f5 from pull request #1548

## Objectives

* Use the right syntax in the robots.txt file in order to make it easier for search engines to read it