### PR TITLE
Update gem dependencies once a month

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,5 @@ updates:
 - package-ecosystem: bundler
   directory: "/"
   schedule:
-    interval: daily
-    time: "04:00"
-    timezone: Etc/UTC
-  open-pull-requests-limit: 25
+    interval: monthly
+  open-pull-requests-limit: 50


### PR DESCRIPTION
## References

* We originally set a daily interval in pull request #5153

## Objectives

* Find a proper balance while managing dependencies

## Notes

We usually wait a few days/weeks between the time a gem is released and the moment we update it, and there are gems releasing new versions every few days, so maintaining daily updates would become tedious quickly.

So we're now doing it once a month. We're also increasing the limit of open pull requests so we don't need to worry about whether dependabot is opening pull requests for every dependency. We'll change the limit again if we ever go beyond 25 open dependency pull requests again.