### PR TITLE
Add rubocop rules affecting Rails 6.1

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -510,6 +510,9 @@ Rails/Validation:
 Rails/WhereEquals:
   Enabled: true
 
+Rails/WhereMissing:
+  Enabled: true
+
 Rails/WhereNot:
   Enabled: true
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -377,6 +377,9 @@ Rails/CreateTableWithTimestamps:
 Rails/Date:
   Enabled: true
 
+Rails/DeprecatedActiveModelErrorsMethods: # TODO: Remove after upgrading to Rails 7
+  Enabled: true
+
 Rails/DurationArithmetic:
   Enabled: true
 

--- a/app/models/concerns/sdg/relatable.rb
+++ b/app/models/concerns/sdg/relatable.rb
@@ -44,7 +44,7 @@ module SDG::Relatable
     end
 
     def pending_sdg_review
-      left_joins(:sdg_review).merge(SDG::Review.where(id: nil))
+      where.missing(:sdg_review)
     end
   end
 

--- a/app/models/poll/question/answer.rb
+++ b/app/models/poll/question/answer.rb
@@ -17,9 +17,9 @@ class Poll::Question::Answer < ApplicationRecord
   scope :with_content, -> { where.not(id: without_content) }
   scope :without_content, -> do
     where(description: "")
-      .left_joins(:images).where(images: { id: nil })
-      .left_joins(:documents).where(documents: { id: nil })
-      .left_joins(:videos).where(poll_question_answer_videos: { id: nil })
+      .where.missing(:images)
+      .where.missing(:documents)
+      .where.missing(:videos)
   end
 
   def self.order_answers(ordered_array)


### PR DESCRIPTION
## References

* We upgraded to Rails 6.1 in pull request #5151

## Objectives

* Make sure we don't accidentally re-introduce deprecated code regarding error messages
* Simplify code to find records without associations