### PR TITLE
Add Part Funding as an option for winners

### DIFF
--- a/app/components/admin/budgets/form_component.html.erb
+++ b/app/components/admin/budgets/form_component.html.erb
@@ -47,6 +47,15 @@
       </div>
     </div>
 
+    <div class="row expanded">
+      <div class="small-12 column">
+        <p class="form-label"><%= t("admin.budgets.edit.part_fund") %></p>
+        <p class="help-text"><%= t("admin.budgets.edit.part_fund_help_text") %></p>
+        <%= f.check_box :part_fund %>
+      </div>
+    </div>
+
+
     <% unless wizard? %>
       <div class="small-12 medium-6 column">
         <%= f.select :phase, phases_select_options %>

--- a/app/controllers/admin/budgets_controller.rb
+++ b/app/controllers/admin/budgets_controller.rb
@@ -66,6 +66,7 @@ class Admin::BudgetsController < Admin::BaseController
         :currency_symbol,
         :voting_style,
         :hide_money,
+        :part_fund,
         administrator_ids: [],
         valuator_ids: [],
         image_attributes: image_attributes

--- a/app/models/budget/result.rb
+++ b/app/models/budget/result.rb
@@ -24,7 +24,8 @@ class Budget
     end
 
     def inside_budget?
-      available_budget >= @current_investment.price
+#      available_budget >= @current_investment.price
+       available_budget > @current_investment.price || (available_budget > 0 && @budget.part_fund)
     end
 
     def available_budget
@@ -44,7 +45,13 @@ class Budget
     end
 
     def set_winner
-      @money_spent += @current_investment.price
+#      @money_spent += @current_investment.price
+#      @current_investment.update!(winner: true)
+      if @budget.part_fund
+        @money_spent += [@current_investment.price, available_budget].min
+      else
+        @money_spent += @current_investment.price
+      end
       @current_investment.update!(winner: true)
     end
 

--- a/app/views/budgets/results/_results_table.html.erb
+++ b/app/views/budgets/results/_results_table.html.erb
@@ -34,12 +34,12 @@
               class="budget-investments <%= investment.winner? ? "success" : "js-discarded" %>"
               style="<%= investment.winner? ? "" : "display: none" %>">
             <td>
-              <% if investment.winner? %>
-                <span class="icon-check">
-                  <span class="show-for-sr">
-                    <%= t("budgets.results.accepted") %>
-                  </span>
-                </span>
+            <% if investment.winner? %>
+               <span class="icon-check" style="color: <%= @budget.part_fund && investment.winner && amount_available - investment.price < 0 ? 'orange' : '' %>">
+                 <span class="show-for-sr">
+                   <%= t("budgets.results.accepted") %>
+                 </span>
+               </span>
               <% else %>
                 <span class="icon-x delete">
                   <span class="show-for-sr">
@@ -53,17 +53,27 @@
               <%= investment.ballot_lines_count %>
             </td>
             <% if @budget.show_money? %>
-              <td class="text-center">
-                <%= @budget.formatted_amount(investment.price) %>
-              </td>
-              <% if results_type == :compatible %>
-                <td class="small text-right"
-                    title="<%= @budget.formatted_amount(amount_available) %> - <%= @budget.formatted_amount(investment.price) %>">
-                    <%= @budget.formatted_amount(amount_available - investment.price) %>
-                    <% amount_available -= investment.price if investment.winner? %>
+  	    <td class="text-center" >
+    	      <% if @budget.part_fund && investment.winner && amount_available - investment.price < 0 %>
+       	      <%= @budget.formatted_amount(investment.price) %>(Part Fund)
+	    <% else %>
+  	      <%= @budget.formatted_amount(investment.price) %>
+	    <% end %>
+            </td>
+            <% if results_type == :compatible %>
+              <% if @budget.part_fund && investment.winner && amount_available - investment.price < 0 %>
+                <% amount_after_investment = amount_available - investment.price %>
+                <td class="small text-right" title="<%= @budget.formatted_amount(amount_available) %> - <%= @budget.formatted_amount(investment.price) %>">
+                  <%= @budget.formatted_amount(amount_after_investment) %>
+                </td>
+              <% else %>
+                <td class="small text-right" title="<%= @budget.formatted_amount(amount_available) %> - <%= @budget.formatted_amount(investment.price) %> ">
+                  <%= @budget.formatted_amount(amount_available - investment.price) %>
+                  <% amount_available -= investment.price if investment.winner? %>
                 </td>
               <% end %>
             <% end %>
+           <% end %>
         </tr>
       <% end %>
     </tbody>

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -143,6 +143,8 @@ en:
           staff_settings: "Administrators and Valuators assigned to the budget"
         hide_money: "Hide money"
         hide_money_help_text: "If this option is checked, all fields showing the amount of money will be hidden throughout the process."
+        part_fund: "Part Fund Winners"
+        part_fund_help_text: "If this option is checked, if there is insufficient budget left, the next most voted for investment will be offered part funding"
       destroy:
         success_notice: Budget deleted successfully
         unable_notice: You cannot delete a budget that has associated investments

--- a/db/migrate/20240304153958_add_part_fund_to_budgets.rb
+++ b/db/migrate/20240304153958_add_part_fund_to_budgets.rb
@@ -1,0 +1,5 @@
+class AddPartFundToBudgets < ActiveRecord::Migration[6.1]
+  def change
+    add_column :budgets, :part_fund, :boolean
+  end
+end


### PR DESCRIPTION

## Objectives

The default behaviour of calculating winning investments makes an investment a winner if it is the next most popular affordable price even if there are investments which have more votes but are unaffordable.

In our PB processes our cities have wanted to offer partial funding to the next most popular investment as they consider this more democratic

This pull request creates an option within the budget which allows Part Funding of an investment if there is insufficient budget available.

**_This is still a work in progress but making the pull request  to check if Allow edits by maintainers works_**

There is no change to the default method of calculating winners

## Visual Changes

A checkbox is added to the Edit Budget view
Winning Investments which are partially funded are given an Orange Check instead of Green
**Admin**
![Admin](https://github.com/consuldemocracy/consuldemocracy/assets/102246590/595c5a94-e9c2-494b-b79a-762984cc2d81)

**Before**
![Before](https://github.com/consuldemocracy/consuldemocracy/assets/102246590/46729490-42c4-4b6f-83b9-76122a3ee7da)

**After**
![After](https://github.com/consuldemocracy/consuldemocracy/assets/102246590/545f5eb0-788d-4417-bb68-23bcac29c0dd)
