### PR TITLE
Bump foundation-sites from 6.6.2 to 6.7.5

### DIFF
--- a/app/assets/stylesheets/_consul_settings.scss
+++ b/app/assets/stylesheets/_consul_settings.scss
@@ -6,7 +6,6 @@
 //  1. Foundation settings overrides
 //  2. CONSUL DEMOCRACY variables
 //  3. Foundation overrides depending on CONSUL DEMOCRACY variables
-//  4. Foundation fixes
 
 // 1. Foundation settings overrides
 // ---------------------------------
@@ -164,14 +163,3 @@ $tab-item-padding: $line-height * 0.5  0 !default;
 $tab-content-border: $border !default;
 
 $tooltip-background-color: $brand !default;
-
-// 4. Foundation fixes
-// -------------------
-
-$alert-color: null !default;
-$primary-color: null !default;
-$secondary-color: null !default;
-$success-color: null !default;
-$warning-color: null !default;
-$-zf-bp-value: null !default;
-$-zf-size: null !default;

--- a/app/assets/stylesheets/functions/pow.scss
+++ b/app/assets/stylesheets/functions/pow.scss
@@ -1,0 +1,5 @@
+@use "sass:math";
+
+@function pow($base, $exponent, $prec: 16) {
+  @return math.pow($base, $exponent);
+}

--- a/app/views/proposals/_support_status.html.erb
+++ b/app/views/proposals/_support_status.html.erb
@@ -8,7 +8,7 @@
          data-sticky
          data-stick-to="bottom"
          data-sticky-on="small"
-         data-top-anchor="0"
+         data-top-anchor="1"
          data-btm-anchor="sticky_stop"
          data-check-every="0">
       <div class="fixed-mobile-content">

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,14 +7,13 @@
       "name": "consuldemocracy",
       "dependencies": {
         "blueimp-file-upload": "^9.34.0",
-        "foundation-sites": "^6.6.2",
+        "foundation-sites": "^6.7.5",
         "jquery": "^3.7.1",
         "jquery-ui": "^1.13.2",
         "jquery-ujs": "^1.2.3",
         "leaflet": "^1.9.4",
         "leaflet.markercluster": "^1.5.3",
-        "markdown-it": "^12.3.2",
-        "motion-ui": "^2.0.3"
+        "markdown-it": "^12.3.2"
       },
       "devDependencies": {
         "@stylistic/stylelint-plugin": "^2.1.0",
@@ -584,16 +583,16 @@
       "dev": true
     },
     "node_modules/foundation-sites": {
-      "version": "6.6.2",
-      "resolved": "https://registry.npmjs.org/foundation-sites/-/foundation-sites-6.6.2.tgz",
-      "integrity": "sha512-fGdJVYodUxUCbdNDuNTXFIpEWAD+9yl0uLkkX8/rRHmK8/EYqQnRAGnmPADDhMKLZ+fJuSGheEcnSM2imgk3Wg==",
+      "version": "6.7.5",
+      "resolved": "https://registry.npmjs.org/foundation-sites/-/foundation-sites-6.7.5.tgz",
+      "integrity": "sha512-MEjAENdF/IV2XQvlQmg20o+iDTyyWu0N/j440e8fKbEylbKxARzgg5S7vcnxtjukC1Lqg+rRm7ZDSSyGhVVoUQ==",
       "engines": {
-        "node": ">=8.4.0",
-        "npm": ">=2.14.2"
+        "node": ">=12.0"
       },
       "peerDependencies": {
-        "jquery": ">=2.2.0",
-        "what-input": ">=4.1.0"
+        "jquery": ">=3.6.0",
+        "motion-ui": "latest",
+        "what-input": ">=5.2.10"
       }
     },
     "node_modules/glob-parent": {
@@ -975,11 +974,12 @@
       }
     },
     "node_modules/motion-ui": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/motion-ui/-/motion-ui-2.0.3.tgz",
-      "integrity": "sha512-f9xzh/hbZTUYjk4M7y1aDcsiPTfqUbuvCv/+If05TSIBEJMu3hGBU+YSe9csQPP7WBBHXxjossEygM/TJo2enw==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/motion-ui/-/motion-ui-2.0.5.tgz",
+      "integrity": "sha512-MJs4dS7/bSnJ92X5IB4bTIif6SwqwEDbX1F/eiUGSzIVhVTl4UqD8xr8ygg01dXZrpPrDjjUNoVkB8vT+PaY/g==",
+      "peer": true,
       "peerDependencies": {
-        "jquery": ">=2.2.0"
+        "jquery": ">=3.6.0"
       }
     },
     "node_modules/ms": {

--- a/package.json
+++ b/package.json
@@ -2,14 +2,13 @@
   "name": "consuldemocracy",
   "dependencies": {
     "blueimp-file-upload": "^9.34.0",
-    "foundation-sites": "^6.6.2",
+    "foundation-sites": "^6.7.5",
     "jquery": "^3.7.1",
     "jquery-ui": "^1.13.2",
     "jquery-ujs": "^1.2.3",
     "leaflet": "^1.9.4",
     "leaflet.markercluster": "^1.5.3",
-    "markdown-it": "^12.3.2",
-    "motion-ui": "^2.0.3"
+    "markdown-it": "^12.3.2"
   },
   "devDependencies": {
     "@stylistic/stylelint-plugin": "^2.1.0",


### PR DESCRIPTION
## References

* Depends on #5446 and #5477
* This will remove a warning we're getting when upgrading autoprefixer-rails (pull request #5346)
* The performance issue we ran into when updating Foundation is mentioned in foundation/foundation-sites#12592

## Notes

Since compiling Foundation now takes more than 3 minutes (on my machine) when using Libsass, we're moving to Dart Sass, so this pull request depends on pull request #5477.