### PR TITLE
Allow whitespace between square brackets in GeoJSON polygons

### DIFF
--- a/app/models/geozone.rb
+++ b/app/models/geozone.rb
@@ -28,9 +28,10 @@ class Geozone < ApplicationRecord
 
     def normalized_coordinates
       if geojson.present?
-        if geojson.match(/"coordinates"\s*:\s*\[{4}/)
+        if geojson.match(/"coordinates"\s*:\s*\[\s*\[\s*\[\s*\[/)
           coordinates.reduce([], :concat).reduce([], :concat)
-        elsif geojson.match(/"coordinates"\s*:\s*\[{3}/)
+         elsif geojson.match(/"coordinates"\s*:\s*\[\s*\[\s*\[/)
+  
           coordinates.reduce([], :concat)
         else
           coordinates
@@ -39,7 +40,7 @@ class Geozone < ApplicationRecord
         []
       end
     end
-
+    
     def coordinates
       JSON.parse(geojson)["geometry"]["coordinates"]
     end

--- a/app/models/geozone.rb
+++ b/app/models/geozone.rb
@@ -30,8 +30,7 @@ class Geozone < ApplicationRecord
       if geojson.present?
         if geojson.match(/"coordinates"\s*:\s*\[\s*\[\s*\[\s*\[/)
           coordinates.reduce([], :concat).reduce([], :concat)
-         elsif geojson.match(/"coordinates"\s*:\s*\[\s*\[\s*\[/)
-  
+        elsif geojson.match(/"coordinates"\s*:\s*\[\s*\[\s*\[/)
           coordinates.reduce([], :concat)
         else
           coordinates
@@ -40,7 +39,7 @@ class Geozone < ApplicationRecord
         []
       end
     end
-    
+
     def coordinates
       JSON.parse(geojson)["geometry"]["coordinates"]
     end

--- a/spec/models/geozone_spec.rb
+++ b/spec/models/geozone_spec.rb
@@ -76,5 +76,77 @@ describe Geozone do
          [-3.9247799675785, 40.8789131852224]]
       )
     end
+
+    it "handles coordinates with three-dimensional arrays" do
+      geozone = build(:geozone, geojson: '{
+        "geometry": {
+          "type": "Polygon",
+          "coordinates": [[[40.8792937308316, -3.9259027239257],
+            [40.8788966596619, -3.9249047078766],
+            [40.8789131852224, -3.9247799675785]]]
+        }
+      }')
+
+      expect(geozone.outline_points).to eq(
+        [[-3.9259027239257, 40.8792937308316],
+         [-3.9249047078766, 40.8788966596619],
+         [-3.9247799675785, 40.8789131852224]]
+      )
+    end
+
+    it "handles coordinates with three-dimensional arrays with spaces between brackets" do
+      geozone = build(:geozone, geojson: '{
+        "geometry": {
+          "type": "Polygon",
+          "coordinates": [[
+            [40.8792937308316, -3.9259027239257],
+            [40.8788966596619, -3.9249047078766],
+            [40.8789131852224, -3.9247799675785]
+          ]]
+        }
+      }')
+
+      expect(geozone.outline_points).to eq(
+        [[-3.9259027239257, 40.8792937308316],
+         [-3.9249047078766, 40.8788966596619],
+         [-3.9247799675785, 40.8789131852224]]
+      )
+    end
+
+    it "handles coordinates with four-dimensional arrays" do
+      geozone = build(:geozone, geojson: '{
+        "geometry": {
+          "type": "Polygon",
+          "coordinates": [[[[40.8792937308316, -3.9259027239257],
+            [40.8788966596619, -3.9249047078766],
+            [40.8789131852224, -3.9247799675785]]]]
+        }
+      }')
+
+      expect(geozone.outline_points).to eq(
+        [[-3.9259027239257, 40.8792937308316],
+         [-3.9249047078766, 40.8788966596619],
+         [-3.9247799675785, 40.8789131852224]]
+      )
+    end
+
+    it "handles coordinates with four-dimensional arrays with spaces between brackets" do
+      geozone = build(:geozone, geojson: '{
+        "geometry": {
+          "type": "Polygon",
+          "coordinates": [[[
+            [40.8792937308316, -3.9259027239257],
+            [40.8788966596619, -3.9249047078766],
+            [40.8789131852224, -3.9247799675785]
+          ]]]
+        }
+      }')
+
+      expect(geozone.outline_points).to eq(
+        [[-3.9259027239257, 40.8792937308316],
+         [-3.9249047078766, 40.8788966596619],
+         [-3.9247799675785, 40.8789131852224]]
+      )
+    end
   end
 end


### PR DESCRIPTION
Refactor regex in normalized_coordinates method to allow for whitespace between square brackets

## References

Closes #5388 

