### PR TITLE
Make it easier to find permanent links to documents

### DIFF
--- a/app/components/admin/poll/questions/answers/documents/table_actions_component.html.erb
+++ b/app/components/admin/poll/questions/answers/documents/table_actions_component.html.erb
@@ -2,6 +2,6 @@
                                                    destroy_path: document_path(document)) do |actions| %>
   <%= actions.action(:download,
                      text: t("documents.buttons.download_document"),
-                     path: document.attachment,
+                     path: rails_blob_path(document.attachment, disposition: "attachment"),
                      rel: "nofollow") %>
 <% end %>

--- a/app/components/admin/site_customization/documents/copy_link_dialog_component.html.erb
+++ b/app/components/admin/site_customization/documents/copy_link_dialog_component.html.erb
@@ -1,0 +1,8 @@
+<section id="<%= dialog_id %>" class="small reveal" data-reveal aria-labelledby="<%= dialog_label_id %>">
+  <h2 id="<%= dialog_label_id %>"><%= t("admin.site_customization.documents.copy_link_dialog.title") %></h2>
+  <button class="close-button" aria-label="<%= t("admin.shared.close_modal") %>" type="button" data-close>
+    <span aria-hidden="true">&times;</span>
+  </button>
+  <p><%= t("admin.site_customization.documents.copy_link_dialog.description") %></p>
+  <code><%= polymorphic_url(document.attachment) %></code>
+</section>

--- a/app/components/admin/site_customization/documents/copy_link_dialog_component.rb
+++ b/app/components/admin/site_customization/documents/copy_link_dialog_component.rb
@@ -1,0 +1,16 @@
+class Admin::SiteCustomization::Documents::CopyLinkDialogComponent < ApplicationComponent
+  with_collection_parameter :document
+  attr_reader :document
+
+  def initialize(document:)
+    @document = document
+  end
+
+  def dialog_id
+    "#{dom_id(document)}-dialog"
+  end
+
+  def dialog_label_id
+    "#{dom_id(document)}-dialog-heading"
+  end
+end

--- a/app/views/admin/site_customization/documents/index.html.erb
+++ b/app/views/admin/site_customization/documents/index.html.erb
@@ -28,6 +28,11 @@
               actions: [:destroy],
               destroy_path: admin_site_customization_document_path(document)
             ) do |actions| %>
+              <%= actions.action(:show,
+                                 text: t("documents.buttons.show_link"),
+                                 path: "#",
+                                 rel: "nofollow",
+                                 data: { open: "#{dom_id(document)}-dialog" }) %>
               <%= actions.action(:download,
                                  text: t("documents.buttons.download_document"),
                                  path: rails_blob_path(document.attachment, disposition: "attachment"),
@@ -38,6 +43,8 @@
       <% end %>
     </tbody>
   <table>
+
+  <%= render Admin::SiteCustomization::Documents::CopyLinkDialogComponent.with_collection(@documents) %>
 <% else %>
   <div class="callout primary">
     <%= t("admin.documents.index.no_documents") %>

--- a/app/views/admin/site_customization/documents/index.html.erb
+++ b/app/views/admin/site_customization/documents/index.html.erb
@@ -30,7 +30,7 @@
             ) do |actions| %>
               <%= actions.action(:download,
                                  text: t("documents.buttons.download_document"),
-                                 path: document.attachment,
+                                 path: rails_blob_path(document.attachment, disposition: "attachment"),
                                  rel: "nofollow") %>
             <% end %>
           </td>

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -1603,6 +1603,10 @@ en:
             footer_legal: Footer (legal terms)
             subnavigation_left: Main Navigation Left
             subnavigation_right: Main Navigation Right
+      documents:
+        copy_link_dialog:
+          title: "Document link"
+          description: "You can use the link below if you need to include this document in a custom page or want to share it."
       images:
         index:
           title: Custom images

--- a/config/locales/en/documents.yml
+++ b/config/locales/en/documents.yml
@@ -18,6 +18,7 @@ en:
     buttons:
       download_document: Download file
       destroy_document: Delete document
+      show_link: Show link
     errors:
       messages:
         in_between: must be in between %{min} and %{max}

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -1603,6 +1603,10 @@ es:
             footer_legal: Pie de página (términos legales)
             subnavigation_left: Navegación principal izquierda
             subnavigation_right: Navegación principal derecha
+      documents:
+        copy_link_dialog:
+          title: "Enlace al documento"
+          description: "Puedes usar el enlace a continuación si quieres compartir o enlazar este documento en una página personalizada."
       images:
         index:
           title: Personalizar imágenes

--- a/config/locales/es/documents.yml
+++ b/config/locales/es/documents.yml
@@ -18,6 +18,7 @@ es:
     buttons:
       download_document: Descargar archivo
       destroy_document: Eliminar documento
+      show_link: Ver enlace
     errors:
       messages:
         in_between: debe estar entre %{min} y %{max}

--- a/spec/components/admin/poll/questions/answers/documents/table_actions_component_spec.rb
+++ b/spec/components/admin/poll/questions/answers/documents/table_actions_component_spec.rb
@@ -1,8 +1,19 @@
 require "rails_helper"
 
 describe Admin::Poll::Questions::Answers::Documents::TableActionsComponent, :admin do
+  include Rails.application.routes.url_helpers
+
   let(:future_answer) { create(:poll_question_answer, poll: create(:poll, :future)) }
   let(:current_answer) { create(:poll_question_answer, poll: create(:poll)) }
+
+  it "displays the download action using `attachment` disposition" do
+    document = create(:document, documentable: future_answer)
+
+    render_inline Admin::Poll::Questions::Answers::Documents::TableActionsComponent.new(document)
+
+    url = rails_blob_path(document.attachment, disposition: "attachment", only_path: true)
+    expect(page).to have_link "Download file", href: url
+  end
 
   it "displays the destroy action when the poll has not started" do
     document = create(:document, documentable: future_answer)

--- a/spec/system/admin/site_customization/documents_spec.rb
+++ b/spec/system/admin/site_customization/documents_spec.rb
@@ -18,7 +18,7 @@ describe "Documents", :admin do
     1.times { create(:document) }
 
     document = Document.first
-    url = polymorphic_path(document.attachment)
+    url = rails_blob_path(document.attachment, disposition: "attachment")
 
     visit admin_site_customization_documents_path
 

--- a/spec/system/admin/site_customization/documents_spec.rb
+++ b/spec/system/admin/site_customization/documents_spec.rb
@@ -26,6 +26,27 @@ describe "Documents", :admin do
     expect(page).to have_link "Download file", href: url
   end
 
+  scenario "Index shows a link that opens a modal dialog with the document permanent link" do
+    document_1 = create(:document, :admin)
+    document_2 = create(:document, :admin)
+    document_1_url = polymorphic_url(document_1.attachment, host: app_host)
+    document_2_url = polymorphic_url(document_2.attachment, host: app_host)
+
+    visit admin_site_customization_documents_path
+    within "#document_#{document_1.id}" do
+      click_link "Show link"
+    end
+
+    expect(page).to have_content(document_1_url)
+
+    click_button "Close modal"
+    within "#document_#{document_2.id}" do
+      click_link "Show link"
+    end
+
+    expect(page).to have_content(document_2_url)
+  end
+
   scenario "Index (empty)" do
     visit admin_site_customization_documents_path
 


### PR DESCRIPTION
## References

This PR tries to address the issues described in:
*  #5112

## Objectives

1. Use the Rails recommended way to render document download links
2. Provide an obvious place from where to copy the permanent link to documents so administrators can paste it anywhere they want.

## Visual Changes

**Before**

<img width="735" alt="Captura de pantalla 2023-12-01 a las 13 20 00" src="https://github.com/consuldemocracy/consuldemocracy/assets/15726/e34fe5c0-80d0-425e-8de1-8e4efd50a516">

**After**

Link "Show link" added. It opens an alert box 
<img width="739" alt="Captura de pantalla 2023-12-01 a las 13 18 55" src="https://github.com/consuldemocracy/consuldemocracy/assets/15726/a0dc86e6-ead5-4203-a773-4ce4f0719088">

Modal dialog with the permanent URL
<img width="917" alt="Captura de pantalla 2024-01-23 a las 13 59 49" src="https://github.com/consuldemocracy/consuldemocracy/assets/15726/2ace9a03-2faa-4161-9ef0-3a0a82d6c0e9">


Alert box with the permanent URL (Previous implementation)

<img width="740" alt="Captura de pantalla 2023-12-01 a las 13 19 06" src="https://github.com/consuldemocracy/consuldemocracy/assets/15726/4c909c18-1103-426a-bea0-49624af96317">
