### PR TITLE
Fix font-awesome icons in Internet Explorer 11

### DIFF
--- a/app/assets/stylesheets/in_favor_against.scss
+++ b/app/assets/stylesheets/in_favor_against.scss
@@ -50,15 +50,20 @@
       cursor: pointer;
 
       &[aria-pressed=false]:hover,
-      &[aria-pressed=false]:active,
-      &[aria-pressed=true]:not(:hover, :active) {
+      &[aria-pressed=false]:active {
         @include has-fa-icon($icon, solid);
       }
 
       &[aria-pressed=true] {
+        @include has-fa-icon($icon, solid);
         background: $pressed-color;
         border-color: $pressed-color;
         color: #fff;
+
+        &:hover,
+        &:active {
+          @include has-fa-icon($icon, regular);
+        }
       }
     }
   }


### PR DESCRIPTION
## References

* This issue was introduced in commit 3482e6e05 from pull request #5278

## Objectives

* Correctly display the icons for as many people as possible