### PR TITLE
Change the English translation of check ballot to avoid confusion

### DIFF
--- a/config/locales/en/budgets.yml
+++ b/config/locales/en/budgets.yml
@@ -106,7 +106,7 @@ en:
           change_vote_link: "change your vote"
           different_heading_assigned: "You have active votes in another heading: %{heading_link}"
           change_ballot: "If you change your mind you can remove your votes in %{check_ballot} and start again."
-          check_ballot_link: "submit my ballot"
+          check_ballot_link: "check my votes"
           zero: You have not voted any investment project in this group.
           verified_only: "To create a new budget investment %{verify}."
           create: "Create a budget investment"
@@ -155,10 +155,10 @@ en:
           other: "%{count} supports"
           zero: No supports
       header:
-        check_ballot: "Submit my ballot"
+        check_ballot: "Check my votes"
         different_heading_assigned: "You have active votes in another heading: %{heading_link}"
         change_ballot: "If you change your mind you can remove your votes in %{check_ballot} and start again."
-        check_ballot_link: "submit my ballot"
+        check_ballot_link: "check my votes"
         price: "Total budget"
       votes:
         already_supported: "You have already supported this investment project. Share it!"

--- a/spec/system/budgets/ballots_spec.rb
+++ b/spec/system/budgets/ballots_spec.rb
@@ -116,7 +116,7 @@ describe "Ballots" do
         within("#sidebar") do
           expect(page).to have_content "Bring back King Kong"
           expect(page).to have_content "€10,000"
-          expect(page).to have_link "Submit my ballot"
+          expect(page).to have_link "Check my votes"
         end
 
         add_to_ballot("Paint cabs black")
@@ -127,7 +127,7 @@ describe "Ballots" do
         within("#sidebar") do
           expect(page).to have_content "Paint cabs black"
           expect(page).to have_content "€20,000"
-          expect(page).to have_link "Submit my ballot"
+          expect(page).to have_link "Check my votes"
         end
       end
 
@@ -143,7 +143,7 @@ describe "Ballots" do
         within("#sidebar") do
           expect(page).to have_content investment.title
           expect(page).to have_content "€10,000"
-          expect(page).to have_link "Submit my ballot"
+          expect(page).to have_link "Check my votes"
         end
 
         within("#budget_investment_#{investment.id}") do
@@ -156,7 +156,7 @@ describe "Ballots" do
         within("#sidebar") do
           expect(page).not_to have_content investment.title
           expect(page).not_to have_content "€10,000"
-          expect(page).to have_link "Submit my ballot"
+          expect(page).to have_link "Check my votes"
         end
       end
 
@@ -430,7 +430,7 @@ describe "Ballots" do
       add_to_ballot("Sully monument")
 
       within(".budget-heading") do
-        click_link "Submit my ballot"
+        click_link "Check my votes"
       end
 
       expect(page).to have_content("You have voted one investment")
@@ -451,7 +451,7 @@ describe "Ballots" do
       visit budget_investments_path(budget, heading_id: new_york.id)
 
       within(".budget-heading") do
-        click_link "Submit my ballot"
+        click_link "Check my votes"
       end
 
       expect(page).to have_content("You have voted 0 investments")
@@ -701,7 +701,7 @@ describe "Ballots" do
         expect(page).not_to have_content investment_1.price
         expect(page).not_to have_content investment_2.price
         expect(page).not_to have_content "€"
-        click_link "Submit my ballot"
+        click_link "Check my votes"
       end
 
       expect(page).to have_content investment_1.title

--- a/spec/system/budgets/investments_spec.rb
+++ b/spec/system/budgets/investments_spec.rb
@@ -823,12 +823,12 @@ describe "Budget Investments" do
 
       visit budget_investments_path(budget, heading_id: heading.id)
 
-      expect(page).not_to have_link("Submit my ballot")
+      expect(page).not_to have_link("Check my votes")
       expect(page).not_to have_css("#progress_bar")
 
       within("#sidebar") do
         expect(page).not_to have_content("My ballot")
-        expect(page).not_to have_link("Submit my ballot")
+        expect(page).not_to have_link("Check my votes")
       end
     end
 
@@ -1394,7 +1394,7 @@ describe "Budget Investments" do
         expect(page).to have_content "€20,000"
       end
 
-      expect(page).to have_link "Submit my ballot"
+      expect(page).to have_link "Check my votes"
       expect(page).to have_content "STILL AVAILABLE TO YOU €666,666"
     end
 
@@ -1568,12 +1568,12 @@ describe "Budget Investments" do
 
       visit budget_investments_path(budget, heading_id: heading.id)
 
-      expect(page).to have_link("Submit my ballot")
+      expect(page).to have_link("Check my votes")
       expect(page).to have_css("#progress_bar")
 
       within("#sidebar") do
         expect(page).to have_content("MY BALLOT")
-        expect(page).to have_link("Submit my ballot")
+        expect(page).to have_link("Check my votes")
       end
     end
 


### PR DESCRIPTION
This fixes #5322 

The current english translation of check_ballot is Submit my ballot. This is incorrect and confusing for users
The Spanish translation looks to be correct

Before
![image](https://github.com/consuldemocracy/consuldemocracy/assets/102246590/b57c0433-ec37-4157-a88d-bc61e953019b)

After
![image](https://github.com/consuldemocracy/consuldemocracy/assets/102246590/c6500d08-978e-4fca-ae36-ad063d7027f0)
