### PR TITLE
Add new content block `footer_legal` to Footer

### DIFF
--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -734,6 +734,28 @@ footer {
   border-top: 1px solid $text-light;
   font-size: $small-font-size;
   padding-top: $line-height / 2;
+
+  .legal {
+    display: inline-block;
+    margin-#{$global-left}: 0;
+
+    &::before {
+      content: "|";
+    }
+
+    li {
+      display: inline-block;
+
+      &::after {
+        content: "|";
+        margin-left: 4px;
+      }
+
+      &:last-child::after {
+        content: none;
+      }
+    }
+  }
 }
 
 // 04. Tags

--- a/app/components/layout/footer_component.html.erb
+++ b/app/components/layout/footer_component.html.erb
@@ -27,6 +27,7 @@
         <li><%= link_to t("layouts.footer.privacy"), page_path("privacy") %></li>
         <li><%= link_to t("layouts.footer.conditions"), page_path("conditions") %></li>
         <li><%= link_to t("layouts.footer.accessibility"), page_path("accessibility") %></li>
+        <%= raw footer_legal_content_block %>
       </ul>
     </div>
 

--- a/app/components/layout/footer_component.html.erb
+++ b/app/components/layout/footer_component.html.erb
@@ -22,11 +22,11 @@
 
   <div class="subfooter row">
     <div class="small-12 medium-8 column">
-      <%= t("layouts.footer.copyright", year: Time.current.year) %>&nbsp;|
-      <ul class="no-bullet inline-block">
-        <li class="inline-block"><%= link_to t("layouts.footer.privacy"), page_path("privacy") %>&nbsp;|</li>
-        <li class="inline-block"><%= link_to t("layouts.footer.conditions"), page_path("conditions") %>&nbsp;|</li>
-        <li class="inline-block"><%= link_to t("layouts.footer.accessibility"), page_path("accessibility") %></li>
+      <%= t("layouts.footer.copyright", year: Time.current.year) %>
+      <ul class="legal">
+        <li><%= link_to t("layouts.footer.privacy"), page_path("privacy") %></li>
+        <li><%= link_to t("layouts.footer.conditions"), page_path("conditions") %></li>
+        <li><%= link_to t("layouts.footer.accessibility"), page_path("accessibility") %></li>
       </ul>
     </div>
 

--- a/app/components/layout/footer_component.rb
+++ b/app/components/layout/footer_component.rb
@@ -1,2 +1,7 @@
 class Layout::FooterComponent < ApplicationComponent
+  delegate :content_block, to: :helpers
+
+  def footer_legal_content_block
+    content_block("footer_legal")
+  end
 end

--- a/app/models/site_customization/content_block.rb
+++ b/app/models/site_customization/content_block.rb
@@ -1,5 +1,5 @@
 class SiteCustomization::ContentBlock < ApplicationRecord
-  VALID_BLOCKS = %w[top_links footer subnavigation_left subnavigation_right].freeze
+  VALID_BLOCKS = %w[top_links footer footer_legal subnavigation_left subnavigation_right].freeze
 
   validates :locale, presence: true, inclusion: { in: I18n.available_locales.map(&:to_s) }
   validates :name, presence: true, uniqueness: { scope: :locale }, inclusion: { in: ->(*) { VALID_BLOCKS }}

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -1590,7 +1590,8 @@ en:
           name: Name
           names:
             top_links: Top Links
-            footer: Footer
+            footer: Footer (social media)
+            footer_legal: Footer (legal terms)
             subnavigation_left: Main Navigation Left
             subnavigation_right: Main Navigation Right
       images:

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -1590,7 +1590,8 @@ es:
           name: Nombre
           names:
             top_links: Enlaces superiores
-            footer: Pie de página
+            footer: Pie de página (redes sociales)
+            footer_legal: Pie de página (términos legales)
             subnavigation_left: Navegación principal izquierda
             subnavigation_right: Navegación principal derecha
       images:

--- a/spec/system/site_customization/content_blocks_spec.rb
+++ b/spec/system/site_customization/content_blocks_spec.rb
@@ -26,13 +26,37 @@ describe "Custom content blocks" do
 
     visit "/?locale=en"
 
-    expect(page).to have_content("content for footer")
-    expect(page).not_to have_content("contenido para footer")
+    within ".social" do
+      expect(page).to have_content("content for footer")
+      expect(page).not_to have_content("contenido para footer")
+    end
 
     visit "/?locale=es"
 
-    expect(page).to have_content("contenido para footer")
-    expect(page).not_to have_content("content for footer")
+    within ".social" do
+      expect(page).to have_content("contenido para footer")
+      expect(page).not_to have_content("content for footer")
+    end
+  end
+
+  scenario "footer_legal content block" do
+    create(:site_customization_content_block, name: "footer_legal", locale: "en",
+                                              body: "legal content for footer")
+    create(:site_customization_content_block, name: "footer_legal", locale: "es",
+                                              body: "contenido legal para el footer")
+
+    visit "/?locale=en"
+
+    within ".legal" do
+      expect(page).to have_content("legal content for footer")
+      expect(page).not_to have_content("contenido legal para el footer")
+    end
+
+    visit "/?locale=es"
+    within ".legal" do
+      expect(page).to have_content("contenido legal para el footer")
+      expect(page).not_to have_content("legal content for footer")
+    end
   end
 
   scenario "main navigation left" do


### PR DESCRIPTION
## Objectives
- Add new content block (footer_legal) to the footer for additional flexibility and modularity.
- Refactor the footer to remove the non-semantic separators and implement them using CSS.

## Visual Changes
- Create a new content block
![Create a new content block](https://github.com/consuldemocracy/consuldemocracy/assets/16189/0e9b688b-c0f8-4b75-b927-79ae23b3400c)

- Allow selecting new footer_legal content block
![Allow selecting new footer_legal content block](https://github.com/consuldemocracy/consuldemocracy/assets/16189/89fd7823-b920-40ea-958e-9c1bbffde6f6)

- Footer with new link
![Footer with new link](https://github.com/consuldemocracy/consuldemocracy/assets/16189/530edbee-4434-45b0-8886-12a5c956ca61)


