### PR TITLE
Move customizations to more intuitive admin menu section

### DIFF
--- a/app/components/admin/menu_component.rb
+++ b/app/components/admin/menu_component.rb
@@ -55,8 +55,7 @@ class Admin::MenuComponent < ApplicationComponent
 
     def settings?
       controllers_names = ["settings", "tenants", "tags", "geozones", "local_census_records", "imports"]
-      controllers_names.include?(controller_name) &&
-        controller.class.module_parent != Admin::Poll::Questions::Answers
+      controllers_names.include?(controller_name)
     end
 
     def customization?

--- a/app/components/admin/menu_component.rb
+++ b/app/components/admin/menu_component.rb
@@ -54,15 +54,14 @@ class Admin::MenuComponent < ApplicationComponent
     end
 
     def settings?
-      controllers_names = ["settings", "tenants", "tags", "geozones", "images",
-                           "content_blocks", "local_census_records", "imports"]
+      controllers_names = ["settings", "tenants", "tags", "geozones", "local_census_records", "imports"]
       controllers_names.include?(controller_name) &&
         controller.class.module_parent != Admin::Poll::Questions::Answers
     end
 
     def customization?
-      ["pages", "banners", "information_texts", "documents"].include?(controller_name) ||
-        homepage? || pages?
+      controllers_names = ["pages", "banners", "information_texts", "documents", "images", "content_blocks"]
+      controllers_names.include?(controller_name) || homepage? || pages?
     end
 
     def homepage?
@@ -256,6 +255,8 @@ class Admin::MenuComponent < ApplicationComponent
           banners_link,
           information_texts_link,
           documents_link,
+          images_link,
+          content_blocks_link,
           class: ("is-active" if customization? &&
                                  controller.class.module_parent != Admin::Poll::Questions::Answers)
         )
@@ -458,8 +459,6 @@ class Admin::MenuComponent < ApplicationComponent
           tenants_link,
           tags_link,
           geozones_link,
-          images_link,
-          content_blocks_link,
           local_census_records_link,
           class: ("is-active" if settings?)
         )

--- a/spec/system/admin/site_customization/content_blocks_spec.rb
+++ b/spec/system/admin/site_customization/content_blocks_spec.rb
@@ -17,7 +17,7 @@ describe "Admin custom content blocks", :admin do
       visit admin_root_path
 
       within("#side_menu") do
-        click_link "Settings"
+        click_link "Site content"
         click_link "Custom content blocks"
       end
 
@@ -42,7 +42,7 @@ describe "Admin custom content blocks", :admin do
       visit admin_root_path
 
       within("#side_menu") do
-        click_link "Settings"
+        click_link "Site content"
         click_link "Custom content blocks"
       end
 
@@ -69,7 +69,7 @@ describe "Admin custom content blocks", :admin do
       visit admin_root_path
 
       within("#side_menu") do
-        click_link "Settings"
+        click_link "Site content"
         click_link "Custom content blocks"
       end
 

--- a/spec/system/admin/site_customization/images_spec.rb
+++ b/spec/system/admin/site_customization/images_spec.rb
@@ -5,7 +5,7 @@ describe "Admin custom images", :admin do
     visit admin_root_path
 
     within("#side_menu") do
-      click_link "Settings"
+      click_link "Site content"
       click_link "Custom images"
     end
 


### PR DESCRIPTION
## References

#4995 (no complete resolution of this issue, but an improvement discussed in it)

## Objectives

There were already some menu items to customization pages under the "Site content" admin menu ("Custom pages", "Custom information texts", "Custom documents"). It therefore makes sense to move "Custom images" and "Custom content blocks" (which were previously located under "Settings") to "Site content" as well.

## Visual Changes

<img width="239" alt="New site content menu" src="https://github.com/consuldemocracy/consuldemocracy/assets/15640196/86917d44-d262-4f91-83ad-dcbd27e7e9e8">
<img width="239" alt="New Settings menu" src="https://github.com/consuldemocracy/consuldemocracy/assets/15640196/af1ce90a-8e9d-47ec-b785-e0a240b1a409">


## Notes

It's possible that some admins may have memorized "Custom images" and "Custom content blocks" to be located under "Settings". However, it is more intuitive to have them under "Site content", so the possible confusion at first will probably pay off in the long-term, when all admins have more intuitive access to them.
