### PR TITLE
Geozone Admin maps

### DIFF
--- a/app/components/admin/geozones/index_component.html.erb
+++ b/app/components/admin/geozones/index_component.html.erb
@@ -29,5 +29,8 @@
     <% end %>
   </tbody>
 </table>
-
+<div class="small-12 column">
+  <h2><%= t("admin.geozones.index.geojson_map") %></h2>
+  <p class="help-text">  <%= t("admin.geozones.index.geojson_map_help") %></p>
+</div>
 <%= render Shared::MapLocationComponent.new(nil, geozones_data: geozones_data) %>

--- a/app/components/admin/geozones/index_component.html.erb
+++ b/app/components/admin/geozones/index_component.html.erb
@@ -29,3 +29,6 @@
     <% end %>
   </tbody>
 </table>
+<div class="budgets-map">
+  <%= render Shared::MapLocationComponent.new(nil, investments_coordinates: nil, geozones_data: nil) %>
+</div>

--- a/app/components/admin/geozones/index_component.html.erb
+++ b/app/components/admin/geozones/index_component.html.erb
@@ -29,8 +29,10 @@
     <% end %>
   </tbody>
 </table>
-<div class="small-12 column">
-  <h2><%= t("admin.geozones.index.geojson_map") %></h2>
-  <p class="help-text">  <%= t("admin.geozones.index.geojson_map_help") %></p>
-</div>
-<%= render Shared::MapLocationComponent.new(nil, geozones_data: geozones_data) %>
+
+<section>
+  <h3><%= t("admin.geozones.index.geojson_map") %></h3>
+  <p class="help-text"><%= t("admin.geozones.index.geojson_map_help") %></p>
+
+  <%= render Shared::MapLocationComponent.new(nil, geozones_data: geozones_data) %>
+</section>

--- a/app/components/admin/geozones/index_component.html.erb
+++ b/app/components/admin/geozones/index_component.html.erb
@@ -30,5 +30,5 @@
   </tbody>
 </table>
 <div class="budgets-map">
-  <%= render Shared::MapLocationComponent.new(nil, investments_coordinates: nil, geozones_data: nil) %>
+  <%= render Shared::MapLocationComponent.new(nil, investments_coordinates: nil, geozones_data: geozones_data) %>
 </div>

--- a/app/components/admin/geozones/index_component.html.erb
+++ b/app/components/admin/geozones/index_component.html.erb
@@ -29,6 +29,5 @@
     <% end %>
   </tbody>
 </table>
-<div class="budgets-map">
-  <%= render Shared::MapLocationComponent.new(nil, investments_coordinates: nil, geozones_data: geozones_data) %>
-</div>
+
+<%= render Shared::MapLocationComponent.new(nil, geozones_data: geozones_data) %>

--- a/app/components/admin/geozones/index_component.rb
+++ b/app/components/admin/geozones/index_component.rb
@@ -22,8 +22,12 @@ class Admin::Geozones::IndexComponent < ApplicationComponent
     def geozones_data
        geozones.map do |geozone|
         {
+         
           outline_points: geozone.outline_points,
           color: geozone.color,
+          headings: geozones.where(id: geozone).map do | geozone|
+             link_to(geozone.name, edit_admin_geozone_path(geozone.id))
+          end
         }
        end
     end

--- a/app/components/admin/geozones/index_component.rb
+++ b/app/components/admin/geozones/index_component.rb
@@ -19,4 +19,13 @@ class Admin::Geozones::IndexComponent < ApplicationComponent
         t("shared.no")
       end
     end
+    def geozones_data
+       geozones.map do |geozone|
+        {
+          outline_points: geozone.outline_points,
+          color: geozone.color,
+        }
+       end
+    end
+
 end

--- a/app/components/admin/geozones/index_component.rb
+++ b/app/components/admin/geozones/index_component.rb
@@ -19,17 +19,14 @@ class Admin::Geozones::IndexComponent < ApplicationComponent
         t("shared.no")
       end
     end
+
     def geozones_data
-       geozones.map do |geozone|
+      geozones.map do |geozone|
         {
-         
           outline_points: geozone.outline_points,
           color: geozone.color,
-          headings: geozones.where(id: geozone).map do | geozone|
-             link_to(geozone.name, edit_admin_geozone_path(geozone.id))
-          end
+          headings: [link_to(geozone.name, edit_admin_geozone_path(geozone))]
         }
-       end
+      end
     end
-
 end

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -1400,6 +1400,8 @@ en:
       index:
         title: Geozone
         create: Create geozone
+        geojson_map: GeoJSON Map
+        geojson_map_help: "If GeoJSON coordinates are available they will be displayed on the map below"
       geozone:
         name: Name
         external_code: External code

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -1400,6 +1400,8 @@ es:
       index:
         title: Zonas
         create: Crear una zona
+        geojson_map: Mapa GeoJSON
+        geojson_map_help: "Si las coordenadas GeoJSON están disponibles, aparecerán en el siguiente mapa"
       geozone:
         name: Nombre
         external_code: Código externo

--- a/spec/system/admin/geozones_spec.rb
+++ b/spec/system/admin/geozones_spec.rb
@@ -143,24 +143,12 @@ describe "Admin geozones", :admin do
     end
   end
 
-
   scenario "Show polygons on geozone admin view" do
     Setting["feature.map"] = true
-
     geojson = '{ "geometry": { "type": "Polygon", "coordinates": [[-0.1,51.5],[-0.2,51.4],[-0.3,51.6]] } }'
-    geozone = create(:geozone, name: "Polygon me!")
-
-    visit edit_admin_geozone_path(geozone)
-    fill_in "GeoJSON data (optional)", with: geojson
-    fill_in "Color (optional)", with: "#f5c211"
-    click_button "Save changes"
-
-    expect(page).to have_content "Geozone updated successfully"
+    geozone = create(:geozone, name: "Polygon me!", geojson: geojson)
 
     visit admin_geozones_path
-
-    expect(page).to have_css ".map-polygon[fill='#f5c211']"
-    within(".map-location") { expect(page).not_to have_link "Area 51" }
 
     find(".map-polygon").click
 
@@ -168,6 +156,4 @@ describe "Admin geozones", :admin do
       expect(page).to have_link "Polygon me!", href: edit_admin_geozone_path(geozone)
     end
   end
-
-
 end

--- a/spec/system/admin/geozones_spec.rb
+++ b/spec/system/admin/geozones_spec.rb
@@ -142,4 +142,32 @@ describe "Admin geozones", :admin do
       expect(page).to have_link "Area 51", href: budget_investments_path(budget, heading_id: heading.id)
     end
   end
+
+
+  scenario "Show polygons on geozone admin view" do
+    Setting["feature.map"] = true
+
+    geojson = '{ "geometry": { "type": "Polygon", "coordinates": [[-0.1,51.5],[-0.2,51.4],[-0.3,51.6]] } }'
+    geozone = create(:geozone, name: "Polygon me!")
+
+    visit edit_admin_geozone_path(geozone)
+    fill_in "GeoJSON data (optional)", with: geojson
+    fill_in "Color (optional)", with: "#f5c211"
+    click_button "Save changes"
+
+    expect(page).to have_content "Geozone updated successfully"
+
+    visit admin_geozones_path
+
+    expect(page).to have_css ".map-polygon[fill='#f5c211']"
+    within(".map-location") { expect(page).not_to have_link "Area 51" }
+
+    find(".map-polygon").click
+
+    within ".map-location" do
+      expect(page).to have_link "Polygon me!", href: edit_admin_geozone_path(geozone)
+    end
+  end
+
+
 end


### PR DESCRIPTION


## Objectives

This pull request renders a map and geojson geozones on the Geozones admin page making it easier to see if Geojson has been imported correctly

## Visual Changes

The map is appended to the bottom of the Geozone admin page.  Clicking on the location link opens the geozone edit page

![image](https://github.com/consuldemocracy/consuldemocracy/assets/102246590/e984f141-14e3-426d-aa58-343e9dfc91ad)

