### PR TITLE
Replace rails-assets.org with Node.js packages

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -64,10 +64,6 @@ gem "whenever", "~> 1.0.0", require: false
 gem "wicked_pdf", "~> 2.8.0"
 gem "wkhtmltopdf-binary", "~> 0.12.6"
 
-source "https://rails-assets.org" do
-  gem "rails-assets-markdown-it", "~> 9.0.1"
-end
-
 group :development, :test do
   gem "bullet", "~> 7.1.6"
   gem "byebug", "~> 11.1.3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,4 @@
 GEM
-  remote: https://rails-assets.org/
-  specs:
-    rails-assets-markdown-it (9.0.1)
-
-GEM
   remote: https://rubygems.org/
   specs:
     Ascii85 (1.1.0)
@@ -770,7 +765,6 @@ DEPENDENCIES
   pronto-scss (~> 0.11.0)
   puma (~> 5.6.8)
   rails (= 6.1.7.7)
-  rails-assets-markdown-it (~> 9.0.1)!
   recipient_interceptor (~> 0.3.1)
   redcarpet (~> 3.6.0)
   responders (~> 3.1.1)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -86,7 +86,7 @@
 //= require banners
 //= require social_share
 //= require checkbox_toggle
-//= require markdown-it
+//= require markdown-it/dist/markdown-it
 //= require markdown_editor
 //= require html_editor
 //= require cocoon

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,22 @@
         "jquery-ui": "^1.13.2",
         "jquery-ujs": "^1.2.3",
         "leaflet": "^1.9.4",
-        "leaflet.markercluster": "^1.5.3"
+        "leaflet.markercluster": "^1.5.3",
+        "markdown-it": "^9.0.1"
       }
+    },
+    "node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/entities": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
+      "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w=="
     },
     "node_modules/jquery": {
       "version": "3.7.1",
@@ -46,6 +60,44 @@
       "peerDependencies": {
         "leaflet": "^1.3.1"
       }
+    },
+    "node_modules/linkify-it": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-2.2.0.tgz",
+      "integrity": "sha512-GnAl/knGn+i1U/wjBz3akz2stz+HrHLsxMwHQGofCDfPvlf+gDKN58UtfmUquTY4/MXeE2x7k19KQmeoZi94Iw==",
+      "dependencies": {
+        "uc.micro": "^1.0.1"
+      }
+    },
+    "node_modules/markdown-it": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-9.0.1.tgz",
+      "integrity": "sha512-XC9dMBHg28Xi7y5dPuLjM61upIGPJG8AiHNHYqIaXER2KNnn7eKnM5/sF0ImNnyoV224Ogn9b1Pck8VH4k0bxw==",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "entities": "~1.1.1",
+        "linkify-it": "^2.0.0",
+        "mdurl": "^1.0.1",
+        "uc.micro": "^1.0.5"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.js"
+      }
+    },
+    "node_modules/mdurl": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
+      "integrity": "sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g=="
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
+    },
+    "node_modules/uc.micro": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
+      "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "jquery-ui": "^1.13.2",
     "jquery-ujs": "^1.2.3",
     "leaflet": "^1.9.4",
-    "leaflet.markercluster": "^1.5.3"
+    "leaflet.markercluster": "^1.5.3",
+    "markdown-it": "^9.0.1"
   }
 }


### PR DESCRIPTION
## References

* We started using Node.js packages in pull request #5159

## Objectives

* Make it easier to update assets like markdown-it
* Avoid having to connect to rails-assets.org (which hasn't always been reliable in the past) to install dependencies