### PR TITLE
Do not use third-party cookies in embedded videos

### DIFF
--- a/app/components/shared/embedded_video_component.html.erb
+++ b/app/components/shared/embedded_video_component.html.erb
@@ -1,0 +1,5 @@
+<div class="small-12 medium-7 small-centered">
+  <div class="flex-video">
+    <div id="js-embedded-video" data-video-code="<%= embedded_video_code %>"></div>
+  </div>
+</div>

--- a/app/components/shared/embedded_video_component.rb
+++ b/app/components/shared/embedded_video_component.rb
@@ -43,9 +43,9 @@ class Shared::EmbeddedVideoComponent < ApplicationComponent
 
     def src
       if server == "Vimeo"
-        "https://player.vimeo.com/video/"
+        "https://player.vimeo.com/video/#{match[2]}?dnt=1"
       elsif server == "YouTube"
-        "https://www.youtube-nocookie.com/embed/"
+        "https://www.youtube-nocookie.com/embed/#{match[2]}"
       end
     end
 
@@ -54,6 +54,6 @@ class Shared::EmbeddedVideoComponent < ApplicationComponent
     end
 
     def iframe_attributes
-      tag.attributes(src: "#{src}#{match[2]}", style: "border:0;", allowfullscreen: true, title: title)
+      tag.attributes(src: src, style: "border:0;", allowfullscreen: true, title: title)
     end
 end

--- a/app/components/shared/embedded_video_component.rb
+++ b/app/components/shared/embedded_video_component.rb
@@ -12,8 +12,6 @@ class Shared::EmbeddedVideoComponent < ApplicationComponent
   def embedded_video_code
     if match && match[2]
       "<iframe #{iframe_attributes}></iframe>"
-    else
-      ""
     end
   end
 

--- a/app/components/shared/embedded_video_component.rb
+++ b/app/components/shared/embedded_video_component.rb
@@ -1,7 +1,17 @@
-module EmbedVideosHelper
-  def embedded_video_code(resource)
-    link = resource.video_url
-    title = t("proposals.show.embed_video_title", proposal: resource.title)
+class Shared::EmbeddedVideoComponent < ApplicationComponent
+  attr_reader :record
+
+  def initialize(record)
+    @record = record
+  end
+
+  def render?
+    record.video_url.present?
+  end
+
+  def embedded_video_code
+    link = record.video_url
+    title = t("proposals.show.embed_video_title", proposal: record.title)
     if link =~ /vimeo.*/
       server = "Vimeo"
     elsif link =~ /youtu*.*/
@@ -9,10 +19,10 @@ module EmbedVideosHelper
     end
 
     if server == "Vimeo"
-      reg_exp = resource.class::VIMEO_REGEX
+      reg_exp = record.class::VIMEO_REGEX
       src = "https://player.vimeo.com/video/"
     elsif server == "YouTube"
-      reg_exp = resource.class::YOUTUBE_REGEX
+      reg_exp = record.class::YOUTUBE_REGEX
       src = "https://www.youtube.com/embed/"
     end
 

--- a/app/components/shared/embedded_video_component.rb
+++ b/app/components/shared/embedded_video_component.rb
@@ -45,7 +45,7 @@ class Shared::EmbeddedVideoComponent < ApplicationComponent
       if server == "Vimeo"
         "https://player.vimeo.com/video/"
       elsif server == "YouTube"
-        "https://www.youtube.com/embed/"
+        "https://www.youtube-nocookie.com/embed/"
       end
     end
 

--- a/app/components/shared/embedded_video_component.rb
+++ b/app/components/shared/embedded_video_component.rb
@@ -33,7 +33,7 @@ class Shared::EmbeddedVideoComponent < ApplicationComponent
       end
     end
 
-    def reg_exp
+    def regex
       if server == "Vimeo"
         record.class::VIMEO_REGEX
       elsif server == "YouTube"
@@ -50,7 +50,7 @@ class Shared::EmbeddedVideoComponent < ApplicationComponent
     end
 
     def match
-      @match ||= link.match(reg_exp) if reg_exp
+      @match ||= link.match(regex) if regex
     end
 
     def iframe_attributes

--- a/app/components/shared/embedded_video_component.rb
+++ b/app/components/shared/embedded_video_component.rb
@@ -10,30 +10,52 @@ class Shared::EmbeddedVideoComponent < ApplicationComponent
   end
 
   def embedded_video_code
-    link = record.video_url
-    title = t("proposals.show.embed_video_title", proposal: record.title)
-    if link =~ /vimeo.*/
-      server = "Vimeo"
-    elsif link =~ /youtu*.*/
-      server = "YouTube"
-    end
-
-    if server == "Vimeo"
-      reg_exp = record.class::VIMEO_REGEX
-      src = "https://player.vimeo.com/video/"
-    elsif server == "YouTube"
-      reg_exp = record.class::YOUTUBE_REGEX
-      src = "https://www.youtube.com/embed/"
-    end
-
-    if reg_exp
-      match = link.match(reg_exp)
-    end
-
     if match && match[2]
-      '<iframe src="' + src + match[2] + '" style="border:0;" allowfullscreen title="' + title + '"></iframe>'
+      "<iframe #{iframe_attributes}></iframe>"
     else
       ""
     end
   end
+
+  private
+
+    def link
+      record.video_url
+    end
+
+    def title
+      t("proposals.show.embed_video_title", proposal: record.title)
+    end
+
+    def server
+      if link =~ /vimeo.*/
+        "Vimeo"
+      elsif link =~ /youtu*.*/
+        "YouTube"
+      end
+    end
+
+    def reg_exp
+      if server == "Vimeo"
+        record.class::VIMEO_REGEX
+      elsif server == "YouTube"
+        record.class::YOUTUBE_REGEX
+      end
+    end
+
+    def src
+      if server == "Vimeo"
+        "https://player.vimeo.com/video/"
+      elsif server == "YouTube"
+        "https://www.youtube.com/embed/"
+      end
+    end
+
+    def match
+      @match ||= link.match(reg_exp) if reg_exp
+    end
+
+    def iframe_attributes
+      tag.attributes(src: "#{src}#{match[2]}", style: "border:0;", allowfullscreen: true, title: title)
+    end
 end

--- a/app/helpers/embed_videos_helper.rb
+++ b/app/helpers/embed_videos_helper.rb
@@ -1,7 +1,4 @@
 module EmbedVideosHelper
-  VIMEO_REGEX = /vimeo.*(staffpicks\/|channels\/|videos\/|video\/|\/)([^#\&\?]*).*/
-  YOUTUBE_REGEX = /youtu.*(be\/|v\/|u\/\w\/|embed\/|watch\?v=|\&v=)([^#\&\?]*).*/
-
   def embedded_video_code(resource)
     link = resource.video_url
     title = t("proposals.show.embed_video_title", proposal: resource.title)
@@ -12,10 +9,10 @@ module EmbedVideosHelper
     end
 
     if server == "Vimeo"
-      reg_exp = VIMEO_REGEX
+      reg_exp = resource.class::VIMEO_REGEX
       src = "https://player.vimeo.com/video/"
     elsif server == "YouTube"
-      reg_exp = YOUTUBE_REGEX
+      reg_exp = resource.class::YOUTUBE_REGEX
       src = "https://www.youtube.com/embed/"
     end
 
@@ -28,13 +25,5 @@ module EmbedVideosHelper
     else
       ""
     end
-  end
-
-  def valid_video_url?
-    return if video_url.blank?
-    return if video_url.match(VIMEO_REGEX)
-    return if video_url.match(YOUTUBE_REGEX)
-
-    errors.add(:video_url, :invalid)
   end
 end

--- a/app/models/concerns/videoable.rb
+++ b/app/models/concerns/videoable.rb
@@ -1,0 +1,28 @@
+module Videoable
+  extend ActiveSupport::Concern
+
+  included do
+    validate :valid_video_url?
+  end
+
+  VIMEO_REGEX = /vimeo.*(staffpicks\/|channels\/|videos\/|video\/|\/)([^#\&\?]*).*/
+  YOUTUBE_REGEX = /youtu.*(be\/|v\/|u\/\w\/|embed\/|watch\?v=|\&v=)([^#\&\?]*).*/
+
+  def valid_video_url?
+    url = send(video_url_field)
+
+    return if url.blank?
+    return if url.match(VIMEO_REGEX)
+    return if url.match(YOUTUBE_REGEX)
+
+    errors.add(video_url_field, :invalid)
+  end
+
+  def video_url_field
+    if has_attribute?(:video_url)
+      :video_url
+    else
+      :url
+    end
+  end
+end

--- a/app/models/poll/question/answer/video.rb
+++ b/app/models/poll/question/answer/video.rb
@@ -1,17 +1,6 @@
 class Poll::Question::Answer::Video < ApplicationRecord
   belongs_to :answer, class_name: "Poll::Question::Answer"
-
-  VIMEO_REGEX = /vimeo.*(staffpicks\/|channels\/|videos\/|video\/|\/)([^#\&\?]*).*/
-  YOUTUBE_REGEX = /youtu.*(be\/|v\/|u\/\w\/|embed\/|watch\?v=|\&v=)([^#\&\?]*).*/
+  include Videoable
 
   validates :title, presence: true
-  validate :valid_url?
-
-  def valid_url?
-    return if url.blank?
-    return if url.match(VIMEO_REGEX)
-    return if url.match(YOUTUBE_REGEX)
-
-    errors.add(:url, :invalid)
-  end
 end

--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -14,7 +14,7 @@ class Proposal < ApplicationRecord
   include Mappable
   include Notifiable
   include Documentable
-  include EmbedVideosHelper
+  include Videoable
   include Relationable
   include Milestoneable
   include Randomizable
@@ -58,8 +58,6 @@ class Proposal < ApplicationRecord
             inclusion: { in: ->(*) { RETIRE_OPTIONS }}, unless: -> { retired_at.blank? }
 
   validates :terms_of_service, acceptance: { allow_nil: false }, on: :create
-
-  validate :valid_video_url?
 
   before_validation :set_responsible_name
 

--- a/app/views/legislation/proposals/show.html.erb
+++ b/app/views/legislation/proposals/show.html.erb
@@ -65,13 +65,7 @@
 
         <blockquote><%= @proposal.summary %></blockquote>
 
-        <% if @proposal.video_url.present? %>
-          <div class="small-12 medium-7 small-centered">
-            <div class="flex-video">
-              <div id="js-embedded-video" data-video-code="<%= embedded_video_code(@proposal) %>"></div>
-            </div>
-          </div>
-        <% end %>
+        <%= render Shared::EmbeddedVideoComponent.new(@proposal) %>
 
         <%= auto_link_already_sanitized_html wysiwyg(@proposal.description) %>
 

--- a/app/views/proposals/_info.html.erb
+++ b/app/views/proposals/_info.html.erb
@@ -30,13 +30,7 @@
 
 <blockquote><%= @proposal.summary %></blockquote>
 
-<% if @proposal.video_url.present? %>
-  <div class="small-12 medium-7 small-centered">
-    <div class="flex-video">
-      <div id="js-embedded-video" data-video-code="<%= embedded_video_code(@proposal) %>"></div>
-    </div>
-  </div>
-<% end %>
+<%= render Shared::EmbeddedVideoComponent.new(@proposal) %>
 
 <%= auto_link_already_sanitized_html wysiwyg(@proposal.description) %>
 

--- a/spec/components/shared/embedded_video_component_spec.rb
+++ b/spec/components/shared/embedded_video_component_spec.rb
@@ -24,7 +24,7 @@ describe Shared::EmbeddedVideoComponent do
 
     it "embeds a youtube video for youtube URLs" do
       allow(record).to receive(:video_url).and_return "http://www.youtube.com/watch?v=a7UFm6ErMPU"
-      embed_url = "https://www.youtube.com/embed/a7UFm6ErMPU"
+      embed_url = "https://www.youtube-nocookie.com/embed/a7UFm6ErMPU"
 
       render_inline component
 

--- a/spec/components/shared/embedded_video_component_spec.rb
+++ b/spec/components/shared/embedded_video_component_spec.rb
@@ -1,0 +1,43 @@
+require "rails_helper"
+
+describe Shared::EmbeddedVideoComponent do
+  describe "src attribute" do
+    before do
+      dummy_class = Class.new do
+        include ActiveModel::Model
+        attr_accessor :title, :video_url
+
+        include Videoable
+      end
+
+      stub_const("DummyClass", dummy_class)
+    end
+
+    let(:record) { DummyClass.new(title: "Dummy Video", video_url: "") }
+    let(:component) { Shared::EmbeddedVideoComponent.new(record) }
+
+    it "does not render anything for empty URls" do
+      render_inline component
+
+      expect(page).not_to be_rendered
+    end
+
+    it "embeds a youtube video for youtube URLs" do
+      allow(record).to receive(:video_url).and_return "http://www.youtube.com/watch?v=a7UFm6ErMPU"
+      embed_url = "https://www.youtube.com/embed/a7UFm6ErMPU"
+
+      render_inline component
+
+      expect(page).to have_css "[data-video-code*='src=\"#{embed_url}\"']"
+    end
+
+    it "embeds a vimeo video for vimeo URLs" do
+      allow(record).to receive(:video_url).and_return "https://vimeo.com/7232823"
+      embed_url = "https://player.vimeo.com/video/7232823"
+
+      render_inline component
+
+      expect(page).to have_css "[data-video-code*='src=\"#{embed_url}\"']"
+    end
+  end
+end

--- a/spec/components/shared/embedded_video_component_spec.rb
+++ b/spec/components/shared/embedded_video_component_spec.rb
@@ -33,7 +33,7 @@ describe Shared::EmbeddedVideoComponent do
 
     it "embeds a vimeo video for vimeo URLs" do
       allow(record).to receive(:video_url).and_return "https://vimeo.com/7232823"
-      embed_url = "https://player.vimeo.com/video/7232823"
+      embed_url = "https://player.vimeo.com/video/7232823?dnt=1"
 
       render_inline component
 

--- a/spec/system/proposals_spec.rb
+++ b/spec/system/proposals_spec.rb
@@ -315,7 +315,7 @@ describe "Proposals" do
       visit proposal_path(proposal)
 
       within "#js-embedded-video" do
-        expect(page).to have_css "iframe[src='https://player.vimeo.com/video/7232823']"
+        expect(page).to have_css "iframe[src='https://player.vimeo.com/video/7232823?dnt=1']"
       end
     end
 

--- a/spec/system/proposals_spec.rb
+++ b/spec/system/proposals_spec.rb
@@ -301,23 +301,30 @@ describe "Proposals" do
   context "Embedded video" do
     scenario "Show YouTube video" do
       proposal = create(:proposal, video_url: "http://www.youtube.com/watch?v=a7UFm6ErMPU")
+
       visit proposal_path(proposal)
-      expect(page).to have_css "div[id='js-embedded-video']"
-      expect(page.html).to include "https://www.youtube.com/embed/a7UFm6ErMPU"
+
+      within "#js-embedded-video" do
+        expect(page).to have_css "iframe[src='https://www.youtube.com/embed/a7UFm6ErMPU']"
+      end
     end
 
     scenario "Show Vimeo video" do
       proposal = create(:proposal, video_url: "https://vimeo.com/7232823")
+
       visit proposal_path(proposal)
-      expect(page).to have_css "div[id='js-embedded-video']"
-      expect(page.html).to include "https://player.vimeo.com/video/7232823"
+
+      within "#js-embedded-video" do
+        expect(page).to have_css "iframe[src='https://player.vimeo.com/video/7232823']"
+      end
     end
 
     scenario "Dont show video" do
       proposal = create(:proposal, video_url: nil)
 
       visit proposal_path(proposal)
-      expect(page).not_to have_css "div[id='js-embedded-video']"
+
+      expect(page).not_to have_css "#js-embedded-video"
     end
   end
 

--- a/spec/system/proposals_spec.rb
+++ b/spec/system/proposals_spec.rb
@@ -305,7 +305,7 @@ describe "Proposals" do
       visit proposal_path(proposal)
 
       within "#js-embedded-video" do
-        expect(page).to have_css "iframe[src='https://www.youtube.com/embed/a7UFm6ErMPU']"
+        expect(page).to have_css "iframe[src='https://www.youtube-nocookie.com/embed/a7UFm6ErMPU']"
       end
     end
 


### PR DESCRIPTION
## References

* [Turn on privacy-enhanced mode embedding YouTube videos](https://support.google.com/youtube/answer/171780#zippy=%2Cturn-on-privacy-enhanced-mode)
* [Vimeo Player parameters overview](https://help.vimeo.com/hc/en-us/articles/12426260232977-Player-parameters-overview)

## Objectives

* Don't store third-party cookies when people watch a YouTube/Vimeo video embedded in a Consul Democracy installation
* Refactor the code rendering embedded videos

## Notes

Even with these changes, Vimeo still stores cookies that we cannot avoid; quoting from Vimeo player parameters overview:
    
> When DNT is enabled, Vimeo deploys one essential cookie via the embeddable player:
> * The __cf_bm cookie, which is part of Cloudflare's Bot Management service and helps mitigate risk associated with spam and bot traffic.

Not sure whether Google stores a NID cookie when playing YouTube videos :thinking:. I haven't been  able to reproduce it.

## Sponsored
<p align="center">
<strong>Functionality developed by</strong>
</p>
<p align="center">
<img src="https://github.com/consuldemocracy/consuldemocracy/assets/16189/b06eadef-54a8-4373-803e-7bd9d03392ad">
</p>
