### PR TITLE
Keep rendering pre-Rails7 ActiveStorage images

### DIFF
--- a/config/initializers/active_storage_message_and_cookie_rotator.rb
+++ b/config/initializers/active_storage_message_and_cookie_rotator.rb
@@ -1,4 +1,17 @@
 # This code was copied from:
+# https://github.com/hotwired/turbo-rails/blob/v1.4.0/UPGRADING.md#key-digest-changes-in-111
+# Removing this code will make ActiveStorage image URLs generated with Rails 6.1
+# or earlier inaccessible, causing images attached with CKEditor or linked from
+# somewhere else not to be rendered.
+Rails.application.config.after_initialize do |app|
+  key_generator = ActiveSupport::KeyGenerator.new(
+    app.secret_key_base, iterations: 1000, hash_digest_class: OpenSSL::Digest::SHA1
+  )
+
+  app.message_verifier("ActiveStorage").rotate(key_generator.generate_key("ActiveStorage"))
+end
+
+# This code was copied from:
 # https://guides.rubyonrails.org/v7.0/upgrading_ruby_on_rails.html#key-generator-digest-class-changing-to-use-sha256
 # TODO: safe to remove after upgrading to Rails 7.1 or releasing a new
 # version of Consul Democracy


### PR DESCRIPTION
## References

* We changed the key generator hash digest class in commit b3f5705121 from pull request #5465
* The code in this pull request was copied from [Key digest changes in Turbo Rails 1.1.1](https://github.com/hotwired/turbo-rails/blob/v1.4.0/UPGRADING.md#key-digest-changes-in-111)

## Objectives

* Make sure images in custom pages created with Consul Democracy 2.1.1 and earlier are still rendered after upgrading to Consul Democracy 2.2.0
* Make sure existing URLs pointing to images in Consul Democracy installations keep working 

## Release notes

TODO: Should we recommend re-attaching images in custom pages so they get URLs using the new hash digest class?