### PR TITLE
Update bash script to run Knapsack Pro

### DIFF
--- a/bin/knapsack_pro_rspec
+++ b/bin/knapsack_pro_rspec
@@ -3,8 +3,8 @@ if [ "$KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC" = "" ]; then
   KNAPSACK_PRO_ENDPOINT=https://api-disabled-for-fork.knapsackpro.com \
     KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC=disabled-for-fork \
     KNAPSACK_PRO_MAX_REQUEST_RETRIES=0 \
-    bundle exec rake knapsack_pro:rspec # use Regular Mode here always
+    KNAPSACK_PRO_CI_NODE_RETRY_COUNT=0 \
+    bundle exec rake knapsack_pro:queue:rspec
 else
-  # Queue Mode - dynamic tests allocation across CI nodes
   bundle exec rake knapsack_pro:queue:rspec
 fi


### PR DESCRIPTION
We made a few experiments with forked repositeries after applying commit dc1e0209a and everything seems to work fine, but it looks like that isn't the case. For instance, on pull requests opened by external contributors, the tests aren't running.

The fix we're applying is mentioned on the Knapsack Pro repository [1] (pull request 197).

[1] https://github.com/KnapsackPro/knapsack_pro-ruby

## References

* We introduced this issue in pull request #5214. Back then we did tests with forked repositories, but apparently we didn't test every case

## Objectives

* Make it possible to run the test suite when there's no Knapsack Pro token available