### PR TITLE
[WIP] Allow administrators to assign booths before the voting begins

### DIFF
--- a/app/controllers/admin/poll/booths_controller.rb
+++ b/app/controllers/admin/poll/booths_controller.rb
@@ -32,7 +32,7 @@ class Admin::Poll::BoothsController < Admin::Poll::BaseController
   end
 
   def available
-    @booths = Poll::Booth.available.order(name: :asc).page(params[:page])
+    @booths = Poll::Booth.available_for_admin.order(name: :asc).page(params[:page])
     render :index
   end
 

--- a/app/models/poll.rb
+++ b/app/models/poll.rb
@@ -86,6 +86,10 @@ class Poll < ApplicationRecord
     ends_at < timestamp
   end
 
+  def future_event?(timestamp = Time.current)
+    starts_at > timestamp
+  end
+
   def recounts_confirmed?
     ends_at < 1.month.ago
   end

--- a/app/models/poll/booth.rb
+++ b/app/models/poll/booth.rb
@@ -22,6 +22,10 @@ class Poll
       where(polls: { id: Poll.current_or_recounting }).joins(:polls)
     end
 
+    def self.available_for_admin
+      where(polls: { id: Poll.current_or_recounting.or(Poll.future_event?) }).joins(:polls)
+    end
+
     def assignment_on_poll(poll)
       booth_assignments.find_by(poll: poll)
     end

--- a/spec/models/poll/booth_spec.rb
+++ b/spec/models/poll/booth_spec.rb
@@ -58,4 +58,26 @@ describe Poll::Booth do
       expect(Poll::Booth.available.count).to eq 1
     end
   end
+
+  describe ".available_for_admin" do
+    it "returns booths associated to current polls" do
+      booth_for_current_poll = create(:poll_booth, polls: [create(:poll)])
+      booth_for_expired_poll = create(:poll_booth, polls: [create(:poll, :expired)])
+
+      expect(Poll::Booth.available_for_admin).to eq [booth_for_current_poll]
+      expect(Poll::Booth.available_for_admin).not_to include(booth_for_expired_poll)
+    end
+
+    it "returns polls with multiple translations only once" do
+      create(:poll_booth, polls: [create(:poll, name: "English", name_es: "Spanish")])
+
+      expect(Poll::Booth.available_for_admin.count).to eq 1
+    end
+
+    it "returns booths associated to future polls" do
+      booth_for_future_poll = create(:poll_booth, polls: [create(:poll, starts_at: Time.current + 1.day)])
+
+      expect(Poll::Booth.available_for_admin).to include(booth_for_future_poll)
+    end
+  end
 end


### PR DESCRIPTION
## References

Related to #5275 . Work in progress, have to test a bit more.

## Objectives

> What are the objectives of these changes?

## Visual Changes

> Any visual changes? please attach screenshots (or gifs) showing them.
> If modified views are public (not the admin panel), try them in mobile display (with your browser's developer console) and add screenshots.

## Notes

> Mention rake tasks or actions to be done when deploying this changes to a server (if any).
> Explain any caveats, or important things to notice like deprecations (if any).
