### PR TITLE
Map node binaries whenever `rvm1:hook` is called and evaluate the `fnm_setup_command` dynamically

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -60,7 +60,7 @@ namespace :deploy do
   Rake::Task["delayed_job:default"].clear_actions
   Rake::Task["puma:smart_restart"].clear_actions
 
-  after "git:create_release", "map_node_bins"
+  after "rvm1:hook", "map_node_bins"
 
   after :updating, "install_node"
   after :updating, "install_ruby"
@@ -127,7 +127,7 @@ task :map_node_bins do
   on roles(:app) do
     within release_path do
       with rails_env: fetch(:rails_env) do
-        prefix = "#{fetch(:fnm_setup_command)} && fnm exec"
+        prefix = -> { "#{fetch(:fnm_setup_command)} && fnm exec" }
 
         fetch(:fnm_map_bins).each do |command|
           SSHKit.config.command_map.prefix[command.to_sym].unshift(prefix)


### PR DESCRIPTION
# References

* #5158 

The previous version worked fine when using Capistrano to deploy a new release, but it did not work for other commands, like `cap npm install` or `cap puma:start`, as they do not create a release. Therefore, the `git:create_release` was never called, and the `map_node_bins` was not invoked.

## Objectives

Since we need node binaries available to the deploy user when executing any process that runs the application, like puma, delayed_job, and rake tasks, among others, it makes sense to load FNM to use the correct Node version in the same places where Capistrano loads RVM to load the correct Ruby version.

With dynamic loading of the `fnm_setup_command`, we get the correct path when deploying a new release and also when running any other capistrano command that does not deploy a new release.