### PR TITLE
Bump sprockets-rails from 3.2.2 to 3.4.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -609,9 +609,9 @@ GEM
     sprockets (4.2.1)
       concurrent-ruby (~> 1.0)
       rack (>= 2.2.4, < 4)
-    sprockets-rails (3.2.2)
-      actionpack (>= 4.0)
-      activesupport (>= 4.0)
+    sprockets-rails (3.4.2)
+      actionpack (>= 5.2)
+      activesupport (>= 5.2)
       sprockets (>= 3.0.0)
     sshkit (1.22.0)
       mutex_m

--- a/config/application.rb
+++ b/config/application.rb
@@ -39,6 +39,9 @@ module Consul
     # work with the _count database columns we use for caching purposes
     config.active_record.has_many_inversing = false
 
+    # Disable Sprockets AssetUrlProcessor for CKEditor compatibility
+    config.assets.resolve_assets_in_css_urls = false
+
     # Keep reading existing data in the legislation_annotations ranges column
     config.active_record.yaml_column_permitted_classes = [ActiveSupport::HashWithIndifferentAccess, Symbol]
 


### PR DESCRIPTION
## References

* The sprockets-rails gems changed its way to process CSS files in rails/sprockets-rails#476 and added an option to keep the old behavior in rails/sprockets-rails#489
* The new way to process CSS files breaks CKEditor icons, as reported in galetahub/ckeditor#919
* The sprockets-rails gem will need to be added as an explicit dependency in Rails 7, as mentioned in the [Upgrading Ruby on Rails guide](https://guides.rubyonrails.org/v7.0/upgrading_ruby_on_rails.html#sprockets-is-now-an-optional-dependency)

## Objectives

* Avoid breaking CKEditor every time we (or Dependabot) run `bundle update <gem>` and accidentally update sprockets-rails
* Make sure we don't break CKEditor when upgrading to Rails 7.0