### PR TITLE
Make model concerns customization easier

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -137,6 +137,8 @@ module Consul
     config.autoload_paths << "#{Rails.root}/app/graphql/custom"
     config.autoload_paths << "#{Rails.root}/app/mailers/custom"
     config.autoload_paths << "#{Rails.root}/app/models/custom"
+    config.autoload_paths << "#{Rails.root}/app/models/custom/concerns"
+
     config.paths["app/views"].unshift(Rails.root.join("app", "views", "custom"))
 
     # Set to true to enable managing different tenants using the same application


### PR DESCRIPTION
## Objectives

Make model concerns customization easier.

The custom model concerns must be placed in the `app/models/custom/concerns` folder.

With this change, we can create custom model concerns in the same way we do with models.

## Example
`app/models/custom/concerns/statisticable.rb`
```
require_dependency Rails.root.join("app", "models", "concerns", "statisticable").to_s

module Statisticable
  def gender?
    participants.male.any? || participants.female.any? || participants.other_gender.any?
  end

  def total_other_gender_participants
    participants.other_gender.count
  end

  def other_gender_percentage
    calculate_percentage(total_other_gender_participants, total_participants_with_gender)
  end
end
```