### PR TITLE
Make legislation summary configurable

### DIFF
--- a/app/controllers/admin/legislation/processes_controller.rb
+++ b/app/controllers/admin/legislation/processes_controller.rb
@@ -72,6 +72,8 @@ class Admin::Legislation::ProcessesController < Admin::Legislation::BaseControll
         :background_color,
         :font_color,
         :related_sdg_list,
+        :summary_publication_date,
+        :summary_publication_enabled,
         translation_params(::Legislation::Process),
         documents_attributes: document_attributes,
         image_attributes: image_attributes

--- a/app/models/abilities/administrator.rb
+++ b/app/models/abilities/administrator.rb
@@ -18,7 +18,8 @@ module Abilities
       can :create, Legislation::Proposal
       can :show, Legislation::Proposal
       can :proposals, ::Legislation::Process
-
+      can :summary, ::Legislation::Process
+      
       can :restore, Legislation::Proposal
       cannot :restore, Legislation::Proposal, hidden_at: nil
 

--- a/app/models/abilities/everyone.rb
+++ b/app/models/abilities/everyone.rb
@@ -20,8 +20,13 @@ module Abilities
       can :read_executions, Budget, phase: "finished"
       can [:read, :debate, :draft_publication, :allegations, :result_publication,
            :proposals, :milestones], Legislation::Process, published: true
-      can :summary, Legislation::Process,
-          id: Legislation::Process.past.published.where(result_publication_enabled: true).ids
+           
+      can :summary, Legislation::Process do |process|
+          process.summary_publication_enabled? && 
+            (process.summary_publication_date.nil? || process.summary_publication_date <= Date.current) &&
+            process.id.in?(Legislation::Process.published.where(summary_publication_enabled: true).ids)
+      end
+                     
       can [:read, :changes, :go_to_version], Legislation::DraftVersion
       can [:read], Legislation::Question
       can [:read, :share], Legislation::Proposal

--- a/app/models/legislation/process.rb
+++ b/app/models/legislation/process.rb
@@ -93,6 +93,10 @@ class Legislation::Process < ApplicationRecord
                                     proposals_phase_end_date, proposals_phase_enabled)
   end
 
+  def summary_publication
+    Legislation::Process::Publication.new(summary_publication_date, summary_publication_enabled)
+  end
+
   def draft_publication
     Legislation::Process::Publication.new(draft_publication_date, draft_publication_enabled)
   end

--- a/app/views/admin/legislation/processes/_form.html.erb
+++ b/app/views/admin/legislation/processes/_form.html.erb
@@ -4,6 +4,7 @@
 
   <%= render "shared/errors", resource: @process %>
 
+<div class="row">
   <fieldset>
     <legend class="small-12 medium-4 column">
       <%= t("admin.legislation.processes.form.draft_phase") %>
@@ -85,12 +86,45 @@
     <div class="small-12 medium-3 column">
       <%= f.date_field :allegations_end_date, id: "allegations_end_date" %>
     </div>
-    <div class="small-12 medium-2 column margin-top">
+     <div class="small-12 medium-2 column margin-top">
       <%= f.check_box :allegations_phase_enabled, checked: @process.allegations_phase.enabled?, label: t("admin.legislation.processes.form.enabled") %>
+    </div>
+   </fieldset>
+   <fieldset>
+    <legend class="small-12 medium-4 column">
+      <%= t("admin.legislation.processes.form.draft_publication") %>
+      <span class="help-text"><%= t("admin.legislation.processes.form.draft_publication_description") %></span>
+    </legend>
+
+    <div class="small-12 medium-3 column end">
+      <%= f.date_field :draft_publication_date, id: "draft_publication_date" %>
+    </div>
+    <div class="small-12 medium-2 column margin-top">
+      <%= f.check_box :draft_publication_enabled, checked: @process.draft_publication.enabled?, label: t("admin.legislation.processes.form.enabled") %>
+    </div>
+   </fieldset>
+   <fieldset>
+
+    <legend class="small-12 medium-4 column">
+      <%= t("admin.legislation.processes.form.final_publication") %>
+      <span class="help-text"><%= t("admin.legislation.processes.form.final_publication_description") %></span>
+    </legend>
+
+    <div class="small-12 medium-3 column end">
+      <%= f.date_field :result_publication_date, id: "result_publication_date" %>
+    </div>
+
+    <div class="small-12 medium-2 column margin-top">
+      <%= f.check_box :result_publication_enabled, checked: @process.result_publication.enabled?, label: t("admin.legislation.processes.form.enabled") %>
     </div>
   </fieldset>
 
   <fieldset>
+    <legend class="small-12 medium-4 column">
+      <%= t("admin.legislation.processes.form.summary_phase") %>
+      <span class="help-text"><%= t("admin.legislation.processes.form.summary_phase_description") %></span>
+    </legend>
+
     <div class="small-12 medium-3 column end">
       <%= f.date_field :summary_publication_date, id: "summary_publication_date" %>
     </div>
@@ -98,24 +132,7 @@
       <%= f.check_box :summary_publication_enabled, checked: @process.summary_publication.enabled?, label: t("admin.legislation.processes.form.enabled") %>
     </div>
   </fieldset>
-
-  <fieldset>
-    <div class="small-12 medium-3 column end">
-      <%= f.date_field :draft_publication_date, id: "draft_publication_date" %>
-    </div>
-    <div class="small-12 medium-2 column margin-top">
-      <%= f.check_box :draft_publication_enabled, checked: @process.draft_publication.enabled?, label: t("admin.legislation.processes.form.enabled") %>
-    </div>
-  </fieldset>
-
-  <fieldset>
-    <div class="small-12 medium-3 column end">
-      <%= f.date_field :result_publication_date, id: "result_publication_date" %>
-    </div>
-    <div class="small-12 medium-2 column margin-top">
-      <%= f.check_box :result_publication_enabled, checked: @process.result_publication.enabled?, label: t("admin.legislation.processes.form.enabled") %>
-    </div>
-  </fieldset>
+  </div>
 
   <div class="row">
     <div class="small-12 column">

--- a/app/views/admin/legislation/processes/_form.html.erb
+++ b/app/views/admin/legislation/processes/_form.html.erb
@@ -92,6 +92,15 @@
 
   <fieldset>
     <div class="small-12 medium-3 column end">
+      <%= f.date_field :summary_publication_date, id: "summary_publication_date" %>
+    </div>
+    <div class="small-12 medium-2 column margin-top">
+      <%= f.check_box :summary_publication_enabled, checked: @process.summary_publication.enabled?, label: t("admin.legislation.processes.form.enabled") %>
+    </div>
+  </fieldset>
+
+  <fieldset>
+    <div class="small-12 medium-3 column end">
       <%= f.date_field :draft_publication_date, id: "draft_publication_date" %>
     </div>
     <div class="small-12 medium-2 column margin-top">

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -589,6 +589,12 @@ en:
           draft_phase_description: If this phase is active, the process won't be listed on processes index. Allow to preview the process and create content before the start.
           allegations_phase: Comments phase
           proposals_phase: Proposals phase
+          summary_phase: Summary Phase
+          summary_phase_description: This phase will show a summary of proposals which have been selected and the best comments from the most recent draft.
+          draft_publication: Draft Publication
+          draft_publication_description: In draft state, registered users can comment on your document
+          final_publication_description: This publishes your final version of the legislation or outcome of this process. Users cannot comment on this version. 
+          final_publication: Final Result Publication
           use_markdown: Use Markdown to format the text
           homepage_description: Here you can explain the content of the process
           banner_title: Header colors

--- a/db/migrate/20231212153823_add_summary_publication_fields_to_legislation_processes.rb
+++ b/db/migrate/20231212153823_add_summary_publication_fields_to_legislation_processes.rb
@@ -1,0 +1,6 @@
+class AddSummaryPublicationFieldsToLegislationProcesses < ActiveRecord::Migration[6.1]
+  def change
+    add_column :legislation_processes, :summary_publication_date, :date
+    add_column :legislation_processes, :summary_publication_enabled, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_10_12_141318) do
+ActiveRecord::Schema.define(version: 2023_12_12_153823) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
@@ -790,6 +790,8 @@ ActiveRecord::Schema.define(version: 2023_10_12_141318) do
     t.text "background_color"
     t.text "font_color"
     t.tsvector "tsv"
+    t.date "summary_publication_date"
+    t.boolean "summary_publication_enabled"
     t.index ["allegations_end_date"], name: "index_legislation_processes_on_allegations_end_date"
     t.index ["allegations_start_date"], name: "index_legislation_processes_on_allegations_start_date"
     t.index ["debate_end_date"], name: "index_legislation_processes_on_debate_end_date"

--- a/spec/system/legislation/summary_spec.rb
+++ b/spec/system/legislation/summary_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
-describe "Legislation" do
+describe "Legislation" do 
+  let(:admin_user) { create(:user, :admin) }
+
   context "process summary page" do
     scenario "summary tab is not shown for open processes" do
       process = create(:legislation_process, :open)
@@ -10,12 +12,22 @@ describe "Legislation" do
       expect(page).not_to have_content "Summary"
     end
 
-    scenario "summary tab is shown por past processes" do
-      process = create(:legislation_process, :past)
+    scenario "summary tab is shown for processes with enabled summary and past date" do
+      process = create(:legislation_process,
+                       summary_publication_enabled: true,
+                       summary_publication_date: Date.current - 1.day)
 
       visit legislation_process_path(process)
 
       expect(page).to have_content "Summary"
+    end
+
+    scenario "summary tab is not shown for processes with disabled summary" do
+      process = create(:legislation_process, summary_publication_enabled: false)
+
+      visit legislation_process_path(process)
+
+      expect(page).not_to have_content "Summary"
     end
   end
 


### PR DESCRIPTION
## User Story
The Legislation Summary contains useful information for Administrators.  One of the biggest complaints I receive from my users is about being able to view/download/summarise comments as there is often a statutory obligation on the city to review and publish comments in other places.

When carrying out a legislation process there is often a long time period between the phases which means at the moment that the Admin doesn't get to see the summary until the process is complete which can be many months after a phase is carried out.

Because the information is useful to Admins, there is no reason why an Admin shouldn't see it all of the time, therefore I propose to make the Summary visible to Admins all the time in the same way as all of the other phases (debate, proposals etc) are visible all of the time.

It is also possible that this information may be useful to citizens as part of the legislation process as it provides an overview of the previous phases, so can give a sense of what has already happened without having to read all of the previous comments/proposals etc

I am suggesting that this should be an option for the Admin to switch on/off/publish as this makes it consistent with the way other phases behave in Legislation

## Objectives

The Legislation Summary is a useful overview for admins. This change makes the Legislation Summary tab visible to admins at all times.
At the moment the summary is only published when the process is finished.
A configuration item is added to allow the admin to publish the summary on a chosen date

This pull request also tidies up the layout of the Legislation configuration page by enclosing the configuration items in a row and adding labels and descriptions to some options

## Visual Changes

## original layout
![image](https://github.com/consuldemocracy/consuldemocracy/assets/102246590/c59e8dcb-aa47-43db-846e-cc5a48d3fb29)
## revised layout
![image](https://github.com/consuldemocracy/consuldemocracy/assets/102246590/9de4eb0d-5a8b-412f-912d-bfc0d6473faf)

## new alignment and options
![image](https://github.com/consuldemocracy/consuldemocracy/assets/102246590/3aa2f342-513c-4b56-8707-b362826a3929)
 
## Summary displayed in advance of final publication
![image](https://github.com/consuldemocracy/consuldemocracy/assets/102246590/95479ce9-8b6a-485c-853c-3da287a03ff4)


## Notes

This adds a db migration to add fields for summary_publication_date and summary_publication_enabled