### PR TITLE
Clarify authentication_logs secret

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -139,7 +139,7 @@ module Consul
     config.paths["app/views"].unshift(Rails.root.join("app", "views", "custom"))
 
     # Set to true to enable user authentication log
-    config.authentication_logs = Rails.application.secrets.dig(:security, :authentication_logs) || false
+    config.authentication_logs = Rails.application.secrets.authentication_logs || false
 
     # Set to true to enable devise user lockable feature
     config.devise_lockable = Rails.application.secrets.devise_lockable

--- a/config/secrets.yml.example
+++ b/config/secrets.yml.example
@@ -18,10 +18,10 @@ http_basic_auth: &http_basic_auth
 development:
   http_basic_username: "dev"
   http_basic_password: "pass"
+  authentication_logs: false
   devise_lockable: false
   multitenancy: false
   security:
-    authentication_logs: false
     last_sign_in: false
     password_complexity: false
     # lockable:
@@ -55,12 +55,12 @@ staging:
   errbit_self_hosted_ssl: false
   http_basic_username: ""
   http_basic_password: ""
+  authentication_logs: false
   devise_lockable: false
   managers_url: ""
   managers_application_key: ""
   multitenancy: false
   security:
-    authentication_logs: false
     last_sign_in: false
     password_complexity: false
     # lockable:
@@ -99,12 +99,12 @@ preproduction:
   errbit_self_hosted_ssl: false
   http_basic_username: ""
   http_basic_password: ""
+  authentication_logs: false
   devise_lockable: false
   managers_url: ""
   managers_application_key: ""
   multitenancy: false
   security:
-    authentication_logs: false
     last_sign_in: false
     password_complexity: false
     # lockable:
@@ -148,12 +148,12 @@ production:
   errbit_self_hosted_ssl: false
   http_basic_username: ""
   http_basic_password: ""
+  authentication_logs: false
   devise_lockable: false
   managers_url: ""
   managers_application_key: ""
   multitenancy: false
   security:
-    authentication_logs: false
     last_sign_in: false
     password_complexity: false
     # lockable:


### PR DESCRIPTION
## References
Related PR: #5302 

## Objectives
Avoid that it can be thought that this secret can be configured per tenant.

The secrets defined in the `secrets.yml` are used to configure the application. When introducing the concept of multitenancy, it is sometimes interesting to allow the configuration of each of these secrets for each tenant. That is why in this `secrets.yml` file there is the following section where it is specified which secrets can be overwritten:

>   tenants:
    # If you've enabled multitenancy, you can overwrite secrets for a
    # specific tenant with:
    #
    # my_tenant_subdomain:
    #   secret_key: my_secret_value
    #
    # Currently you can overwrite SMTP, SMS, manager, microsoft API,
    # HTTP basic, twitter, facebook, google, wordpress and **security settings.**

In the related PR we were including this secret in the `security` section and as can be seen in the text above, it is specified that this section can be configured by each tenant. 

As this is not the case for this secret and it cannot be defined independently by each tenant, to avoid confusion, we took it out of the `security` section.
