### PR TITLE
Replace back link on budget results

### DIFF
--- a/app/views/budgets/executions/show.html.erb
+++ b/app/views/budgets/executions/show.html.erb
@@ -15,7 +15,7 @@
   <div class="expanded no-margin-top padding header">
     <div class="row">
       <div class="small-12 column">
-        <%= back_link_to budgets_path %>
+        <%= back_link_to budget_path(@budget) %>
         <h2 class="margin-top">
           <%= t("budgets.executions.heading") %><br>
           <span><%= @budget.name %></span>

--- a/app/views/budgets/results/show.html.erb
+++ b/app/views/budgets/results/show.html.erb
@@ -14,7 +14,7 @@
   <div class="expanded no-margin-top padding header">
     <div class="row">
       <div class="small-12 column">
-        <%= back_link_to budgets_path %>
+        <%= back_link_to budget_path(@budget) %>
         <h2 class="margin-top">
           <%= t("budgets.results.heading") %><br>
           <span><%= @budget.name %></span>

--- a/app/views/budgets/stats/show.html.erb
+++ b/app/views/budgets/stats/show.html.erb
@@ -12,7 +12,7 @@
   <div class="expanded no-margin-top padding header">
     <div class="row">
       <div class="small-12 column">
-        <%= back_link_to budgets_path %>
+        <%= back_link_to budget_path(@budget) %>
         <h2 class="margin-top">
           <%= t("stats.title") %><br>
           <span><%= @budget.name %></span>

--- a/spec/system/budgets/executions_spec.rb
+++ b/spec/system/budgets/executions_spec.rb
@@ -76,6 +76,12 @@ describe "Executions" do
     expect(page).to have_content("No winner investments in this state")
   end
 
+  scenario "Back link redirects to budget page" do
+    visit budget_executions_path(budget)
+
+    expect(page).to have_link("Go back", href: budget_path(budget))
+  end
+
   context "Images" do
     scenario "renders milestone image if available" do
       milestone1 = create(:milestone, :with_image, milestoneable: investment1)

--- a/spec/system/budgets/results_spec.rb
+++ b/spec/system/budgets/results_spec.rb
@@ -14,6 +14,12 @@ describe "Results" do
     Budget::Result.new(budget, heading).calculate_winners
   end
 
+  scenario "Back link redirects to budget page" do
+    visit budget_results_path(budget)
+
+    expect(page).to have_link("Go back", href: budget_path(budget))
+  end
+
   scenario "No links to budget results with results disabled" do
     budget.update!(results_enabled: false)
 

--- a/spec/system/budgets/stats_spec.rb
+++ b/spec/system/budgets/stats_spec.rb
@@ -30,5 +30,11 @@ describe "Stats" do
         expect(page).not_to have_content "Advanced statistics"
       end
     end
+
+    scenario "Back link redirects to budget page" do
+      visit budget_stats_path(budget)
+
+      expect(page).to have_link("Go back", href: budget_path(budget))
+    end
   end
 end


### PR DESCRIPTION
## Objectives

To enhance the UX a bit, this PR modifies the "Go back" link on the results page of a Participatory Budget. 

Instead of redirecting users to `/budgets`, which could be confusing if there are multiple PBs, it now directs them to the corresponding PB. This change helps maintain context, especially when dealing with different PBs.

