### PR TITLE
Correctly close <main> tag in admin layout

### DIFF
--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -30,7 +30,7 @@
         <%= render "layouts/flash" %>
         <%= render "layouts/officing_booth" if controller.class.module_parent == Officing && session[:booth_id].present? %>
         <%= yield %>
-      </div>
+      </main>
     </div>
   </body>
 </html>


### PR DESCRIPTION
## References

* This change should have been part of commit 2b962f278 from pull request #5396

## Objectives

* Close the same HTML tags that we open :smile: