### PR TITLE
Refresh CSRF Token when using Turbolinks

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -121,6 +121,7 @@
 //= require budget_edit_associations
 //= require budget_hide_money
 //= require datepicker
+//= require authenticity_token_refresh
 //= require_tree ./admin
 //= require_tree ./sdg
 //= require_tree ./sdg_management
@@ -183,6 +184,7 @@ var initialize_modules = function() {
   App.Datepicker.initialize();
   App.SDGRelatedListSelector.initialize();
   App.SDGManagementRelationSearch.initialize();
+  App.AuthenticityTokenRefresh.initialize();
 };
 
 var destroy_non_idempotent_modules = function() {

--- a/app/assets/javascripts/authenticity_token_refresh.js
+++ b/app/assets/javascripts/authenticity_token_refresh.js
@@ -1,0 +1,8 @@
+(function() {
+  "use strict";
+  App.AuthenticityTokenRefresh = {
+    initialize: function() {
+      $.rails.refreshCSRFTokens();
+    }
+  };
+}).call(this);


### PR DESCRIPTION
## References

This PR fixes:
* #5160

## Objectives
Refresh the authenticity token when browsing the application with Turbolinks.

## Notes
We cannot reproduce the error in the test or development environment. So, we cannot write a test that demonstrates it. We verified manually that this commit fixes the problem described in #5160 when running the application in staging or production environments.

