### PR TITLE
Update Rubocop version used in Code Climate

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,7 +1,7 @@
 engines:
   rubocop:
     enabled: true
-    channel: rubocop-0-74
+    channel: rubocop-1-31-0
   duplication:
     enabled: true
     config:


### PR DESCRIPTION
## References

* [Code Climate builds are currently failing](https://codeclimate.com/github/consuldemocracy/consuldemocracy/builds/1)
* [List of available Rubocop version in Code Climate](https://github.com/codeclimate/codeclimate-rubocop/branches/all?utf8=%E2%9C%93&query=channel%2Frubocop)
