### PR TITLE
Update screenshots path in GitHub Actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -71,7 +71,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: screenshots
+          name: screenshots-${{ matrix.ci_node_index }}
           path: tmp/capybara/
   coveralls:
     permissions:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -72,7 +72,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: screenshots
-          path: tmp/screenshots
+          path: tmp/capybara/
   coveralls:
     permissions:
       contents: none


### PR DESCRIPTION
## References

* Continues pull request #5465 (the path for the screenshots was changed when we upgraded to Rails 7.0)
* We're also updating the actions to be compatible with upload-artifact 4, which we started using in pull request #5420

## Objectives

* Access screenshots taken after a test fails on our CI
* Access screenshots when two or more jobs fail in our CI