### PR TITLE
Don't run linters in Code Climate

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,7 +1,4 @@
 engines:
-  rubocop:
-    enabled: true
-    channel: rubocop-1-56-3
   duplication:
     enabled: true
     config:
@@ -12,13 +9,7 @@ engines:
     enabled: true
   bundler-audit:
     enabled: true
-  coffeelint:
-    enabled: true
-  stylelint:
-    enabled: true
   fixme:
-    enabled: true
-  markdownlint:
     enabled: true
 ratings:
   paths:

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -14,7 +14,7 @@ engines:
     enabled: true
   coffeelint:
     enabled: true
-  scss-lint:
+  stylelint:
     enabled: true
   fixme:
     enabled: true


### PR DESCRIPTION
## References

* We check all these linters via github actions since pull requests #5545 and #5582
* SCSS linter checks in code climate are broken since pull request #5448
* [List of Code Climate engines](https://github.com/codeclimate/codeclimate/blob/master/config/engines.yml)

## Objectives

* Remove checks that we no longer need and that might be incompatible with our configuration because code climate doesn't use the same versions of the linters as we do