### PR TITLE
Remove duplicated spec

### DIFF
--- a/spec/system/budgets/investments_spec.rb
+++ b/spec/system/budgets/investments_spec.rb
@@ -1334,17 +1334,6 @@ describe "Budget Investments" do
         expect(page).to have_content "1 support"
       end
     end
-
-    scenario "Show should display support text and count" do
-      investment = create(:budget_investment, budget: budget, heading: heading, voters: [create(:user)])
-
-      visit budget_investment_path(budget, investment)
-
-      within("#budget_investment_#{investment.id}") do
-        expect(page).to have_content "SUPPORTS"
-        expect(page).to have_content "1 support"
-      end
-    end
   end
 
   context "Publishing prices phase" do


### PR DESCRIPTION
## Objectives

This PR deletes a duplicate spec on `budgets/investments_spec.rb`.

### Spec deleted
```ruby
scenario "Show should display support text and count" do
  investment = create(:budget_investment, budget: budget, heading: heading, voters: [create(:user)])

  visit budget_investment_path(budget, investment)

  within("#budget_investment_#{investment.id}") do
    expect(page).to have_content "SUPPORTS"
    expect(page).to have_content "1 support"
  end
end
```

### Spec that remains 
_`budgets/investments_spec.rb:1317`_

```ruby
scenario "Sidebar in show should display support text and count" do
  investment = create(:budget_investment, :selected, budget: budget, voters: [create(:user)])

  visit budget_investment_path(budget, investment)

  within("aside") do
    expect(page).to have_content "SUPPORTS"
    expect(page).to have_content "1 support"
  end
end
```

Since the only place the "**_SUPPORTS / 1 support_**" text appears in the show view is in the sidebar, I think it makes more sense to leave this one using the `<aside>` to check that it appears. 😌 