### PR TITLE
Add new GraphQL types for budget investments

### DIFF
--- a/app/graphql/types/budget_investment_type.rb
+++ b/app/graphql/types/budget_investment_type.rb
@@ -9,5 +9,6 @@ module Types
     field :location, String, null: true
     field :comments, Types::CommentType.connection_type, null: true
     field :comments_count, Integer, null: true
+    field :milestones, Types::MilestoneType.connection_type, null: true
   end
 end

--- a/app/graphql/types/budget_investment_type.rb
+++ b/app/graphql/types/budget_investment_type.rb
@@ -1,0 +1,13 @@
+module Types
+  class BudgetInvestmentType < Types::BaseObject
+    field :id, ID, null: false
+    field :public_author, Types::UserType, null: true
+    field :price, GraphQL::Types::BigInt, null: true
+    field :feasibility, String, null: true
+    field :title, String, null: true
+    field :description, String, null: true
+    field :location, String, null: true
+    field :comments, Types::CommentType.connection_type, null: true
+    field :comments_count, Integer, null: true
+  end
+end

--- a/app/graphql/types/budget_type.rb
+++ b/app/graphql/types/budget_type.rb
@@ -1,0 +1,19 @@
+module Types
+  class BudgetType < Types::BaseObject
+    field :id, ID, null: false
+    field :name, String, null: true
+    field :phase, String, null: true
+    field :investments, Types::BudgetInvestmentType.connection_type, "Returns all investments", null: false
+    field :investment, Types::BudgetInvestmentType, null: false do
+      argument :id, ID, required: true, default_value: false
+    end
+
+    def investments
+      Budget::Investment.public_for_api
+    end
+
+    def investment(id:)
+      Budget::Investment.find(id)
+    end
+  end
+end

--- a/app/graphql/types/milestone_type.rb
+++ b/app/graphql/types/milestone_type.rb
@@ -1,0 +1,8 @@
+module Types
+  class MilestoneType < Types::BaseObject
+    field :title, String, null: true
+    field :description, String, null: true
+    field :id, ID, null: false
+    field :publication_date, GraphQL::Types::ISO8601Date, null: true
+  end
+end

--- a/app/graphql/types/proposal_type.rb
+++ b/app/graphql/types/proposal_type.rb
@@ -20,6 +20,7 @@ module Types
     field :title, String, null: true
     field :video_url, String, null: true
     field :votes_for, Types::VoteType.connection_type, null: true
+    field :milestones, Types::MilestoneType.connection_type, null: true
 
     def tags
       object.tags.public_for_api

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -1,5 +1,10 @@
 module Types
   class QueryType < Types::BaseObject
+    field :budgets, Types::BudgetType.connection_type, "Returns all budgets", null: false
+    field :budget, Types::BudgetType, "Returns budget for ID", null: false do
+      argument :id, ID, required: true, default_value: false
+    end
+
     field :comments, Types::CommentType.connection_type, "Returns all comments", null: false
     field :comment, Types::CommentType, "Returns comment for ID", null: false do
       argument :id, ID, required: true, default_value: false
@@ -45,6 +50,14 @@ module Types
     field :votes, Types::VoteType.connection_type, "Returns all votes", null: false
     field :vote, Types::VoteType, "Returns vote for ID", null: false do
       argument :id, ID, required: true, default_value: false
+    end
+
+    def budgets
+      Budget.public_for_api
+    end
+
+    def budget(id:)
+      Budget.find(id)
     end
 
     def comments

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -20,6 +20,11 @@ module Types
       argument :id, ID, required: true, default_value: false
     end
 
+    field :milestones, Types::MilestoneType.connection_type, "Returns all milestones", null: false
+    field :milestone, Types::MilestoneType, "Returns milestone for ID", null: false do
+      argument :id, ID, required: true, default_value: false
+    end
+
     field :proposals, Types::ProposalType.connection_type, "Returns all proposals", null: false
     field :proposal, Types::ProposalType, "Returns proposal for ID", null: false do
       argument :id, ID, required: true, default_value: false
@@ -82,6 +87,14 @@ module Types
 
     def geozone(id:)
       Geozone.find(id)
+    end
+
+    def milestones
+      Milestone.public_for_api
+    end
+
+    def milestone(id:)
+      Milestone.find(id)
     end
 
     def proposals

--- a/app/models/budget.rb
+++ b/app/models/budget.rb
@@ -58,6 +58,7 @@ class Budget < ApplicationRecord
   scope :balloting, -> { where(phase: "balloting") }
   scope :reviewing_ballots, -> { where(phase: "reviewing_ballots") }
   scope :finished, -> { where(phase: "finished") }
+  scope :public_for_api, -> { published }
 
   class << self; undef :open; end
   scope :open, -> { where.not(phase: "finished") }

--- a/app/models/budget/investment.rb
+++ b/app/models/budget/investment.rb
@@ -13,6 +13,7 @@ class Budget
     include Mappable
     include Documentable
     include SDG::Relatable
+    include HasPublicAuthor
 
     acts_as_taggable_on :valuation_tags
     acts_as_votable
@@ -111,6 +112,7 @@ class Budget
     end
 
     scope :for_render, -> { includes(:heading) }
+    scope :public_for_api, -> { where(budget: Budget.public_for_api) }
 
     def self.by_valuator(valuator_id)
       where(budget_valuator_assignments: { valuator_id: valuator_id }).joins(:valuator_assignments)

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -38,7 +38,10 @@ class Comment < ApplicationRecord
   scope :sort_by_flags, -> { order(flags_count: :desc, updated_at: :desc) }
   scope :public_for_api, -> do
     not_valuations
-      .where(commentable: [Debate.public_for_api, Proposal.public_for_api, Poll.public_for_api])
+      .where(commentable: [Debate.public_for_api,
+                           Proposal.public_for_api,
+                           Poll.public_for_api,
+                           Budget::Investment.public_for_api])
   end
 
   scope :sort_by_most_voted, -> { order(confidence_score: :desc, created_at: :desc) }

--- a/app/models/milestone.rb
+++ b/app/models/milestone.rb
@@ -16,6 +16,9 @@ class Milestone < ApplicationRecord
   scope :order_by_publication_date, -> { order(publication_date: :asc, created_at: :asc) }
   scope :published,                 -> { where(publication_date: ..Date.current.end_of_day) }
   scope :with_status,               -> { where.not(status_id: nil) }
+  scope :public_for_api, -> do
+    where(milestoneable: [Proposal.public_for_api, Budget::Investment.public_for_api])
+  end
 
   def self.title_max_length
     80

--- a/docs/en/features/graphql.md
+++ b/docs/en/features/graphql.md
@@ -130,6 +130,8 @@ The models are the following:
 | `User`                  | Users                         |
 | `Debate`                | Debates                       |
 | `Proposal`              | Proposals                     |
+| `Budget`                | Participatory budgets         |
+| `Budget::Investment`    | Budget investments            |
 | `Comment`               | Comments on debates, proposals and other comments |
 | `Geozone`               | Geozones (districts)          |
 | `ProposalNotification`  | Notifications related to proposals |

--- a/docs/en/features/graphql.md
+++ b/docs/en/features/graphql.md
@@ -133,6 +133,7 @@ The models are the following:
 | `Budget`                | Participatory budgets         |
 | `Budget::Investment`    | Budget investments            |
 | `Comment`               | Comments on debates, proposals and other comments |
+| `Milestone`             | Proposals, investments and processes milestones |
 | `Geozone`               | Geozones (districts)          |
 | `ProposalNotification`  | Notifications related to proposals |
 | `Tag`                   | Tags on debates and proposals |

--- a/docs/es/features/graphql.md
+++ b/docs/es/features/graphql.md
@@ -130,6 +130,8 @@ La lista de modelos es la siguiente:
 | `User`                  | Usuarios                     |
 | `Debate`                | Debates                      |
 | `Proposal`              | Propuestas                   |
+| `Budget`                | Presupuestos participativos  |
+| `Budget::Investment`    | Proyectos de gasto           |
 | `Comment`               | Comentarios en debates, propuestas y otros comentarios |
 | `Geozone`               | Geozonas (distritos)         |
 | `ProposalNotification`  | Notificaciones asociadas a propuestas |

--- a/docs/es/features/graphql.md
+++ b/docs/es/features/graphql.md
@@ -133,6 +133,7 @@ La lista de modelos es la siguiente:
 | `Budget`                | Presupuestos participativos  |
 | `Budget::Investment`    | Proyectos de gasto           |
 | `Comment`               | Comentarios en debates, propuestas y otros comentarios |
+| `Milestone`             | Hitos en propuestas, proyectos de gasto y procesos |
 | `Geozone`               | Geozonas (distritos)         |
 | `ProposalNotification`  | Notificaciones asociadas a propuestas |
 | `Tag`                   | Tags en debates y propuestas |

--- a/spec/lib/graphql_spec.rb
+++ b/spec/lib/graphql_spec.rb
@@ -678,6 +678,16 @@ describe "Consul Schema" do
     end
   end
 
+  describe "Milestone" do
+    it "formats publication date like in view" do
+      milestone = create(:milestone, publication_date: Time.zone.parse("2024-07-02 11:45:17"))
+
+      response = execute("{ milestone(id: #{milestone.id}) { id publication_date } }")
+      received_publication_date = dig(response, "data.milestone.publication_date")
+      expect(received_publication_date).to eq "2024-07-02"
+    end
+  end
+
   describe "Budget investment" do
     it "does not include hidden comments" do
       budget = create(:budget)

--- a/spec/lib/graphql_spec.rb
+++ b/spec/lib/graphql_spec.rb
@@ -193,6 +193,17 @@ describe "Consul Schema" do
     end
   end
 
+  describe "Budgets" do
+    it "does not include unpublished budgets" do
+      create(:budget, :drafting, name: "Draft")
+
+      response = execute("{ budgets { edges { node { name } } } }")
+      received_names = extract_fields(response, "budgets", "name")
+
+      expect(received_names).to eq []
+    end
+  end
+
   describe "Debates" do
     it "does not include hidden debates" do
       create(:debate, title: "Visible")
@@ -252,16 +263,17 @@ describe "Consul Schema" do
   end
 
   describe "Comments" do
-    it "only returns comments from proposals, debates and polls" do
+    it "only returns comments from proposals, debates, polls and Budget::Investment" do
       create(:comment, commentable: create(:proposal))
       create(:comment, commentable: create(:debate))
       create(:comment, commentable: create(:poll))
-      build(:comment, commentable: create(:budget_investment)).save!(skip_validation: true)
+      create(:comment, commentable: create(:topic))
+      create(:comment, commentable: create(:budget_investment))
 
       response = execute("{ comments { edges { node { commentable_type } } } }")
       received_commentables = extract_fields(response, "comments", "commentable_type")
 
-      expect(received_commentables).to match_array ["Proposal", "Debate", "Poll"]
+      expect(received_commentables).to match_array ["Proposal", "Debate", "Poll", "Budget::Investment"]
     end
 
     it "displays comments of authors even if public activity is set to false" do
@@ -336,6 +348,19 @@ describe "Consul Schema" do
       expect(received_comments).to match_array ["I can see the poll"]
     end
 
+    it "does not include comments from hidden investments" do
+      visible_investment = create(:budget_investment)
+      hidden_investment  = create(:budget_investment, :hidden)
+
+      create(:comment, commentable: visible_investment, body: "I can see the investment")
+      create(:comment, commentable: hidden_investment, body: "This investment is hidden!")
+
+      response = execute("{ comments { edges { node { body } } } }")
+      received_comments = extract_fields(response, "comments", "body")
+
+      expect(received_comments).to match_array ["I can see the investment"]
+    end
+
     it "does not include comments of debates that are not public" do
       not_public_debate = create(:debate, :hidden)
       not_public_debate_comment = create(:comment, commentable: not_public_debate)
@@ -367,6 +392,16 @@ describe "Consul Schema" do
       received_comments = extract_fields(response, "comments", "body")
 
       expect(received_comments).not_to include(not_public_poll_comment.body)
+    end
+
+    it "does not include comments of investments that are not public" do
+      investment = create(:budget_investment, budget: create(:budget, :drafting))
+      not_public_investment_comment = create(:comment, commentable: investment)
+
+      response = execute("{ comments { edges { node { body } } } }")
+      received_comments = extract_fields(response, "comments", "body")
+
+      expect(received_comments).not_to include(not_public_investment_comment.body)
     end
 
     it "only links public comments" do
@@ -640,6 +675,37 @@ describe "Consul Schema" do
       received_timestamps = extract_fields(response, "votes", "public_created_at")
 
       expect(Time.zone.parse(received_timestamps.first)).to eq Time.zone.parse("2017-12-31 9:00:00")
+    end
+  end
+
+  describe "Budget investment" do
+    it "does not include hidden comments" do
+      budget = create(:budget)
+      investment = create(:budget_investment, budget: budget)
+
+      create(:comment, commentable: investment, body: "Visible")
+      create(:comment, :hidden, commentable: investment, body: "Hidden")
+
+      query = <<~GRAPHQL
+        {
+          budget(id: #{budget.id}) {
+            investment(id: #{investment.id}) {
+              comments {
+                edges {
+                  node {
+                    body
+                  }
+                }
+              }
+            }
+          }
+        }
+      GRAPHQL
+
+      response = execute(query)
+      received_bodies = extract_fields(response, "budget.investment.comments", "body")
+
+      expect(received_bodies).to eq ["Visible"]
     end
   end
 end

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -175,8 +175,14 @@ describe Comment do
       expect(Comment.public_for_api).to be_empty
     end
 
-    it "does not return comments on elements which are not debates or proposals" do
-      create(:comment, commentable: create(:budget_investment))
+    it "returns comments on budget investments" do
+      comment = create(:comment, commentable: create(:budget_investment))
+
+      expect(Comment.public_for_api).to eq [comment]
+    end
+
+    it "does not return comments on elements which are not debates, proposals or budget investments" do
+      create(:comment, commentable: create(:topic))
 
       expect(Comment.public_for_api).to be_empty
     end


### PR DESCRIPTION
For now, in draft only status, as a start of a conversation.
## References

Attempt to close issue #4986 

## Objectives
Provide via GraphQL the like of https://demo.consuldemocracy.org/budgets/1/investments/16/ in JSON 
via the GraphQL API.


## Visual Changes

None. Technical changes only

## Notes

> Mention rake tasks or actions to be done when deploying this changes to a server (if any).
> Explain any caveats, or important things to notice like deprecations (if any).
