### PR TITLE
Allow to set the application timezone via secrets

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -51,7 +51,7 @@ module Consul
 
     # Set Time.zone default to the specified zone and make Active Record auto-convert to this zone.
     # Run "rake -D time" for a list of tasks for finding time zone names. Default is UTC.
-    config.time_zone = "Madrid"
+    config.time_zone = Rails.application.secrets.time_zone.presence || "Madrid"
 
     # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]

--- a/config/secrets.yml.example
+++ b/config/secrets.yml.example
@@ -16,6 +16,7 @@ http_basic_auth: &http_basic_auth
   http_basic_auth: true
 
 development:
+  # time_zone: ""
   http_basic_username: "dev"
   http_basic_password: "pass"
   devise_lockable: false
@@ -31,12 +32,14 @@ development:
   <<: *maps
 
 test:
+  # time_zone: ""
   secret_key_base: 56792feef405a59b18ea7db57b4777e855103882b926413d4afdfb8c0ea8aa86ea6649da4e729c5f5ae324c0ab9338f789174cf48c544173bc18fdc3b14262e4
   <<: *maps
 
 staging:
   # secret_key_base: ""
   server_name: ""
+  # time_zone: ""
   # mailer_delivery_method: :smtp
   # smtp_settings:
   #   :address: "smtp.example.com"
@@ -81,6 +84,7 @@ staging:
 preproduction:
   # secret_key_base: ""
   server_name: ""
+  # time_zone: ""
   # mailer_delivery_method: :smtp
   # smtp_settings:
   #   :address: "smtp.example.com"
@@ -131,6 +135,7 @@ preproduction:
 production:
   # secret_key_base: ""
   server_name: ""
+  # time_zone: ""
   # mailer_delivery_method: :smtp
   # smtp_settings:
   #   :address: "smtp.example.com"


### PR DESCRIPTION
## References

This PR makes sense along with:
* consuldemocracy/installer#230


## Objectives

If the installer PR#230 gets merged, installations can set the desired timezone from the installer.

This PR makes the application read the timezone from the application secrets. When the timezone is not defined in application secrets, the application uses Madrid as the default timezone.

This will allow Consul Democracy installations to change the application timezone via secrets without coding or deploying the application. Of course, after updating the secrets, the application must be restarted for the new timezone to take effect.

## Release notes
Existing installations using a timezone other than Madrid must add the `time_zone` entry to the `secrets.yml` file before deploying these changes. If you have some custom code to set the application timezone you can remove it and rely on the secrets configuration.

You can search supported timezone names by running the following in the rails console:
`ActiveSupport::TimeZone.all`


