### PR TITLE
Associate all form inputs with labels

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -75,6 +75,7 @@ group :development, :test do
 end
 
 group :test do
+  gem "axe-core-rspec", "~> 4.8.2", require: false
   gem "capybara", "~> 3.40.0"
   gem "capybara-webmock", "~> 0.7.0"
   gem "email_spec", "~> 2.2.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -95,6 +95,17 @@ GEM
       request_store (~> 1.2)
     autoprefixer-rails (10.4.16.0)
       execjs (~> 2)
+    axe-core-api (4.9.0)
+      dumb_delegator
+      virtus
+    axe-core-rspec (4.8.2)
+      axe-core-api
+      dumb_delegator
+      virtus
+    axiom-types (0.1.1)
+      descendants_tracker (~> 0.0.4)
+      ice_nine (~> 0.11.0)
+      thread_safe (~> 0.3, >= 0.3.1)
     base64 (0.1.1)
     bcrypt (3.1.20)
     better_html (2.1.1)
@@ -164,6 +175,8 @@ GEM
       terrapin
     climate_control (0.2.0)
     cocoon (1.2.15)
+    coercible (1.0.0)
+      descendants_tracker (~> 0.0.1)
     coffee-rails (5.0.0)
       coffee-script (>= 2.2.0)
       railties (>= 5.2.0)
@@ -184,6 +197,8 @@ GEM
     delayed_job_active_record (4.1.8)
       activerecord (>= 3.0, < 8.0)
       delayed_job (>= 3.0, < 5)
+    descendants_tracker (0.0.4)
+      thread_safe (~> 0.3, >= 0.3.1)
     device_detector (1.1.2)
     devise (4.9.3)
       bcrypt (~> 3.0)
@@ -195,6 +210,7 @@ GEM
       devise (>= 4.3.0)
     diff-lcs (1.5.1)
     docile (1.4.0)
+    dumb_delegator (1.0.0)
     email_spec (2.2.2)
       htmlentities (~> 4.3.3)
       launchy (~> 2.1)
@@ -285,6 +301,7 @@ GEM
       rails-i18n
       rainbow (>= 2.2.2, < 4.0)
       terminal-table (>= 1.5.1)
+    ice_nine (0.11.2)
     image_processing (1.12.2)
       mini_magick (>= 4.9.5, < 5)
       ruby-vips (>= 2.0.17, < 3)
@@ -639,6 +656,7 @@ GEM
     terrapin (0.6.0)
       climate_control (>= 0.0.3, < 1.0)
     thor (1.3.1)
+    thread_safe (0.3.6)
     tilt (2.0.10)
     timeout (0.4.1)
     tomlrb (2.0.3)
@@ -664,6 +682,10 @@ GEM
       activesupport (>= 5.2.0, < 8.0)
       concurrent-ruby (~> 1.0)
       method_source (~> 1.0)
+    virtus (2.0.0)
+      axiom-types (~> 0.1)
+      coercible (~> 1.0)
+      descendants_tracker (~> 0.0, >= 0.0.3)
     warden (1.2.9)
       rack (>= 2.0.9)
     wasabi (5.0.2)
@@ -700,6 +722,7 @@ DEPENDENCIES
   ancestry (~> 4.3.3)
   audited (~> 5.4.3)
   autoprefixer-rails (~> 10.4.16)
+  axe-core-rspec (~> 4.8.2)
   bing_translator (~> 6.2.0)
   bullet (~> 7.1.6)
   cancancan (~> 3.5.0)

--- a/app/components/admin/geozones/form_component.html.erb
+++ b/app/components/admin/geozones/form_component.html.erb
@@ -25,13 +25,13 @@
   </div>
 
   <div class="small-12 large-3 column">
-    <%= f.label :color, nil, for: "color_input", id: "color_input_label" %>
+    <%= f.label :color, nil, for: "color_input", id: "color_label" %>
     <p class="help-text">
       <%= t("admin.geozones.geozone.color_help", format_help: t("admin.shared.color_help")) %>
     </p>
     <div class="row collapse">
       <div class="small-12 medium-6 column">
-        <%= f.text_field :color, label: false, type: :color %>
+        <%= f.text_field :color, label: false, type: :color, "aria-labelledby": "color_label" %>
       </div>
       <div class="small-12 medium-6 column">
         <%= f.text_field :color, label: false, id: "color_input" %>

--- a/app/components/admin/site_customization/information_texts/form_field_component.rb
+++ b/app/components/admin/site_customization/information_texts/form_field_component.rb
@@ -1,6 +1,6 @@
 class Admin::SiteCustomization::InformationTexts::FormFieldComponent < ApplicationComponent
   attr_reader :i18n_content, :locale
-  use_helpers :globalize, :site_customization_display_translation_style
+  use_helpers :globalize, :site_customization_enable_translation?
 
   def initialize(i18n_content, locale:)
     @i18n_content = i18n_content
@@ -21,5 +21,9 @@ class Admin::SiteCustomization::InformationTexts::FormFieldComponent < Applicati
 
     def i18n_text
       I18n.translate(i18n_content.key, locale: locale)
+    end
+
+    def site_customization_display_translation_style
+      site_customization_enable_translation? ? "" : "display: none;"
     end
 end

--- a/app/components/shared/globalize_locales_component.html.erb
+++ b/app/components/shared/globalize_locales_component.html.erb
@@ -3,19 +3,19 @@
     <span class="small">
       <strong class="js-languages-description"
         data-texts="<%= t("shared.translations.languages_in_use").to_json %>">
-        <%= selected_languages_description(resource) %>
+        <%= selected_languages_description %>
       </strong>
     </span>
     <%= select_tag :select_language,
-                   options_for_select_language(resource),
+                   options_for_select_language,
                    prompt: t("shared.translations.select_language_prompt"),
                    class: "js-select-language" %>
-    <%= select_language_error(resource) %>
+    <%= select_language_error %>
     <div class="margin-bottom">
       <% if manage_languages %>
         <% I18n.available_locales.each do |locale| %>
           <%= link_to t("shared.translations.remove_language"), "#",
-                      style: display_destroy_locale_style(resource, locale),
+                      style: display_destroy_locale_style(locale),
                       class: "delete js-delete-language js-delete-#{locale}",
                       data: { locale: locale } %>
         <% end %>

--- a/app/components/shared/globalize_locales_component.html.erb
+++ b/app/components/shared/globalize_locales_component.html.erb
@@ -6,9 +6,9 @@
         <%= selected_languages_description %>
       </strong>
     </span>
+    <%= label_tag :select_language, t("shared.translations.current_language") %>
     <%= select_tag :select_language,
                    options_for_select_language,
-                   prompt: t("shared.translations.select_language_prompt"),
                    class: "js-select-language" %>
     <%= select_language_error %>
     <div class="margin-bottom">
@@ -24,6 +24,7 @@
   </div>
   <div class="small-6 large-3 column margin-top end">
     <% if manage_languages %>
+      <%= label_tag :add_language, t("shared.translations.add_language") %>
       <%= select_tag :add_language,
                      options_for_add_language,
                      prompt: t("shared.translations.add_language"),

--- a/app/components/shared/globalize_locales_component.rb
+++ b/app/components/shared/globalize_locales_component.rb
@@ -1,0 +1,91 @@
+class Shared::GlobalizeLocalesComponent < ApplicationComponent
+  attr_reader :resource, :manage_languages
+  use_helpers :first_translation, :first_marked_for_destruction_translation,
+    :enabled_locale?, :name_for_locale, :highlight_translation_html_class
+
+  def initialize(resource = nil, manage_languages: true)
+    @resource = resource
+    @manage_languages = manage_languages
+  end
+
+  private
+
+    def options_for_select_language
+      options_for_select(available_locales, selected_locale)
+    end
+
+    def available_locales
+      I18n.available_locales.select { |locale| enabled_locale?(resource, locale) }.map do |locale|
+        [name_for_locale(locale), locale, { data: { locale: locale }}]
+      end
+    end
+
+    def selected_locale
+      return first_i18n_content_translation_locale if resource.blank?
+
+      if resource.locales_not_marked_for_destruction.any?
+        first_translation(resource)
+      elsif resource.locales_persisted_and_marked_for_destruction.any?
+        first_marked_for_destruction_translation(resource)
+      else
+        I18n.locale
+      end
+    end
+
+    def first_i18n_content_translation_locale
+      if I18nContentTranslation.existing_languages.count == 0 ||
+          I18nContentTranslation.existing_languages.include?(I18n.locale)
+        I18n.locale
+      else
+        I18nContentTranslation.existing_languages.first
+      end
+    end
+
+    def selected_languages_description
+      sanitize(t("shared.translations.languages_in_use", count: active_languages_count))
+    end
+
+    def select_language_error
+      return if resource.blank?
+
+      current_translation = resource.translation_for(selected_locale)
+      if current_translation.errors.added? :base, :translations_too_short
+        tag.div class: "small error" do
+          current_translation.errors[:base].join(", ")
+        end
+      end
+    end
+
+    def active_languages_count
+      if resource.blank?
+        no_resource_languages_count
+      elsif resource.locales_not_marked_for_destruction.size > 0
+        resource.locales_not_marked_for_destruction.size
+      else
+        1
+      end
+    end
+
+    def no_resource_languages_count
+      count = I18nContentTranslation.existing_languages.count
+      count > 0 ? count : 1
+    end
+
+    def display_destroy_locale_style(locale)
+      "display: none;" unless display_destroy_locale_link?(locale)
+    end
+
+    def display_destroy_locale_link?(locale)
+      selected_locale == locale
+    end
+
+    def options_for_add_language
+      options_for_select(all_language_options, nil)
+    end
+
+    def all_language_options
+      I18n.available_locales.map do |locale|
+        [name_for_locale(locale), locale]
+      end
+    end
+end

--- a/app/helpers/globalize_helper.rb
+++ b/app/helpers/globalize_helper.rb
@@ -1,14 +1,4 @@
 module GlobalizeHelper
-  def options_for_select_language(resource)
-    options_for_select(available_locales(resource), selected_locale(resource))
-  end
-
-  def available_locales(resource)
-    I18n.available_locales.select { |locale| enabled_locale?(resource, locale) }.map do |locale|
-      [name_for_locale(locale), locale, { data: { locale: locale }}]
-    end
-  end
-
   def enabled_locale?(resource, locale)
     return site_customization_enable_translation?(locale) if resource.blank?
 
@@ -18,27 +8,6 @@ module GlobalizeHelper
       locale == first_marked_for_destruction_translation(resource)
     else
       locale == I18n.locale
-    end
-  end
-
-  def selected_locale(resource)
-    return first_i18n_content_translation_locale if resource.blank?
-
-    if resource.locales_not_marked_for_destruction.any?
-      first_translation(resource)
-    elsif resource.locales_persisted_and_marked_for_destruction.any?
-      first_marked_for_destruction_translation(resource)
-    else
-      I18n.locale
-    end
-  end
-
-  def first_i18n_content_translation_locale
-    if I18nContentTranslation.existing_languages.count == 0 ||
-       I18nContentTranslation.existing_languages.include?(I18n.locale)
-      I18n.locale
-    else
-      I18nContentTranslation.existing_languages.first
     end
   end
 
@@ -58,36 +27,6 @@ module GlobalizeHelper
     end
   end
 
-  def selected_languages_description(resource)
-    sanitize(t("shared.translations.languages_in_use", count: active_languages_count(resource)))
-  end
-
-  def select_language_error(resource)
-    return if resource.blank?
-
-    current_translation = resource.translation_for(selected_locale(resource))
-    if current_translation.errors.added? :base, :translations_too_short
-      tag.div class: "small error" do
-        current_translation.errors[:base].join(", ")
-      end
-    end
-  end
-
-  def active_languages_count(resource)
-    if resource.blank?
-      no_resource_languages_count
-    elsif resource.locales_not_marked_for_destruction.size > 0
-      resource.locales_not_marked_for_destruction.size
-    else
-      1
-    end
-  end
-
-  def no_resource_languages_count
-    count = I18nContentTranslation.existing_languages.count
-    count > 0 ? count : 1
-  end
-
   def display_translation_style(resource, locale)
     "display: none;" unless display_translation?(resource, locale)
   end
@@ -101,24 +40,6 @@ module GlobalizeHelper
       locale == first_marked_for_destruction_translation(resource)
     else
       locale == I18n.locale
-    end
-  end
-
-  def display_destroy_locale_style(resource, locale)
-    "display: none;" unless display_destroy_locale_link?(resource, locale)
-  end
-
-  def display_destroy_locale_link?(resource, locale)
-    selected_locale(resource) == locale
-  end
-
-  def options_for_add_language
-    options_for_select(all_language_options, nil)
-  end
-
-  def all_language_options
-    I18n.available_locales.map do |locale|
-      [name_for_locale(locale), locale]
     end
   end
 

--- a/app/helpers/globalize_helper.rb
+++ b/app/helpers/globalize_helper.rb
@@ -58,10 +58,6 @@ module GlobalizeHelper
     end
   end
 
-  def translations_for_locale?(resource)
-    resource.locales_not_marked_for_destruction.any?
-  end
-
   def selected_languages_description(resource)
     sanitize(t("shared.translations.languages_in_use", count: active_languages_count(resource)))
   end

--- a/app/helpers/site_customization_helper.rb
+++ b/app/helpers/site_customization_helper.rb
@@ -3,10 +3,6 @@ module SiteCustomizationHelper
     I18nContentTranslation.existing_languages.include?(locale) || locale == I18n.locale
   end
 
-  def site_customization_display_translation_style(locale)
-    site_customization_enable_translation?(locale) ? "" : "display: none;"
-  end
-
   def information_texts_tabs
     [:basic, :debates, :community, :proposals, :polls, :legislation, :budgets, :layouts, :mailers,
      :management, :welcome, :machine_learning]

--- a/app/views/admin/banners/_form.html.erb
+++ b/app/views/admin/banners/_form.html.erb
@@ -46,11 +46,11 @@
 
   <div class="row">
     <div class="small-12 medium-6 large-3 column">
-      <%= f.label :background_color, nil, for: "background_color_input" %>
+      <%= f.label :background_color, nil, for: "background_color_input", id: "background_color_label" %>
       <p class="help-text"><%= t("admin.shared.color_help") %></p>
       <div class="row collapse">
         <div class="small-12 medium-6 column">
-          <%= f.text_field :background_color, label: false, type: :color %>
+          <%= f.text_field :background_color, label: false, type: :color, "aria-labelledby": "background_color_label" %>
         </div>
         <div class="small-12 medium-6 column">
           <%= f.text_field :background_color, label: false, id: "background_color_input" %>
@@ -59,11 +59,11 @@
     </div>
 
     <div class="small-12 medium-6 large-3 column end">
-      <%= f.label :font_color, nil, for: "font_color_input" %>
+      <%= f.label :font_color, nil, for: "font_color_input", id: "font_color_label" %>
       <p class="help-text"><%= t("admin.shared.color_help") %></p>
       <div class="row collapse">
         <div class="small-12 medium-6 column">
-          <%= f.text_field :font_color, label: false, type: :color %>
+          <%= f.text_field :font_color, label: false, type: :color, "aria-labelledby": "font_color_label" %>
         </div>
         <div class="small-12 medium-6 column">
           <%= f.text_field :font_color, label: false, id: "font_color_input" %>

--- a/app/views/admin/budget_investments/_search_form.html.erb
+++ b/app/views/admin/budget_investments/_search_form.html.erb
@@ -33,36 +33,40 @@
   </div>
 
   <div class="small-12 medium-3 column">
+    <%= label_tag :administrator_id %>
     <%= select_tag :administrator_id,
                    options_for_select(admin_select_options(@budget), params[:administrator_id]),
                    { prompt: t("admin.budget_investments.index.administrator_filter_all") } %>
   </div>
   <div class="small-12 medium-3 column">
+    <%= label_tag :valuator_or_group_id %>
     <%= select_tag :valuator_or_group_id,
                    options_for_select(valuator_or_group_select_options(@budget), params[:valuator_or_group_id]),
                    { prompt: t("admin.budget_investments.index.valuator_filter_all") } %>
   </div>
   <div class="small-12 medium-3 column">
+    <%= label_tag :heading_id %>
     <%= select_tag :heading_id,
                    options_for_select(budget_heading_select_options(@budget), params[:heading_id]),
                    { prompt: t("admin.budget_investments.index.heading_filter_all") } %>
   </div>
   <div class="small-12 medium-3 column">
+    <%= label_tag :label_name %>
     <%= select_tag :tag_name,
                    options_for_select(investment_tags_select_options(@budget, "valuation_tags"), params[:tag_name]),
                    { prompt: t("admin.budget_investments.index.tags_filter_all") } %>
   </div>
 
   <div class="small-12 medium-3 column">
+    <%= label_tag :milestone_tag_name %>
     <%= select_tag :milestone_tag_name,
                    options_for_select(investment_tags_select_options(@budget, "milestone_tags"), params[:milestone_tag_name]),
                    { prompt: t("admin.budget_investments.index.milestone_tags_filter_all") } %>
   </div>
 
   <div class="small-12 medium-6 column">
-    <div class="input-group">
-      <%= text_field_tag :title_or_id, params["title_or_id"], placeholder: t("admin.budget_investments.index.placeholder") %>
-    </div>
+    <%= label_tag :title_or_id %>
+    <%= text_field_tag :title_or_id, params["title_or_id"], placeholder: t("admin.budget_investments.index.placeholder") %>
   </div>
 
   <div class="small-12 medium-3 column end">

--- a/app/views/admin/legislation/homepages/_form.html.erb
+++ b/app/views/admin/legislation/homepages/_form.html.erb
@@ -1,7 +1,4 @@
-<%= render "shared/globalize_locales",
-           resource: @process,
-           display_style: lambda { |locale| enable_translation_style(@process, locale) },
-           manage_languages: false %>
+<%= render "shared/globalize_locales", resource: @process, manage_languages: false %>
 
 <%= translatable_form_for [:admin, @process], url: url do |f| %>
 

--- a/app/views/admin/legislation/milestones/_summary_form.html.erb
+++ b/app/views/admin/legislation/milestones/_summary_form.html.erb
@@ -1,7 +1,4 @@
-<%= render "shared/globalize_locales",
-           resource: @process,
-           display_style: lambda { |locale| enable_translation_style(@process, locale) },
-           manage_languages: false %>
+<%= render "shared/globalize_locales", resource: @process, manage_languages: false %>
 
 <%= translatable_form_for [:admin, @process] do |f| %>
   <div class="row">

--- a/app/views/admin/legislation/processes/_form.html.erb
+++ b/app/views/admin/legislation/processes/_form.html.erb
@@ -122,11 +122,11 @@
     </div>
 
     <div class="small-6 large-3 column">
-      <%= f.label :background_color, nil, for: "background_color_input" %>
+      <%= f.label :background_color, nil, for: "background_color_input", id: "background_color_label" %>
       <p class="help-text"><%= t("admin.shared.color_help") %></p>
       <div class="row collapse">
         <div class="small-12 medium-6 column">
-          <%= f.text_field :background_color, label: false, type: :color %>
+          <%= f.text_field :background_color, label: false, type: :color, "aria-labelledby": "background_color_label" %>
         </div>
         <div class="small-12 medium-6 column">
           <%= f.text_field :background_color, label: false, id: "background_color_input" %>
@@ -135,11 +135,11 @@
     </div>
 
     <div class="small-6 large-3 column end">
-      <%= f.label :font_color, nil, for: "font_color_input" %>
+      <%= f.label :font_color, nil, for: "font_color_input", id: "font_color_label" %>
       <p class="help-text"><%= t("admin.shared.color_help") %></p>
       <div class="row collapse">
         <div class="small-12 medium-6 column">
-          <%= f.text_field :font_color, label: false, type: :color %>
+          <%= f.text_field :font_color, label: false, type: :color, "aria-labelledby": "font_color_label" %>
         </div>
         <div class="small-12 medium-6 column">
           <%= f.text_field :font_color, label: false, id: "font_color_input" %>

--- a/app/views/admin/site_customization/information_texts/_globalize_locales.html.erb
+++ b/app/views/admin/site_customization/information_texts/_globalize_locales.html.erb
@@ -1,1 +1,1 @@
-<%= render "shared/common_globalize_locales", resource: nil %>
+<%= render Shared::GlobalizeLocalesComponent.new %>

--- a/app/views/admin/site_customization/information_texts/_globalize_locales.html.erb
+++ b/app/views/admin/site_customization/information_texts/_globalize_locales.html.erb
@@ -1,3 +1,1 @@
-<%= render "shared/common_globalize_locales",
-           resource: nil,
-           display_style: lambda { |locale| site_customization_display_translation_style(locale) } %>
+<%= render "shared/common_globalize_locales", resource: nil %>

--- a/app/views/admin/site_customization/information_texts/_globalize_locales.html.erb
+++ b/app/views/admin/site_customization/information_texts/_globalize_locales.html.erb
@@ -1,4 +1,3 @@
 <%= render "shared/common_globalize_locales",
            resource: nil,
-           display_style: lambda { |locale| site_customization_display_translation_style(locale) },
-           manage_languages: defined?(manage_languages) ? manage_languages : true %>
+           display_style: lambda { |locale| site_customization_display_translation_style(locale) } %>

--- a/app/views/shared/_globalize_locales.html.erb
+++ b/app/views/shared/_globalize_locales.html.erb
@@ -1,6 +1,5 @@
 <% if translations_interface_enabled? %>
   <%= render "shared/common_globalize_locales",
              resource: resource,
-             display_style: lambda { |locale| enable_translation_style(resource, locale) },
              manage_languages: defined?(manage_languages) ? manage_languages : true %>
 <% end %>

--- a/app/views/shared/_globalize_locales.html.erb
+++ b/app/views/shared/_globalize_locales.html.erb
@@ -1,5 +1,6 @@
 <% if translations_interface_enabled? %>
-  <%= render "shared/common_globalize_locales",
-             resource: resource,
-             manage_languages: defined?(manage_languages) ? manage_languages : true %>
+  <%= render Shared::GlobalizeLocalesComponent.new(
+    resource,
+    manage_languages: defined?(manage_languages) ? manage_languages : true
+  ) %>
 <% end %>

--- a/config/locales/en/general.yml
+++ b/config/locales/en/general.yml
@@ -742,7 +742,7 @@ en:
         see_more: See more recommendations
         hide: Hide recommendations
     translations:
-      select_language_prompt: Choose language
+      current_language: Current language
       remove_language: Remove language
       add_language: Add language
       languages_in_use:

--- a/config/locales/es/general.yml
+++ b/config/locales/es/general.yml
@@ -742,7 +742,7 @@ es:
       see_more: Ver más recomendaciones
       hide: Ocultar recomendaciones
     translations:
-      select_language_prompt: Seleccionar idioma
+      current_language: Idioma actual
       remove_language: Eliminar idioma
       add_language: Añadir idioma
       languages_in_use:

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -60,6 +60,10 @@ module Capybara
     def visit(url, ...)
       original_visit(url, ...)
 
+      unless driver.name == :rack_test
+        expect(page).to be_axe_clean.checking_only :label
+      end
+
       unless url.match?("robots.txt") || url.match?("active_storage/representations")
         expect(page).to have_css "main", count: 1
         expect(page).to have_css "#main", count: 1

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,4 @@
+require "axe-rspec"
 require "factory_bot_rails"
 require "email_spec"
 require "devise"

--- a/spec/system/admin/banners_spec.rb
+++ b/spec/system/admin/banners_spec.rb
@@ -95,7 +95,7 @@ describe "Admin banners magement", :admin do
     expect_to_have_language_selected "English"
 
     click_link "Remove language"
-    select "Français", from: "add_language"
+    select "Français", from: "Add language"
 
     fill_in "Title", with: "En Français"
     fill_in "Description", with: "Link en Français"

--- a/spec/system/admin/budget_groups_spec.rb
+++ b/spec/system/admin/budget_groups_spec.rb
@@ -144,7 +144,7 @@ describe "Admin budget groups", :admin do
 
       visit edit_admin_budget_group_path(budget, group)
 
-      select "Español", from: :add_language
+      select "Español", from: "Add language"
       fill_in "Group name", with: "Spanish name"
       click_button "Save group"
 
@@ -156,7 +156,7 @@ describe "Admin budget groups", :admin do
 
       visit edit_admin_budget_group_path(budget, group)
 
-      select "English", from: :select_language
+      select "English", from: "Current language"
       fill_in "Group name", with: "New English Name"
       click_button "Save group"
 

--- a/spec/system/admin/budget_headings_spec.rb
+++ b/spec/system/admin/budget_headings_spec.rb
@@ -181,7 +181,7 @@ describe "Admin budget headings", :admin do
 
       visit edit_admin_budget_group_heading_path(budget, group, heading)
 
-      select "Español", from: :add_language
+      select "Español", from: "Add language"
       fill_in "Heading name", with: "Spanish name"
       click_button "Save heading"
 
@@ -193,7 +193,7 @@ describe "Admin budget headings", :admin do
 
       visit edit_admin_budget_group_heading_path(budget, group, heading)
 
-      select "English", from: :select_language
+      select "English", from: "Current language"
       fill_in "Heading name", with: "New English Name"
       click_button "Save heading"
 

--- a/spec/system/admin/budgets_spec.rb
+++ b/spec/system/admin/budgets_spec.rb
@@ -315,7 +315,7 @@ describe "Admin budgets", :admin do
 
       visit edit_admin_budget_path(budget)
 
-      select "Español", from: :add_language
+      select "Español", from: "Add language"
       fill_in "Name", with: "Spanish name"
       click_button "Update Budget"
 
@@ -327,7 +327,7 @@ describe "Admin budgets", :admin do
 
       visit edit_admin_budget_path(budget)
 
-      select "English", from: :select_language
+      select "English", from: "Current language"
       fill_in "Name", with: "New English Name"
       click_button "Update Budget"
 

--- a/spec/system/admin/legislation/questions_spec.rb
+++ b/spec/system/admin/legislation/questions_spec.rb
@@ -149,7 +149,7 @@ describe "Admin legislation questions", :admin do
 
         find("#nested_question_options input").set("Option 1")
 
-        select "Español", from: :select_language
+        select "Español", from: "Current language"
 
         find("#nested_question_options input").set("Opción 1")
 
@@ -158,7 +158,7 @@ describe "Admin legislation questions", :admin do
 
         expect(page).to have_field(field_en[:id], with: "Option 1")
 
-        select "Español", from: :select_language
+        select "Español", from: "Current language"
 
         expect(page).to have_field(field_es[:id], with: "Opción 1")
       end
@@ -166,13 +166,13 @@ describe "Admin legislation questions", :admin do
       scenario "Add new question option after changing active locale" do
         visit edit_question_url
 
-        select "Español", from: :select_language
+        select "Español", from: "Current language"
 
         click_link "Add option"
 
         find("#nested_question_options input").set("Opción 1")
 
-        select "English", from: :select_language
+        select "English", from: "Current language"
 
         find("#nested_question_options input").set("Option 1")
 
@@ -182,7 +182,7 @@ describe "Admin legislation questions", :admin do
 
         expect(page).to have_field(field_en[:id], with: "Option 1")
 
-        select "Español", from: :select_language
+        select "Español", from: "Current language"
 
         expect(page).to have_field(field_es[:id], with: "Opción 1")
       end

--- a/spec/system/admin/site_customization/information_texts_spec.rb
+++ b/spec/system/admin/site_customization/information_texts_spec.rb
@@ -67,7 +67,7 @@ describe "Admin custom information texts", :admin do
 
       visit admin_site_customization_information_texts_path
 
-      select "Français", from: :add_language
+      select "Français", from: "Add language"
       fill_in "contents[content_#{key}]values[value_fr]", with: "Aide personalise sur les débats"
 
       click_button "Save"
@@ -75,7 +75,7 @@ describe "Admin custom information texts", :admin do
       expect(page).to have_content "Translation updated successfully"
 
       visit admin_site_customization_information_texts_path
-      select "Français", from: :select_language
+      select "Français", from: "Current language"
 
       expect(page).to have_content "Aide personalise sur les débats"
       expect(page).not_to have_content "Aide sur les débats"
@@ -87,14 +87,14 @@ describe "Admin custom information texts", :admin do
 
       visit admin_site_customization_information_texts_path(tab: "proposals")
 
-      select "Français", from: :select_language
+      select "Français", from: "Current language"
       fill_in "contents_content_#{key}values_value_fr", with: "Partager personalise"
 
       click_button "Save"
       expect(page).to have_content "Translation updated successfully"
 
       visit admin_site_customization_information_texts_path(tab: "proposals")
-      select "Français", from: :select_language
+      select "Français", from: "Current language"
 
       expect(page).to have_content "Partager personalise"
       expect(page).not_to have_content "Partager la proposition"
@@ -111,14 +111,14 @@ describe "Admin custom information texts", :admin do
 
       visit admin_site_customization_information_texts_path(tab: "debates")
 
-      select "Español", from: :select_language
+      select "Español", from: "Current language"
       click_link "Remove language"
       click_button "Save"
 
       expect(page).not_to have_link "Español"
 
       visit admin_site_customization_information_texts_path(tab: "debates")
-      select "English", from: :select_language
+      select "English", from: "Current language"
 
       expect(page).to have_content "Start a new debate"
       expect(page).to have_content "Custom featured"

--- a/spec/system/admin/translatable_spec.rb
+++ b/spec/system/admin/translatable_spec.rb
@@ -22,7 +22,7 @@ describe "Admin edit translatable records", :admin do
       scenario "Maintains existing translations" do
         visit path
 
-        select "Français", from: :add_language
+        select "Français", from: "Add language"
         fill_in "Heading name", with: "Nom en Français"
         click_button "Save heading"
 
@@ -30,11 +30,11 @@ describe "Admin edit translatable records", :admin do
 
         expect(page).to have_field "Heading name", with: "Heading name in English"
 
-        select "Español", from: :select_language
+        select "Español", from: "Current language"
 
         expect(page).to have_field "Heading name", with: "Nombre de la partida en español"
 
-        select "Français", from: :select_language
+        select "Français", from: "Current language"
 
         expect(page).to have_field "Heading name", with: "Nom en Français"
       end
@@ -47,7 +47,7 @@ describe "Admin edit translatable records", :admin do
       scenario "Maintains existing translations" do
         visit path
 
-        select "Français", from: :add_language
+        select "Français", from: "Add language"
         fill_in "Title", with: "Titre en Français"
         fill_in "Subtitle", with: "Sous-titres en Français"
         fill_in_ckeditor "Content", with: "Contenu en Français"
@@ -57,11 +57,11 @@ describe "Admin edit translatable records", :admin do
 
         expect(page).to have_ckeditor "Content", with: "Content in English"
 
-        select "Español", from: :select_language
+        select "Español", from: "Current language"
 
         expect(page).to have_ckeditor "Content", with: "Contenido en español"
 
-        select "Français", from: :select_language
+        select "Français", from: "Current language"
 
         expect(page).to have_ckeditor "Content", with: "Contenu en Français"
       end
@@ -74,7 +74,7 @@ describe "Admin edit translatable records", :admin do
       scenario "Maintains existing translations" do
         visit path
 
-        select "Français", from: :add_language
+        select "Français", from: "Add language"
         fill_in "Version title", with: "Titre en Français"
         click_link class: "fullscreen-toggle"
         fill_in "Text", with: "Texte en Français"
@@ -87,13 +87,13 @@ describe "Admin edit translatable records", :admin do
         expect(page).to have_field "Text", with: "Text in English"
 
         click_link class: "fullscreen-toggle"
-        select "Español", from: :select_language
+        select "Español", from: "Current language"
         click_link class: "fullscreen-toggle"
 
         expect(page).to have_field "Text", with: "Texto en español"
 
         click_link class: "fullscreen-toggle"
-        select "Français", from: :select_language
+        select "Français", from: "Current language"
         click_link class: "fullscreen-toggle"
 
         expect(page).to have_field "Text", with: "Texte en Français"
@@ -107,7 +107,7 @@ describe "Admin edit translatable records", :admin do
       scenario "Adds a translation for that locale" do
         visit path
 
-        select "Português brasileiro", from: :add_language
+        select "Português brasileiro", from: "Add language"
         fill_in "Question", with: "Português"
         click_button "Save changes"
 
@@ -128,13 +128,13 @@ describe "Admin edit translatable records", :admin do
       scenario "Shows validation erros" do
         visit edit_admin_budget_path(translatable)
 
-        select "Français", from: :add_language
+        select "Français", from: "Add language"
         fill_in "Name", with: ""
         click_button "Update Budget"
 
         expect(page).to have_css "#error_explanation"
 
-        select "Français", from: :select_language
+        select "Français", from: "Current language"
 
         expect(page).to have_field "Name", with: "", class: "is-invalid-input"
       end
@@ -146,14 +146,14 @@ describe "Admin edit translatable records", :admin do
       scenario "Shows validation errors" do
         visit edit_admin_budget_budget_investment_path(translatable.budget, translatable)
 
-        select "Français", from: :add_language
+        select "Français", from: "Add language"
         fill_in "Title", with: "Titre en Français"
         fill_in_ckeditor "Description", with: ""
         click_button "Update"
 
         expect(page).to have_css "#error_explanation"
 
-        select "Français", from: :select_language
+        select "Français", from: "Current language"
 
         expect(page).to have_ckeditor "Description", with: ""
       end
@@ -165,7 +165,7 @@ describe "Admin edit translatable records", :admin do
       scenario "Shows validation errors" do
         visit edit_admin_legislation_process_draft_version_path(translatable.process, translatable)
 
-        select "Français", from: :add_language
+        select "Français", from: "Add language"
         fill_in "Version title", with: "Titre en Français"
         click_link class: "fullscreen-toggle"
         fill_in "Text", with: ""
@@ -174,7 +174,7 @@ describe "Admin edit translatable records", :admin do
 
         expect(page).to have_css "#error_explanation"
 
-        select "Français", from: :select_language
+        select "Français", from: "Current language"
         click_link class: "fullscreen-toggle"
 
         expect(page).to have_field "Text", with: "", class: "is-invalid-input"
@@ -190,7 +190,7 @@ describe "Admin edit translatable records", :admin do
       scenario "Changes the existing translation" do
         visit path
 
-        select "Español", from: :select_language
+        select "Español", from: "Current language"
 
         within(".translatable-fields") do
           fill_in "Title", with: "Título corregido"
@@ -221,7 +221,7 @@ describe "Admin edit translatable records", :admin do
       scenario "Changes the existing translation" do
         visit path
 
-        select "Español", from: :select_language
+        select "Español", from: "Current language"
 
         within(".translatable-fields") do
           fill_in "Answer", with: "Respuesta corregida"
@@ -266,7 +266,7 @@ describe "Admin edit translatable records", :admin do
 
       scenario "Show validation errors" do
         visit edit_admin_banner_path(translatable)
-        select "Español", from: :select_language
+        select "Español", from: "Current language"
 
         expect(page).to have_field "Title", with: "Title en español"
 
@@ -275,7 +275,7 @@ describe "Admin edit translatable records", :admin do
 
         expect(page).to have_css "#error_explanation"
 
-        select "Español", from: :select_language
+        select "Español", from: "Current language"
 
         expect(page).to have_field "Title", with: "", class: "is-invalid-input"
       end
@@ -287,7 +287,7 @@ describe "Admin edit translatable records", :admin do
       scenario "Shows validation errors" do
         visit edit_admin_legislation_process_draft_version_path(translatable.process, translatable)
 
-        select "Español", from: :select_language
+        select "Español", from: "Current language"
         click_link class: "fullscreen-toggle"
 
         expect(page).to have_field "Text", with: "Texto en español"
@@ -298,7 +298,7 @@ describe "Admin edit translatable records", :admin do
 
         expect(page).to have_css "#error_explanation"
 
-        select "Español", from: :select_language
+        select "Español", from: "Current language"
         click_link class: "fullscreen-toggle"
 
         expect(page).to have_field "Text", with: ""
@@ -338,17 +338,17 @@ describe "Admin edit translatable records", :admin do
     scenario "Keeps the other languages" do
       visit path
 
-      select "Español", from: :select_language
+      select "Español", from: "Current language"
       click_link "Remove language"
 
-      expect(page).not_to have_select :select_language, with_options: ["Español"]
+      expect(page).not_to have_select "Current language", with_options: ["Español"]
 
       click_button "Save group"
 
       visit path
 
-      expect(page).not_to have_select :select_language, with_options: ["Español"]
-      expect(page).to have_select :select_language, with_options: ["English"]
+      expect(page).not_to have_select "Current language", with_options: ["Español"]
+      expect(page).to have_select "Current language", with_options: ["English"]
     end
   end
 
@@ -389,10 +389,10 @@ describe "Admin edit translatable records", :admin do
     scenario "Doesn't remove the translation" do
       visit path
 
-      select "Español", from: :select_language
+      select "Español", from: "Current language"
       click_link "Remove language"
 
-      select "English", from: :select_language
+      select "English", from: "Current language"
       fill_in "Question", with: ""
       click_button "Save"
 
@@ -402,7 +402,7 @@ describe "Admin edit translatable records", :admin do
       expect_not_to_have_language "Español"
 
       visit path
-      select "Español", from: :select_language
+      select "Español", from: "Current language"
 
       expect(page).to have_field "Question", with: "Pregunta en español"
     end
@@ -417,9 +417,9 @@ describe "Admin edit translatable records", :admin do
 
         visit edit_admin_admin_notification_path(translatable)
 
-        select "English", from: :select_language
+        select "English", from: "Current language"
         click_link "Remove language"
-        select "Español", from: :select_language
+        select "Español", from: "Current language"
         click_link "Remove language"
 
         click_button "Update notification"
@@ -436,9 +436,9 @@ describe "Admin edit translatable records", :admin do
 
         visit edit_admin_budget_budget_phase_path(translatable.budget, translatable)
 
-        select "English", from: :select_language
+        select "English", from: "Current language"
         click_link "Remove language"
-        select "Español", from: :select_language
+        select "Español", from: "Current language"
         click_link "Remove language"
 
         click_button "Save changes"
@@ -458,9 +458,9 @@ describe "Admin edit translatable records", :admin do
 
         visit edit_admin_active_polls_path(translatable)
 
-        select "English", from: :select_language
+        select "English", from: "Current language"
         click_link "Remove language"
-        select "Español", from: :select_language
+        select "Español", from: "Current language"
         click_link "Remove language"
         click_button "Save"
 
@@ -498,7 +498,7 @@ describe "Admin edit translatable records", :admin do
 
       expect(page).to have_field "contents_content_#{content.key}values_value_en", with: "Value in English"
 
-      select "Español", from: :select_language
+      select "Español", from: "Current language"
 
       expect(page).to have_field "contents_content_#{content.key}values_value_es", with: "Value en español"
     end
@@ -506,10 +506,10 @@ describe "Admin edit translatable records", :admin do
     scenario "Select a locale and add it to the form" do
       visit path
 
-      select "Français", from: :add_language
+      select "Français", from: "Add language"
 
       expect_to_have_language_selected "Français"
-      expect(page).to have_select :add_language, selected: "Add language"
+      expect(page).to have_select "Add language", selected: "Add language"
       expect(page).to have_field "contents_content_#{content.key}values_value_fr"
     end
 
@@ -523,7 +523,7 @@ describe "Admin edit translatable records", :admin do
       scenario "Increase description count after add new language" do
         visit path
 
-        select "Français", from: :add_language
+        select "Français", from: "Add language"
 
         expect(page).to have_content "3 languages in use"
       end

--- a/spec/system/translatable_spec.rb
+++ b/spec/system/translatable_spec.rb
@@ -43,7 +43,7 @@ describe "Public area translatable records" do
       fill_in_new_investment_title with: "My awesome project"
       fill_in_ckeditor "Description", with: "Everything is awesome!"
 
-      select "Français", from: :add_language
+      select "Français", from: "Add language"
       fill_in_new_investment_title with: "Titre en Français"
       fill_in_ckeditor "Description", with: "Contenu en Français"
 
@@ -56,7 +56,7 @@ describe "Public area translatable records" do
     scenario "Add only single translation at once not having the current locale" do
       visit new_proposal_path
       click_link "Remove language"
-      select "Français", from: :add_language
+      select "Français", from: "Add language"
 
       fill_in_new_proposal_title with: "Titre en Français"
       fill_in "Proposal summary", with: "Résumé en Français"
@@ -71,7 +71,7 @@ describe "Public area translatable records" do
 
       visit new_budget_investment_path(budget)
       click_link "Remove language"
-      select "Português brasileiro", from: :add_language
+      select "Português brasileiro", from: "Add language"
       fill_in_new_investment_title with: "Titre en Français"
       fill_in_ckeditor "Description", with: "Contenu en Français"
 
@@ -123,7 +123,7 @@ describe "Public area translatable records" do
     scenario "Select a locale and add it to the form" do
       visit new_budget_investment_path(create(:budget))
 
-      select "Français", from: :add_language
+      select "Français", from: "Add language"
 
       expect(page).to have_field "Title", with: ""
     end
@@ -147,7 +147,7 @@ describe "Public area translatable records" do
       scenario "Increase description count after add new language" do
         visit new_proposal_path
 
-        select "Español", from: :add_language
+        select "Español", from: "Add language"
 
         expect(page).to have_content "2 languages in use"
       end
@@ -195,7 +195,7 @@ describe "Public area translatable records" do
         scenario "Changes the existing translation" do
           visit path
 
-          select "Español", from: :select_language
+          select "Español", from: "Current language"
 
           fill_in "Debate title", with: "Título corregido"
           fill_in_ckeditor "Initial debate text", with: "Texto corregido"
@@ -218,7 +218,7 @@ describe "Public area translatable records" do
 
         scenario "Show validation errors" do
           visit edit_proposal_path(translatable)
-          select "Español", from: :select_language
+          select "Español", from: "Current language"
 
           expect(page).to have_field "Proposal title", with: "Título en español"
 
@@ -227,7 +227,7 @@ describe "Public area translatable records" do
 
           expect(page).to have_css "#error_explanation"
 
-          select "Español", from: :select_language
+          select "Español", from: "Current language"
 
           expect(page).to have_field "Proposal title", with: "", class: "is-invalid-input"
         end


### PR DESCRIPTION
## Objectives

* Make it easier (or, in some cases even possible) for people using screen readers to access every form input in the application

## Notes

:warning: Before merging, remove the modifications in the `visit` method or decide what to do regarding automated tests for accessibility.