### PR TITLE
Sanitize the output of a dummy component class

### DIFF
--- a/spec/components/application_component_spec.rb
+++ b/spec/components/application_component_spec.rb
@@ -6,7 +6,7 @@ describe ApplicationComponent do
 
     component_class = Class.new(ApplicationComponent) do
       def call
-        t("shared.yes")
+        sanitize(t("shared.yes"))
       end
 
       def self.name


### PR DESCRIPTION
## References

* Continues pull request #5399
* The warning was introduced in https://github.com/ViewComponent/view_component/pull/1950

## Objectives

* Remove a warning so we don't get unnecessary distractions while running our test suite

## Notes

While this change doesn't affect the application (this class is only used in a test), we avoid a warning we were getting when running our test suite:

```
WARNING: The #<Class:0x00007958c06fb8e0> component rendered HTML-unsafe
output. The output will be automatically escaped, but you may want to
investigate.
```

So we're sanitizing the output to avoid this warning.