### PR TITLE
Update Code Climate Rubocop version

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,7 +1,7 @@
 engines:
   rubocop:
     enabled: true
-    channel: rubocop-1-31-0
+    channel: rubocop-1-56-3
   duplication:
     enabled: true
     config:


### PR DESCRIPTION
## References

* We started using rubocop gems that aren't compatible with our current Code Climate setup in pull request #5241
* The fact that these changes fix the issue was confirmed by [Code Climate build 2936](https://codeclimate.com/github/consuldemocracy/consuldemocracy/builds/2936)
* [List of available Rubocop version in Code Climate](https://github.com/codeclimate/codeclimate-rubocop/branches/all?utf8=%E2%9C%93&query=channel%2Frubocop)

## Background

Code Climate was failing to analyze our code because their rubocop 1.31 doesn't support rubocop-capybara.

## Objectives

* Make Code Climate generate reports for our code once again