### PR TITLE
Don't ping search engines after sitemap generation

### DIFF
--- a/config/sitemap.rb
+++ b/config/sitemap.rb
@@ -52,8 +52,4 @@ Tenant.run_on_each do
       end
     end
   end
-
-  unless Rails.env.development? || Rails.env.test?
-    SitemapGenerator::Sitemap.ping_search_engines
-  end
 end


### PR DESCRIPTION
## References

* Sitemaps ping for Bing was removed from sitemap generator in kjvarga/sitemap_generator#408
* [Sitemaps ping was deprecated by Google](https://developers.google.com/search/blog/2023/06/sitemaps-lastmod-ping)

## Objectives

* Avoid an error while pinging Google during deployment

