### PR TITLE
Group people by age instead of birth year in stats 

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -120,7 +120,10 @@ class User < ApplicationRecord
     where("username ILIKE ? OR email ILIKE ? OR document_number ILIKE ?", search, search, search)
   end
   scope :between_ages, ->(from, to, at_time: Time.current) do
-    where(date_of_birth: (at_time - to.years).beginning_of_year..(at_time - from.years).end_of_year)
+    start_date = at_time - (to + 1).years + 1.day
+    end_date = at_time - from.years
+
+    where(date_of_birth: start_date.beginning_of_day..end_date.end_of_day)
   end
 
   before_validation :clean_document_number

--- a/spec/models/budget/stats_spec.rb
+++ b/spec/models/budget/stats_spec.rb
@@ -159,7 +159,7 @@ describe Budget::Stats do
   describe "#participants_by_age" do
     it "returns the age groups hash" do
       [21, 22, 23, 23, 34, 42, 43, 44, 50, 51].each do |age|
-        create(:user, date_of_birth: budget.phases.balloting.ends_at - age.years)
+        create(:user, date_of_birth: budget.phases.balloting.ends_at - age.years - rand(0..11).months)
       end
 
       allow(stats).to receive(:participants).and_return(User.all)
@@ -182,7 +182,7 @@ describe Budget::Stats do
       budget = travel_to(50.years.ago) { create(:budget, :finished) }
 
       [21, 22, 23, 23, 34, 42, 43, 44, 50, 51].each do |age|
-        create(:user, date_of_birth: budget.phases.balloting.ends_at - age.years)
+        create(:user, date_of_birth: budget.phases.balloting.ends_at - age.years - rand(0..11).months)
       end
 
       stats = Budget::Stats.new(budget)

--- a/spec/models/budget/stats_spec.rb
+++ b/spec/models/budget/stats_spec.rb
@@ -159,7 +159,7 @@ describe Budget::Stats do
   describe "#participants_by_age" do
     it "returns the age groups hash" do
       [21, 22, 23, 23, 34, 42, 43, 44, 50, 51].each do |age|
-        create(:user, date_of_birth: age.years.ago)
+        create(:user, date_of_birth: budget.phases.balloting.ends_at - age.years)
       end
 
       allow(stats).to receive(:participants).and_return(User.all)
@@ -179,15 +179,13 @@ describe Budget::Stats do
     end
 
     it "returns stats based on what happened when the voting took place" do
-      travel_to(50.years.ago) do
-        [21, 22, 23, 23, 34, 42, 43, 44, 50, 51].each do |age|
-          create(:user, date_of_birth: age.years.ago)
-        end
+      budget = travel_to(50.years.ago) { create(:budget, :finished) }
 
-        create(:budget, :finished)
+      [21, 22, 23, 23, 34, 42, 43, 44, 50, 51].each do |age|
+        create(:user, date_of_birth: budget.phases.balloting.ends_at - age.years)
       end
 
-      stats = Budget::Stats.new(Budget.last)
+      stats = Budget::Stats.new(budget)
       allow(stats).to receive(:participants).and_return(User.all)
 
       expect(stats.participants_by_age["16 - 19"][:count]).to eq 0

--- a/spec/models/poll/stats_spec.rb
+++ b/spec/models/poll/stats_spec.rb
@@ -169,7 +169,7 @@ describe Poll::Stats do
     it "returns stats based on what happened when the voting took place" do
       travel_to(100.years.ago) do
         [16, 18, 32, 32, 33, 34, 64, 65, 71, 73, 90, 99, 105].each do |age|
-          create(:user, date_of_birth: age.years.ago)
+          create(:user, date_of_birth: age.years.ago - rand(0..11).months)
         end
 
         create(:poll, starts_at: 1.minute.from_now, ends_at: 2.minutes.from_now)


### PR DESCRIPTION
## References

* This issue was introduced in commit 132397b61
* Some of the updated tests were introduced in #5533

## Objectives

* Make age stats more accurate
* Make tests checking age stats more accurate

## Notes

Some tests were failing since June the 1st because, when creating a budget in the tests on June the 1st, its balloting phase would end on the following January (since, by default, each budget phase lasts a month). Since people were considered as having a different age on June than on the following January, the tests were failing.