### PR TITLE
Open links in the same tab unless necessary

### DIFF
--- a/app/components/admin/machine_learning/setting_component.html.erb
+++ b/app/components/admin/machine_learning/setting_component.html.erb
@@ -20,7 +20,7 @@
         <dt><%= t("admin.machine_learning.output_files") %></dt>
         <dd>
           <% filenames.each do |filename| %>
-            <a href="<%= data_path(filename) %>" target="_blank"><%= filename %></a><br>
+            <a href="<%= data_path(filename) %>"><%= filename %></a><br>
           <% end %>
         </dd>
       </dl>

--- a/app/components/admin/machine_learning/settings_component.html.erb
+++ b/app/components/admin/machine_learning/settings_component.html.erb
@@ -9,7 +9,7 @@
     <p><strong><%= t("admin.machine_learning.data_folder_content") %></strong></p>
 
     <% filenames.each do |filename| %>
-      <a href="<%= data_path(filename) %>" target="_blank"><%= filename %></a><br>
+      <a href="<%= data_path(filename) %>"><%= filename %></a><br>
     <% end %>
   </div>
 </div>

--- a/app/components/admin/site_customization/pages/index_component.html.erb
+++ b/app/components/admin/site_customization/pages/index_component.html.erb
@@ -33,8 +33,7 @@
             <% if page.status == "published" %>
               <%= actions.action(:show,
                                  text: t("admin.site_customization.pages.index.see_page"),
-                                 path: page.url,
-                                 target: "_blank") %>
+                                 path: page.url) %>
             <% end %>
           <% end %>
         </td>

--- a/app/components/admin/widget/cards/row_component.html.erb
+++ b/app/components/admin/widget/cards/row_component.html.erb
@@ -12,8 +12,7 @@
   <!-- remove conditional once specs have image validations -->
   <td>
     <% if card.image.present? %>
-      <%= link_to t("admin.shared.show_image"), card.image.variant(:large),
-                  title: card.image.title, target: "_blank" %>
+      <%= link_to t("admin.shared.show_image"), card.image.variant(:large), title: card.image.title %>
     <% end %>
   </td>
   <td>

--- a/app/components/layout/footer_component.html.erb
+++ b/app/components/layout/footer_component.html.erb
@@ -7,8 +7,8 @@
 
       <p class="info">
         <%= sanitize(t("layouts.footer.description",
-                       open_source: link_to(t("layouts.footer.open_source"), t("layouts.footer.open_source_url"), target: "_blank", rel: "nofollow"),
-                       consul: link_to(t("layouts.footer.consul"), t("layouts.footer.consul_url"), target: "_blank", rel: "nofollow"))) %>
+                       open_source: open_source_link,
+                       consul: repository_link)) %>
       </p>
     </div>
 

--- a/app/components/layout/footer_component.html.erb
+++ b/app/components/layout/footer_component.html.erb
@@ -8,7 +8,8 @@
       <p class="info">
         <%= sanitize(t("layouts.footer.description",
                        open_source: open_source_link,
-                       consul: repository_link)) %>
+                       consul: repository_link),
+                     attributes: allowed_link_attributes) %>
       </p>
     </div>
 

--- a/app/components/layout/footer_component.rb
+++ b/app/components/layout/footer_component.rb
@@ -14,4 +14,8 @@ class Layout::FooterComponent < ApplicationComponent
     def repository_link
       link_to(t("layouts.footer.consul"), t("layouts.footer.consul_url"), rel: "nofollow")
     end
+
+    def allowed_link_attributes
+      self.class.sanitized_allowed_attributes + ["rel"]
+    end
 end

--- a/app/components/layout/footer_component.rb
+++ b/app/components/layout/footer_component.rb
@@ -8,12 +8,10 @@ class Layout::FooterComponent < ApplicationComponent
   private
 
     def open_source_link
-      link_to(t("layouts.footer.open_source"), t("layouts.footer.open_source_url"), target: "_blank",
-                                                                                    rel: "nofollow")
+      link_to(t("layouts.footer.open_source"), t("layouts.footer.open_source_url"), rel: "nofollow")
     end
 
     def repository_link
-      link_to(t("layouts.footer.consul"), t("layouts.footer.consul_url"), target: "_blank",
-                                                                          rel: "nofollow")
+      link_to(t("layouts.footer.consul"), t("layouts.footer.consul_url"), rel: "nofollow")
     end
 end

--- a/app/components/layout/footer_component.rb
+++ b/app/components/layout/footer_component.rb
@@ -4,4 +4,16 @@ class Layout::FooterComponent < ApplicationComponent
   def footer_legal_content_block
     content_block("footer_legal")
   end
+
+  private
+
+    def open_source_link
+      link_to(t("layouts.footer.open_source"), t("layouts.footer.open_source_url"), target: "_blank",
+                                                                                    rel: "nofollow")
+    end
+
+    def repository_link
+      link_to(t("layouts.footer.consul"), t("layouts.footer.consul_url"), target: "_blank",
+                                                                          rel: "nofollow")
+    end
 end

--- a/app/components/layout/footer_component.rb
+++ b/app/components/layout/footer_component.rb
@@ -8,11 +8,15 @@ class Layout::FooterComponent < ApplicationComponent
   private
 
     def open_source_link
-      link_to(t("layouts.footer.open_source"), t("layouts.footer.open_source_url"), rel: "nofollow")
+      external_link_to(t("layouts.footer.open_source"), t("layouts.footer.open_source_url"))
     end
 
     def repository_link
-      link_to(t("layouts.footer.consul"), t("layouts.footer.consul_url"), rel: "nofollow")
+      external_link_to(t("layouts.footer.consul"), t("layouts.footer.consul_url"))
+    end
+
+    def external_link_to(text, url)
+      link_to(text, url, rel: "nofollow external")
     end
 
     def allowed_link_attributes

--- a/app/components/layout/social_component.html.erb
+++ b/app/components/layout/social_component.html.erb
@@ -2,7 +2,7 @@
   <ul>
     <% sites.each do |name, url| %>
       <li>
-        <%= link_to "#{url}/#{setting["#{name}_handle"]}", target: "_blank", title: link_title(name) do %>
+        <%= link_to "#{url}/#{setting["#{name}_handle"]}", title: link_title(name) do %>
           <span class="show-for-sr"><%= link_text(name) %></span>
           <span class="icon-<%= name %>" aria-hidden="true"></span>
         <% end %>

--- a/app/components/layout/social_component.rb
+++ b/app/components/layout/social_component.rb
@@ -18,7 +18,7 @@ class Layout::SocialComponent < ApplicationComponent
     end
 
     def link_title(site_name)
-      t("shared.go_to_page") + link_text(site_name) + t("shared.target_blank")
+      t("shared.go_to_page") + link_text(site_name)
     end
 
     def link_text(site_name)

--- a/app/components/polls/questions/read_more_component.html.erb
+++ b/app/components/polls/questions/read_more_component.html.erb
@@ -49,7 +49,6 @@
           <% answer.videos.each do |video| %>
               <%= link_to video.title,
                           video.url,
-                          target: "_blank",
                           rel: "nofollow" %><br>
           <% end %>
         </div>

--- a/app/helpers/mailer_helper.rb
+++ b/app/helpers/mailer_helper.rb
@@ -11,7 +11,6 @@ module MailerHelper
     link_to(
       commentable.title,
       valuation_comments_url(@email.commentable),
-      target: :blank,
       style: "color: #2895F1; text-decoration:none;"
     )
   end

--- a/app/helpers/text_with_links_helper.rb
+++ b/app/helpers/text_with_links_helper.rb
@@ -10,7 +10,7 @@ module TextWithLinksHelper
     return if html.nil?
     raise "Could not add links because the content is not safe" unless html.html_safe?
 
-    raw Rinku.auto_link(html, :all, 'target="_blank" rel="nofollow"')
+    raw Rinku.auto_link(html, :all, 'rel="nofollow"')
   end
 
   def simple_format_no_tags_no_sanitize(html)

--- a/app/views/admin/dashboard/administrator_tasks/_form.html.erb
+++ b/app/views/admin/dashboard/administrator_tasks/_form.html.erb
@@ -11,7 +11,7 @@
       <tr>
         <td>
           <%= link_to administrator_task.source.proposal.title,
-                      proposal_path(administrator_task.source.proposal), target: "_blank" %>
+                      proposal_path(administrator_task.source.proposal) %>
         </td>
         <td>
           <%= administrator_task.source.action.title %>

--- a/app/views/admin/milestones/_milestones.html.erb
+++ b/app/views/admin/milestones/_milestones.html.erb
@@ -40,8 +40,7 @@
           </td>
           <td class="small">
             <%= link_to t("admin.milestones.index.show_image"),
-                        milestone.image.variant(:large),
-                        target: :_blank if milestone.image.present? %>
+                        milestone.image.variant(:large) if milestone.image.present? %>
           </td>
           <td class="small">
             <% if milestone.documents.present? %>

--- a/app/views/admin/poll/polls/_questions.html.erb
+++ b/app/views/admin/poll/polls/_questions.html.erb
@@ -24,8 +24,7 @@
           <% if question.proposal.present? %>
             <small>
               <%= link_to t("admin.polls.show.see_proposal"),
-                          proposal_path(question.proposal),
-                          target: "_blank" %>
+                          proposal_path(question.proposal) %>
             </small>
           <% end %>
         </td>

--- a/app/views/admin/users/_users.html.erb
+++ b/app/views/admin/users/_users.html.erb
@@ -23,10 +23,10 @@
       <% @users.each do |user| %>
         <tr>
           <% if @current_filter == "erased" %>
-            <td><%= link_to user.id, user_path(user), target: "_blank" %></td>
+            <td><%= link_to user.id, user_path(user) %></td>
             <td><%= user.erase_reason %></td>
           <% else %>
-            <td><%= link_to user.name, user_path(user), target: "_blank" %></td>
+            <td><%= link_to user.name, user_path(user) %></td>
             <td><%= user.email %></td>
             <td><%= user.document_number %></td>
             <td><%= display_user_roles(user) %></td>

--- a/app/views/admin/valuators/_user_row.html.erb
+++ b/app/views/admin/valuators/_user_row.html.erb
@@ -1,5 +1,5 @@
 <tr>
-  <td><%= link_to user.name, user_path(user), target: "_blank" %></td>
+  <td><%= link_to user.name, user_path(user) %></td>
   <td><%= user.email %></td>
   <td></td>
   <td></td>

--- a/app/views/dashboard/_proposed_action.html.erb
+++ b/app/views/dashboard/_proposed_action.html.erb
@@ -46,7 +46,7 @@
       <% end %>
 
       <% proposed_action.links.each do |link| %>
-        <p><%= link_to link.label, link.url, target: "_blank" %></p>
+        <p><%= link_to link.label, link.url %></p>
       <% end %>
 
       <% proposed_action.documents.each do |document| %>

--- a/app/views/dashboard/actions/new_request.html.erb
+++ b/app/views/dashboard/actions/new_request.html.erb
@@ -13,7 +13,7 @@
       <div class="margin-top">
         <h4><%= t("dashboard.new_request.links") %></h4>
         <% dashboard_action.links.each do |link| %>
-          <p><%= link_to link.label, link.url, target: "_blank" %></p>
+          <p><%= link_to link.label, link.url %></p>
         <% end %>
       </div>
     <% end %>

--- a/app/views/dashboard/community.html.erb
+++ b/app/views/dashboard/community.html.erb
@@ -4,8 +4,7 @@
   <div class="small-12 medium-9 column">
     <%= link_to t("dashboard.community.access_community"),
                 community_path(proposal.community),
-                class: "button hollow",
-                target: "_blank" %>
+                class: "button hollow" %>
     <% if proposal.community.latest_activity.present? %>
       <p class="help-text">
         <%= t("dashboard.community.latest_activity",

--- a/app/views/dashboard/mailer/forward.html.erb
+++ b/app/views/dashboard/mailer/forward.html.erb
@@ -33,8 +33,7 @@
                       border-radius: 6px; color: #fff !important; font-weight: bold;
                       padding: 17px 20px; text-align: center; text-decoration: none;
                       font-size: 20px; min-width: 200px; display: inline-block;
-                      box-shadow: -4px 18px 45px -19px rgba(0,0,0,0.75);",
-                      target: "_blank" do %>
+                      box-shadow: -4px 18px 45px -19px rgba(0,0,0,0.75);" do %>
             <%= t("dashboard.mailer.forward.support_button") %>
           <% end %>
         </td>

--- a/app/views/dashboard/mailer/new_actions_notification_on_create.html.erb
+++ b/app/views/dashboard/mailer/new_actions_notification_on_create.html.erb
@@ -35,8 +35,7 @@
                       style: "font-family: 'Open Sans',arial,sans-serif; background: #3700fd;
                       border-radius: 6px; color: #fff !important; font-weight: bold;
                       padding: 17px 20px; text-align: center; text-decoration: none;
-                      font-size: 20px; min-width: 200px; display: inline-block;",
-                      target: "_blank" do %>
+                      font-size: 20px; min-width: 200px; display: inline-block;" do %>
             <%= t("mailers.new_actions_notification_on_create.dashboard_button") %>
           <% end %>
         </td>

--- a/app/views/dashboard/mailer/new_actions_notification_on_published.html.erb
+++ b/app/views/dashboard/mailer/new_actions_notification_on_published.html.erb
@@ -52,8 +52,7 @@
                       style: "font-family: 'Open Sans',arial,sans-serif; background: #3700fd;" \
                              "border-radius: 6px; color: #fff !important; font-weight: bold;" \
                              "padding: 17px 20px; text-align: center; text-decoration: none;" \
-                             "font-size: 20px; min-width: 200px; display: inline-block;",
-                      target: "_blank" do %>
+                             "font-size: 20px; min-width: 200px; display: inline-block;" do %>
             <%= t("mailers.new_actions_notification_on_published.dashboard_button") %>
           <% end %>
         </td>

--- a/app/views/dashboard/polls/_poll.html.erb
+++ b/app/views/dashboard/polls/_poll.html.erb
@@ -1,10 +1,6 @@
 <div id="<%= dom_id(poll) %>" class="small-12 medium-6 large-4 column end">
   <div class="poll-card" data-equalizer-watch="poll-cards">
-    <h4>
-      <%= link_to poll.title,
-                  proposal_poll_path(proposal, poll),
-                  target: "_blank" %>
-    </h4>
+    <h4><%= link_to poll.title, proposal_poll_path(proposal, poll) %></h4>
     <span class="small">
       <%= l(poll.starts_at.to_date) %> - <%= l(poll.ends_at.to_date) %>
     </span>
@@ -20,7 +16,7 @@
       <% else %>
         <%= link_to t("dashboard.polls.poll.view_results"),
                     results_proposal_poll_path(proposal, poll),
-                    class: "button", target: "_blank" %>
+                    class: "button" %>
       <% end %>
     </div>
 

--- a/app/views/dashboard/polls/index.html.erb
+++ b/app/views/dashboard/polls/index.html.erb
@@ -14,7 +14,7 @@
     <% if Setting["proposals.poll_link"].present? %>
       <h4><%= t("dashboard.polls.index.links") %></h4>
       <%= link_to t("dashboard.polls.index.additiontal_information"),
-                  Setting["proposals.poll_link"], target: "_blank" %>
+                  Setting["proposals.poll_link"] %>
     <% end %>
 
     <p><strong><%= t("dashboard.polls.index.count", count: @polls.count) %></strong></p>

--- a/app/views/dashboard/show.html.erb
+++ b/app/views/dashboard/show.html.erb
@@ -3,15 +3,13 @@
 <% if current_editable?(proposal) %>
   <%= link_to t("dashboard.index.edit_proposal_link"),
               edit_proposal_path(proposal),
-              target: "_blank",
               class: "button hollow" %>
 <% end %>
 
 <% unless proposal.retired? %>
   <%= link_to t("dashboard.index.retire"),
               retire_form_proposal_path(proposal),
-              class: "button hollow alert",
-              target: "_blank" %>
+              class: "button hollow alert" %>
 <% end %>
 
 <% if can?(:publish, proposal) %>

--- a/app/views/layouts/_mailer_header.html.erb
+++ b/app/views/layouts/_mailer_header.html.erb
@@ -4,11 +4,9 @@
       <table cellpadding="0" cellspacing="0" border="0" style="width: 100%;">
         <tr>
           <td style="border-bottom: 1px solid #dadfe1; padding: 20px 0;">
-            <a href="#" target="_blank">
-              <%= image_tag(image_path_for("logo_email.png"),
-                            style: "border: 0;display: block;width: 100%;max-width: 400px",
-                            alt: setting["org_name"]) %>
-            </a>
+            <%= image_tag(image_path_for("logo_email.png"),
+                          style: "border: 0;display: block;width: 100%;max-width: 400px",
+                          alt: setting["org_name"]) %>
           </td>
         </tr>
       </table>

--- a/app/views/layouts/dashboard/_proposal_header.html.erb
+++ b/app/views/layouts/dashboard/_proposal_header.html.erb
@@ -1,5 +1,5 @@
 <h3 class="proposal-title">
-  <%= link_to proposal.title, proposal, target: "_blank" %>
+  <%= link_to proposal.title, proposal %>
 </h3>
 
 <% if proposal.retired? %>

--- a/app/views/layouts/dashboard/_proposal_totals.html.erb
+++ b/app/views/layouts/dashboard/_proposal_totals.html.erb
@@ -47,9 +47,9 @@
           <div class="small-12 column">
             <div class="proposal-link">
               <% if proposal.draft? %>
-                <%= link_to t("layouts.dashboard.proposal_totals.preview_proposal"), proposal_path(proposal), class: "button success expanded", target: "_blank" %>
+                <%= link_to t("layouts.dashboard.proposal_totals.preview_proposal"), proposal_path(proposal), class: "button success expanded" %>
               <% else %>
-                <%= link_to t("layouts.dashboard.proposal_totals.show_proposal"), proposal_path(proposal), class: "button success expanded", target: "_blank" %>
+                <%= link_to t("layouts.dashboard.proposal_totals.show_proposal"), proposal_path(proposal), class: "button success expanded" %>
               <% end %>
             </div>
           </div>

--- a/app/views/mailer/direct_message_for_receiver.html.erb
+++ b/app/views/mailer/direct_message_for_receiver.html.erb
@@ -11,7 +11,7 @@
     <tbody>
       <tr>
         <td style="padding-bottom: 12px; padding-top: 24px; text-align: center;">
-          <%= link_to user_url(@direct_message.sender), style: css_for_mailer_button, target: "_blank" do %>
+          <%= link_to user_url(@direct_message.sender), style: css_for_mailer_button do %>
             <%= t("mailers.direct_message_for_receiver.reply",
                   sender: @direct_message.sender.name) %>
           <% end %>

--- a/app/views/management/document_verifications/invalid_document.html.erb
+++ b/app/views/management/document_verifications/invalid_document.html.erb
@@ -12,5 +12,5 @@
 
 <p>
   <%= sanitize(t("management.document_verifications.has_no_account",
-                 link: link_to(t("management.document_verifications.link"), root_path, target: "_blank"))) %>
+                 link: link_to(t("management.document_verifications.link"), root_path))) %>
 </p>

--- a/app/views/moderation/budgets/investments/index.html.erb
+++ b/app/views/moderation/budgets/investments/index.html.erb
@@ -14,7 +14,7 @@
             <%= link_to investment.title, admin_budget_budget_investment_path(
                                             budget_id: investment.budget_id,
                                             id: investment.id
-                                          ), target: "_blank" %>
+                                          ) %>
             <br>
             <span class="date"><%= l investment.updated_at.to_date %></span>
             <span class="bullet">&nbsp;&bull;&nbsp;</span>

--- a/app/views/moderation/comments/index.html.erb
+++ b/app/views/moderation/comments/index.html.erb
@@ -12,7 +12,7 @@
         <tr id="comment_<%= comment.id %>">
           <td>
             <%= comment.commentable_type.constantize.model_name.human %> -
-            <%= link_to comment.commentable.title, commentable_path(comment), target: "_blank" %>
+            <%= link_to comment.commentable.title, commentable_path(comment) %>
             <br>
             <span class="date"><%= l comment.updated_at.to_date %></span>
             <span class="bullet">&nbsp;&bull;&nbsp;</span>

--- a/app/views/moderation/debates/index.html.erb
+++ b/app/views/moderation/debates/index.html.erb
@@ -11,7 +11,7 @@
       <% @debates.each do |debate| %>
         <tr id="debate_<%= debate.id %>">
           <td>
-            <%= link_to debate.title, debate, target: "_blank" %>
+            <%= link_to debate.title, debate %>
             <br>
             <span class="date"><%= l debate.updated_at.to_date %></span>
             <span class="bullet">&nbsp;&bull;&nbsp;</span>

--- a/app/views/moderation/proposal_notifications/index.html.erb
+++ b/app/views/moderation/proposal_notifications/index.html.erb
@@ -11,7 +11,7 @@
       <% @proposal_notifications.each do |proposal_notification| %>
         <tr id="proposal_notification_<%= proposal_notification.id %>">
           <td>
-            <%= link_to proposal_notification.title, proposal_notification, target: "_blank" %>
+            <%= link_to proposal_notification.title, proposal_notification %>
             <br>
             <span class="date"><%= l proposal_notification.updated_at.to_date %></span>
             <br>

--- a/app/views/moderation/proposals/index.html.erb
+++ b/app/views/moderation/proposals/index.html.erb
@@ -11,7 +11,7 @@
       <% @proposals.each do |proposal| %>
         <tr id="proposal_<%= proposal.id %>">
           <td>
-            <%= link_to proposal.title, proposal, target: "_blank" %>
+            <%= link_to proposal.title, proposal %>
             <br>
             <span class="date"><%= l proposal.updated_at.to_date %></span>
             <span class="bullet">&nbsp;&bull;&nbsp;</span>

--- a/app/views/polls/_gallery.html.erb
+++ b/app/views/polls/_gallery.html.erb
@@ -18,7 +18,7 @@
 
     <% answer.images.reverse.each_with_index do |image, index| %>
       <li class="orbit-slide <%= is_active_class(index) %>">
-        <%= link_to image.attachment, target: "_blank" do %>
+        <%= link_to image.attachment do %>
           <%= image_tag image.attachment,
                         class: "orbit-image",
                         alt: image.title.unicode_normalize %>

--- a/config/locales/en/general.yml
+++ b/config/locales/en/general.yml
@@ -719,7 +719,7 @@ en:
       districts: "Districts"
       districts_list: "Districts list"
       categories: "Categories"
-    target_blank: " (link opens in new window)"
+    target_blank: "Link opens in new window"
     you_are_in: "You are in"
     unflag: Unflag
     unfollow_entity: "Unfollow %{entity}"

--- a/config/locales/es/general.yml
+++ b/config/locales/es/general.yml
@@ -719,7 +719,7 @@ es:
       districts: "Distritos"
       districts_list: "Listado de distritos"
       categories: "Categorías"
-    target_blank: " (se abre en ventana nueva)"
+    target_blank: "Se abre en ventana nueva"
     you_are_in: "Estás en"
     unflag: Deshacer denuncia
     unfollow_entity: "Dejar de seguir %{entity}"

--- a/lib/markdown_converter.rb
+++ b/lib/markdown_converter.rb
@@ -30,7 +30,7 @@ class MarkdownConverter
       {
         filter_html: false,
         hard_wrap: true,
-        link_attributes: { target: "_blank" }
+        link_attributes: {}
       }
     end
 

--- a/spec/components/layout/footer_component_spec.rb
+++ b/spec/components/layout/footer_component_spec.rb
@@ -6,7 +6,9 @@ describe Layout::FooterComponent do
       render_inline Layout::FooterComponent.new
 
       page.find(".info") do |info|
-        expect(info).to have_css "a[rel=nofollow]", count: 2
+        expect(info).to have_css "a", count: 2
+        expect(info).to have_css "a[rel~=nofollow]", count: 2
+        expect(info).to have_css "a[rel~=external]", count: 2
         expect(info).not_to have_css "a[target]"
       end
     end

--- a/spec/components/layout/footer_component_spec.rb
+++ b/spec/components/layout/footer_component_spec.rb
@@ -1,0 +1,13 @@
+require "rails_helper"
+
+describe Layout::FooterComponent do
+  describe "description links" do
+    it "generates links that open in the same tab" do
+      render_inline Layout::FooterComponent.new
+
+      page.find(".info") do |info|
+        expect(info).not_to have_css "a[target]"
+      end
+    end
+  end
+end

--- a/spec/components/layout/footer_component_spec.rb
+++ b/spec/components/layout/footer_component_spec.rb
@@ -6,6 +6,7 @@ describe Layout::FooterComponent do
       render_inline Layout::FooterComponent.new
 
       page.find(".info") do |info|
+        expect(info).to have_css "a[rel=nofollow]", count: 2
         expect(info).not_to have_css "a[target]"
       end
     end

--- a/spec/components/shared/agree_with_terms_of_service_field_component_spec.rb
+++ b/spec/components/shared/agree_with_terms_of_service_field_component_spec.rb
@@ -25,6 +25,6 @@ describe Shared::AgreeWithTermsOfServiceFieldComponent do
     expect(page).to have_link count: 2
     expect(page).to have_link "Privacy Policy"
     expect(page).to have_link "Terms and conditions of use"
-    expect(page).to have_link " (link opens in new window)", count: 2
+    expect(page).to have_link "Link opens in new window", count: 2
   end
 end

--- a/spec/models/legislation/draft_version_spec.rb
+++ b/spec/models/legislation/draft_version_spec.rb
@@ -38,6 +38,12 @@ describe Legislation::DraftVersion do
     expect(legislation_draft_version.toc_html).to eq(toc_html)
   end
 
+  it "does not add a target attribute to links" do
+    legislation_draft_version.body = "A [link](/url)"
+
+    expect(legislation_draft_version.body_html).to eq("<p>A <a href=\"/url\">link</a></p>\n")
+  end
+
   def body_markdown
     <<~BODY_MARKDOWN
       # Title 1

--- a/spec/system/admin/users_spec.rb
+++ b/spec/system/admin/users_spec.rb
@@ -18,9 +18,9 @@ describe "Admin users" do
   scenario "The username links to their public profile" do
     visit admin_users_path
 
-    within_window(window_opened_by { click_link user.name }) do
-      expect(page).to have_current_path(user_path(user))
-    end
+    click_link user.name
+
+    expect(page).to have_current_path(user_path(user))
   end
 
   scenario "Show active or erased users using filters" do

--- a/spec/system/comments/budget_investments_spec.rb
+++ b/spec/system/comments/budget_investments_spec.rb
@@ -167,7 +167,7 @@ describe "Commenting Budget::Investments" do
       expect(page).to have_content "Built with http://rubyonrails.org/"
       expect(page).to have_link("http://rubyonrails.org/", href: "http://rubyonrails.org/")
       expect(find_link("http://rubyonrails.org/")[:rel]).to eq("nofollow")
-      expect(find_link("http://rubyonrails.org/")[:target]).to eq("_blank")
+      expect(find_link("http://rubyonrails.org/")[:target]).to be_blank
     end
   end
 

--- a/spec/system/comments/budget_investments_valuation_spec.rb
+++ b/spec/system/comments/budget_investments_valuation_spec.rb
@@ -125,7 +125,7 @@ describe "Internal valuation comments on Budget::Investments" do
         expect(page).to have_content("Check http://rubyonrails.org/")
         expect(page).to have_link("http://rubyonrails.org/", href: "http://rubyonrails.org/")
         expect(find_link("http://rubyonrails.org/")[:rel]).to eq("nofollow")
-        expect(find_link("http://rubyonrails.org/")[:target]).to eq("_blank")
+        expect(find_link("http://rubyonrails.org/")[:target]).to be_blank
       end
     end
 

--- a/spec/system/comments/debates_spec.rb
+++ b/spec/system/comments/debates_spec.rb
@@ -170,7 +170,7 @@ describe "Commenting debates" do
       expect(page).to have_content "Built with http://rubyonrails.org/"
       expect(page).to have_link("http://rubyonrails.org/", href: "http://rubyonrails.org/")
       expect(find_link("http://rubyonrails.org/")[:rel]).to eq("nofollow")
-      expect(find_link("http://rubyonrails.org/")[:target]).to eq("_blank")
+      expect(find_link("http://rubyonrails.org/")[:target]).to be_blank
     end
   end
 

--- a/spec/system/comments/legislation_annotations_spec.rb
+++ b/spec/system/comments/legislation_annotations_spec.rb
@@ -164,7 +164,7 @@ describe "Commenting legislation questions" do
       expect(page).to have_content "Built with http://rubyonrails.org/"
       expect(page).to have_link("http://rubyonrails.org/", href: "http://rubyonrails.org/")
       expect(find_link("http://rubyonrails.org/")[:rel]).to eq("nofollow")
-      expect(find_link("http://rubyonrails.org/")[:target]).to eq("_blank")
+      expect(find_link("http://rubyonrails.org/")[:target]).to be_blank
     end
   end
 

--- a/spec/system/comments/legislation_questions_spec.rb
+++ b/spec/system/comments/legislation_questions_spec.rb
@@ -159,7 +159,7 @@ describe "Commenting legislation questions" do
       expect(page).to have_content "Built with http://rubyonrails.org/"
       expect(page).to have_link("http://rubyonrails.org/", href: "http://rubyonrails.org/")
       expect(find_link("http://rubyonrails.org/")[:rel]).to eq("nofollow")
-      expect(find_link("http://rubyonrails.org/")[:target]).to eq("_blank")
+      expect(find_link("http://rubyonrails.org/")[:target]).to be_blank
     end
   end
 

--- a/spec/system/comments/polls_spec.rb
+++ b/spec/system/comments/polls_spec.rb
@@ -148,7 +148,7 @@ describe "Commenting polls" do
       expect(page).to have_content "Built with http://rubyonrails.org/"
       expect(page).to have_link("http://rubyonrails.org/", href: "http://rubyonrails.org/")
       expect(find_link("http://rubyonrails.org/")[:rel]).to eq("nofollow")
-      expect(find_link("http://rubyonrails.org/")[:target]).to eq("_blank")
+      expect(find_link("http://rubyonrails.org/")[:target]).to be_blank
     end
   end
 

--- a/spec/system/comments/proposals_spec.rb
+++ b/spec/system/comments/proposals_spec.rb
@@ -153,7 +153,7 @@ describe "Commenting proposals" do
       expect(page).to have_content "Built with http://rubyonrails.org/"
       expect(page).to have_link("http://rubyonrails.org/", href: "http://rubyonrails.org/")
       expect(find_link("http://rubyonrails.org/")[:rel]).to eq("nofollow")
-      expect(find_link("http://rubyonrails.org/")[:target]).to eq("_blank")
+      expect(find_link("http://rubyonrails.org/")[:target]).to be_blank
     end
   end
 

--- a/spec/system/comments/topics_spec.rb
+++ b/spec/system/comments/topics_spec.rb
@@ -161,7 +161,7 @@ describe "Commenting topics from proposals" do
       expect(page).to have_content "Built with http://rubyonrails.org/"
       expect(page).to have_link("http://rubyonrails.org/", href: "http://rubyonrails.org/")
       expect(find_link("http://rubyonrails.org/")[:rel]).to eq("nofollow")
-      expect(find_link("http://rubyonrails.org/")[:target]).to eq("_blank")
+      expect(find_link("http://rubyonrails.org/")[:target]).to be_blank
     end
   end
 
@@ -710,7 +710,7 @@ describe "Commenting topics from budget investments" do
       expect(page).to have_content "Built with http://rubyonrails.org/"
       expect(page).to have_link("http://rubyonrails.org/", href: "http://rubyonrails.org/")
       expect(find_link("http://rubyonrails.org/")[:rel]).to eq("nofollow")
-      expect(find_link("http://rubyonrails.org/")[:target]).to eq("_blank")
+      expect(find_link("http://rubyonrails.org/")[:target]).to be_blank
     end
   end
 

--- a/spec/system/dashboard/polls_spec.rb
+++ b/spec/system/dashboard/polls_spec.rb
@@ -256,9 +256,9 @@ describe "Polls" do
 
     visit proposal_dashboard_polls_path(proposal)
 
-    within_window(window_opened_by { click_link "View results" }) do
-      expect(page).to have_current_path(results_proposal_poll_path(proposal, poll))
-    end
+    click_link "View results"
+
+    expect(page).to have_current_path(results_proposal_poll_path(proposal, poll))
   end
 
   scenario "Enable and disable results" do

--- a/spec/system/proposals_spec.rb
+++ b/spec/system/proposals_spec.rb
@@ -423,9 +423,9 @@ describe "Proposals" do
     click_link "Dashboard"
     click_link "Edit my proposal"
 
-    within_window(window_opened_by { click_link "Edit proposal" }) do
-      expect(page).to have_field "Full name of the person submitting the proposal", with: "Isabel Garcia"
-    end
+    click_link "Edit proposal"
+
+    expect(page).to have_field "Full name of the person submitting the proposal", with: "Isabel Garcia"
   end
 
   scenario "Responsible name field is not shown for verified users" do
@@ -628,15 +628,15 @@ describe "Proposals" do
         click_link "Edit my proposal"
       end
 
-      within_window(window_opened_by { click_link "Withdraw proposal" }) do
-        expect(page).to have_current_path(retire_form_proposal_path(proposal))
+      click_link "Withdraw proposal"
 
-        select "Duplicated", from: "proposal_retired_reason"
-        fill_in "Explanation", with: "There are three other better proposals with the same subject"
-        click_button "Withdraw proposal"
+      expect(page).to have_current_path(retire_form_proposal_path(proposal))
 
-        expect(page).to have_content "The proposal has been withdrawn"
-      end
+      select "Duplicated", from: "proposal_retired_reason"
+      fill_in "Explanation", with: "There are three other better proposals with the same subject"
+      click_button "Withdraw proposal"
+
+      expect(page).to have_content "The proposal has been withdrawn"
 
       visit proposal_path(proposal)
 


### PR DESCRIPTION
## References

* Depends on pull requests #5281 and #5283
* [Understanding WCAG Success Criterion 3.2.5: Change on Request](https://www.w3.org/WAI/WCAG22/Understanding/change-on-request.html)
* [Opening new windows and tabs from a link only when necessary](https://www.w3.org/WAI/WCAG22/Techniques/general/G200)
* [Opening Links in New Browser Windows and Tabs](https://www.nngroup.com/articles/new-browser-windows-and-tabs/)
* [ When to use target=”_blank” ](https://css-tricks.com/use-target_blank/)

## Objectives

* Give users control regarding how to open links
* Make it easy to go back to the previous page after clicking on a link, particularly on mobile phones