### PR TITLE
Don't depend on the "Help" link in tests

### DIFF
--- a/spec/shared/system/mappable.rb
+++ b/spec/shared/system/mappable.rb
@@ -88,9 +88,9 @@ shared_examples "mappable" do |mappable_factory_name, mappable_association_name,
 
           expect(page).to have_content "User management"
         else
-          click_link "Help"
+          click_link "CONSUL"
 
-          expect(page).to have_content "CONSUL is a platform for citizen participation"
+          expect(page).to have_content "Most active proposals"
         end
 
         go_back
@@ -121,9 +121,9 @@ shared_examples "mappable" do |mappable_factory_name, mappable_association_name,
 
           expect(page).to have_content "User management"
         else
-          click_link "Help"
+          click_link "CONSUL"
 
-          expect(page).to have_content "CONSUL is a platform for citizen participation"
+          expect(page).to have_content "Most active proposals"
         end
 
         go_back
@@ -154,9 +154,9 @@ shared_examples "mappable" do |mappable_factory_name, mappable_association_name,
 
           expect(page).to have_content "User management"
         else
-          click_link "Help"
+          click_link "CONSUL"
 
-          expect(page).to have_content "CONSUL is a platform for citizen participation"
+          expect(page).to have_content "Most active proposals"
         end
 
         go_back

--- a/spec/system/legislation/draft_versions_spec.rb
+++ b/spec/system/legislation/draft_versions_spec.rb
@@ -296,6 +296,8 @@ describe "Legislation Draft Versions" do
 
       find(:css, ".annotator-hl").click
 
+      expect(page).to have_link "Publish Comment"
+
       click_link "CONSUL"
 
       expect(page).to have_content "Most active proposals"

--- a/spec/system/legislation/draft_versions_spec.rb
+++ b/spec/system/legislation/draft_versions_spec.rb
@@ -278,9 +278,9 @@ describe "Legislation Draft Versions" do
 
       expect(page).to have_css(".annotator-hl", count: 1)
 
-      click_link "Help"
+      click_link "CONSUL"
 
-      expect(page).to have_content "CONSUL is a platform for citizen participation"
+      expect(page).to have_content "Most active proposals"
 
       go_back
 
@@ -296,9 +296,9 @@ describe "Legislation Draft Versions" do
 
       find(:css, ".annotator-hl").click
 
-      click_link "Help"
+      click_link "CONSUL"
 
-      expect(page).to have_content "CONSUL is a platform for citizen participation"
+      expect(page).to have_content "Most active proposals"
 
       go_back
 

--- a/spec/system/proposals_spec.rb
+++ b/spec/system/proposals_spec.rb
@@ -214,9 +214,9 @@ describe "Proposals" do
       Setting["org_name"] = "CONSUL"
       proposal = create(:proposal)
       visit proposal_path(proposal)
-      click_link "Help"
+      click_link "CONSUL"
 
-      expect(page).to have_content "CONSUL is a platform for citizen participation"
+      expect(page).to have_content "Most active proposals"
 
       go_back
 


### PR DESCRIPTION
## Objectives

* Don't break tests in Consul Democracy installations which have removed the link to the "Help" page
* Add a missing expectation whose absence was causing a test to hang sometimes