### PR TITLE
Order homepage cards by creation date

### DIFF
--- a/app/models/widget/card.rb
+++ b/app/models/widget/card.rb
@@ -16,6 +16,6 @@ class Widget::Card < ApplicationRecord
   end
 
   def self.body
-    where(header: false, cardable_id: nil).order(:created_at)
+    where(header: false, cardable_id: nil).order(created_at: :desc)
   end
 end

--- a/spec/system/home_spec.rb
+++ b/spec/system/home_spec.rb
@@ -175,6 +175,19 @@ describe "Home" do
     expect(page).not_to have_css(".title", text: "Featured")
   end
 
+  scenario "Cards are ordered by creation date" do
+    create(:widget_card, title: "Card one", link_text: "Link one", link_url: "consul.dev")
+    create(:widget_card, title: "Card two", link_text: "Link two", link_url: "consul.dev")
+    create(:widget_card, title: "Card three", link_text: "Link three", link_url: "consul.dev")
+
+    visit root_path
+
+    within(".cards-container") do
+      expect("CARD THREE").to appear_before("CARD TWO")
+      expect("CARD TWO").to appear_before("CARD ONE")
+    end
+  end
+
   describe "Header Card" do
     scenario "if there is header card with link, the link content is rendered" do
       create(:widget_card, :header, link_text: "Link text", link_url: "consul.dev")


### PR DESCRIPTION
## Objectives

When an administrator creates cards for the homepage from `admin/widget/cards/new` they are displayed in order of **creation date** showing the _newly created one last_.

Since this section is usually used to show "what's new", this PR changes the order to show the cards by **descending creation date** so that the _last card created is shown first_.
