### PR TITLE
Update initializer reference in rubocop config file

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -163,7 +163,7 @@ Layout/LineLength:
     - "config/environments/staging.rb"
     - "config/initializers/devise.rb"
     - "config/initializers/backtrace_silencers.rb"
-    - "config/initializers/cookie_rotator.rb"
+    - "config/initializers/active_storage_message_and_cookie_rotator.rb"
     - "db/migrate/*create_delayed_jobs.rb"
     - "db/migrate/*create_active_storage_variant_records.active_storage.rb"
     - "app/models/budget/stats.rb"


### PR DESCRIPTION
## References

* Continues pull request #5497

## Objectives

* Make sure `rubocop --fail-level convention --display-only-fail-level-offenses` reports no offenses