### PR TITLE
Change the order in which PB Ballot votes are displayed 

### DIFF
--- a/app/components/budgets/ballot/ballot_component.html.erb
+++ b/app/components/budgets/ballot/ballot_component.html.erb
@@ -36,9 +36,7 @@
         <% end %>
 
         <ul class="ballot-list">
-          <%= render Budgets::Ballot::InvestmentComponent.with_collection(
-            ballot.investments.by_group(group.id)
-          ) %>
+          <%= render Budgets::Ballot::InvestmentComponent.with_collection(group_investments(group)) %>
         </ul>
       </div>
     </div>

--- a/app/components/budgets/ballot/ballot_component.rb
+++ b/app/components/budgets/ballot/ballot_component.rb
@@ -28,6 +28,6 @@ class Budgets::Ballot::BallotComponent < ApplicationComponent
     end
 
     def group_investments(group)
-      ballot.investments.by_group(group.id)
+      ballot.investments.by_group(group.id).sort_by_ballot_lines
     end
 end

--- a/app/components/budgets/ballot/ballot_component.rb
+++ b/app/components/budgets/ballot/ballot_component.rb
@@ -26,4 +26,8 @@ class Budgets::Ballot::BallotComponent < ApplicationComponent
         budget_investments_path(budget, heading_id: group.headings.first)
       end
     end
+
+    def group_investments(group)
+      ballot.investments.by_group(group.id)
+    end
 end

--- a/app/components/budgets/ballot/investment_for_sidebar_component.rb
+++ b/app/components/budgets/ballot/investment_for_sidebar_component.rb
@@ -18,6 +18,6 @@ class Budgets::Ballot::InvestmentForSidebarComponent < Budgets::Ballot::Investme
     end
 
     def delete_path
-      budget_ballot_line_path(id: investment.id, investments_ids: investment_ids)
+      budget_ballot_line_path(budget, id: investment.id, investments_ids: investment_ids)
     end
 end

--- a/app/components/budgets/investments/my_ballot_component.html.erb
+++ b/app/components/budgets/investments/my_ballot_component.html.erb
@@ -3,7 +3,7 @@
     <%= t("budgets.investments.index.sidebar.my_ballot") %>
   </h2>
 
-  <% if ballot.investments.by_heading(heading.id).count > 0 %>
+  <% if investments.count > 0 %>
     <p>
       <em><%= sanitize(ballot.voted_info(heading)) %></em>
     </p>
@@ -32,7 +32,7 @@
   <ul class="ballot-list">
     <% if heading %>
       <%= render Budgets::Ballot::InvestmentForSidebarComponent.with_collection(
-        ballot.investments.by_heading(heading.id),
+        investments,
         investment_ids: investment_ids
       ) %>
     <% end %>

--- a/app/components/budgets/investments/my_ballot_component.rb
+++ b/app/components/budgets/investments/my_ballot_component.rb
@@ -20,6 +20,6 @@ class Budgets::Investments::MyBallotComponent < ApplicationComponent
     end
 
     def investments
-      ballot.investments.by_heading(heading.id)
+      ballot.investments.by_heading(heading.id).sort_by_ballot_lines
     end
 end

--- a/app/components/budgets/investments/my_ballot_component.rb
+++ b/app/components/budgets/investments/my_ballot_component.rb
@@ -18,4 +18,8 @@ class Budgets::Investments::MyBallotComponent < ApplicationComponent
     def budget
       ballot.budget
     end
+
+    def investments
+      ballot.investments.by_heading(heading.id)
+    end
 end

--- a/app/models/budget/investment.rb
+++ b/app/models/budget/investment.rb
@@ -99,6 +99,7 @@ class Budget
     scope :last_week,          -> { where("created_at >= ?", 7.days.ago) }
     scope :sort_by_flags,      -> { order(flags_count: :desc, updated_at: :desc) }
     scope :sort_by_created_at, -> { reorder(created_at: :desc) }
+    scope :sort_by_ballot_lines, -> { order(:"budget_ballot_lines.created_at") }
 
     scope :by_budget,           ->(budget)     { where(budget: budget) }
     scope :by_group,            ->(group_id)   { where(group_id: group_id) }

--- a/spec/components/budgets/ballot/ballot_component_spec.rb
+++ b/spec/components/budgets/ballot/ballot_component_spec.rb
@@ -3,11 +3,11 @@ require "rails_helper"
 describe Budgets::Ballot::BallotComponent do
   include Rails.application.routes.url_helpers
   before { vc_test_request.session[:ballot_referer] = "/" }
+  let(:budget) { create(:budget, :balloting) }
+  let(:ballot) { create(:budget_ballot, user: create(:user), budget: budget) }
 
   describe "link to group" do
-    let(:budget) { create(:budget, :balloting) }
     let(:group) { create(:budget_group, budget: budget) }
-    let(:ballot) { create(:budget_ballot, user: create(:user), budget: budget) }
 
     context "group with a single heading" do
       let!(:heading) { create(:budget_heading, group: group, price: 1000) }
@@ -49,5 +49,16 @@ describe Budgets::Ballot::BallotComponent do
                                   href: budget_group_path(budget, group)
       end
     end
+  end
+
+  it "sorts investments by ballot lines" do
+    ["B letter", "A letter", "C letter"].each do |title|
+      ballot.add_investment(create(:budget_investment, :selected, budget: budget, title: title))
+    end
+
+    render_inline Budgets::Ballot::BallotComponent.new(ballot)
+
+    expect("B letter").to appear_before "A letter"
+    expect("A letter").to appear_before "C letter"
   end
 end

--- a/spec/components/budgets/investments/my_ballot_component_spec.rb
+++ b/spec/components/budgets/investments/my_ballot_component_spec.rb
@@ -1,0 +1,28 @@
+require "rails_helper"
+
+describe Budgets::Investments::MyBallotComponent do
+  let(:user) { create(:user, :level_two) }
+  let(:budget) { create(:budget, :balloting) }
+  let(:ballot) { create(:budget_ballot, user: user, budget: budget) }
+  let(:heading) { create(:budget_heading, budget: budget) }
+
+  before do
+    vc_test_request.session[:ballot_referer] = "/"
+    sign_in(user)
+  end
+
+  it "sorts investments by ballot lines" do
+    ["B letter", "A letter", "C letter"].each do |title|
+      ballot.add_investment(create(:budget_investment, :selected, heading: heading, title: title))
+    end
+
+    render_inline Budgets::Investments::MyBallotComponent.new(
+      ballot: ballot,
+      heading: heading,
+      investment_ids: []
+    )
+
+    expect("B letter").to appear_before "A letter"
+    expect("A letter").to appear_before "C letter"
+  end
+end


### PR DESCRIPTION
This pull request explicitly sets a display order for the votes selected by a Voter. The display order is set as the order in which they were selected

The reason for this change is to provide a first step into providing voting types which use ranking. In this scenario the order in which votes are displayed is considered to be the priority selected by the voter. The voter can change priority by selecting proposals in a different order

It may be possible to extend this further in future by attaching a rank position to a vote and/or displaying the rank position on the vote

In the screenshots, the voter selected the proposals in order of price and they are now correctly displayed in that order

![image](https://github.com/consuldemocracy/consuldemocracy/assets/102246590/0c17d326-0f9b-4952-83e9-827ee11b51c2)
![image](https://github.com/consuldemocracy/consuldemocracy/assets/102246590/4fc019f5-5861-4b1f-94aa-cd0d9a2746db)

