### PR TITLE
Use logout to sign out in tests 

### DIFF
--- a/spec/system/budget_polls/voter_spec.rb
+++ b/spec/system/budget_polls/voter_spec.rb
@@ -32,8 +32,7 @@ describe "BudgetPolls", :with_frozen_time do
       expect(Poll::Voter.count).to eq(1)
       expect(Poll::Voter.first.origin).to eq("booth")
 
-      visit root_path
-      click_link "Sign out"
+      logout
       login_as(admin.user)
       visit admin_poll_recounts_path(poll)
 

--- a/spec/system/officing/voters_spec.rb
+++ b/spec/system/officing/voters_spec.rb
@@ -74,8 +74,7 @@ describe "Voters" do
                   document_number: "12345678Z")
     expect(user).not_to be_level_two_verified
 
-    visit root_path
-    click_link "Sign out"
+    logout
     login_through_form_as_officer(officer.user)
 
     visit new_officing_residence_path

--- a/spec/system/polls/polls_spec.rb
+++ b/spec/system/polls/polls_spec.rb
@@ -293,8 +293,11 @@ describe "Polls" do
 
       expect(page).to have_content "Vote introduced!"
 
-      visit new_officing_residence_path
+      within("#notice") { click_button "Close" }
       click_link "Sign out"
+
+      expect(page).to have_content "You must sign in or register to continue."
+
       login_as user
       visit poll_path(poll)
 

--- a/spec/system/polls/voter_spec.rb
+++ b/spec/system/polls/voter_spec.rb
@@ -90,8 +90,7 @@ describe "Voter" do
       expect(Poll::Voter.count).to eq(1)
       expect(Poll::Voter.first.origin).to eq("booth")
 
-      visit root_path
-      click_link "Sign out"
+      logout
       login_as(admin.user)
       visit admin_poll_recounts_path(poll)
 
@@ -148,8 +147,7 @@ describe "Voter" do
         vote_for_poll_via_web(poll, question, "Yes")
         expect(Poll::Voter.count).to eq(1)
 
-        click_link "Sign out"
-
+        logout
         login_through_form_as_officer(officer.user)
 
         visit new_officing_residence_path
@@ -165,9 +163,7 @@ describe "Voter" do
 
         vote_for_poll_via_booth
 
-        visit root_path
-        click_link "Sign out"
-
+        logout
         login_as user
         visit poll_path(poll)
 
@@ -178,8 +174,7 @@ describe "Voter" do
                                      "You can not participate again."
         expect(Poll::Voter.count).to eq(1)
 
-        visit root_path
-        click_link "Sign out"
+        logout
         login_as(admin.user)
         visit admin_poll_recounts_path(poll)
 
@@ -199,9 +194,7 @@ describe "Voter" do
       login_through_form_as_officer(officer.user)
       vote_for_poll_via_booth
 
-      visit root_path
-      click_link "Sign out"
-
+      logout
       login_as user
       visit account_path
       click_link "Verify my account"
@@ -219,8 +212,7 @@ describe "Voter" do
                                    "You can not participate again."
       expect(Poll::Voter.count).to eq(1)
 
-      visit root_path
-      click_link "Sign out"
+      logout
       login_as(admin.user)
       visit admin_poll_recounts_path(poll)
 


### PR DESCRIPTION
## References

* The test "Already voted on booth cannot vote on website" has failed in jobs like [test run #7289, job 4](https://github.com/consuldemocracy/consuldemocracy/actions/runs/9548833638/job/26316959620) (see the [test run #7289, job 4 log](https://github.com/user-attachments/files/15873187/run_7289_job_4.txt))
* Some other tests where "Sign out" was involved (like "Voter Origin Voting in booth") have failed in jobs like [test run #7286, job 3](https://github.com/consuldemocracy/consuldemocracy/actions/runs/9548821609/job/26316914585) (see the  [test run #7286, job 3 log](https://github.com/user-attachments/files/15873241/run_7286_job_3.txt))

## Objectives

* Reduce the chance of tests failing after signing out
* Make the code more consistent

## Notes

Here are the screenshots for the failures mentioned above.

For the "Already voted on booth cannot vote on website" test failure:

![The page to participate in a poll contains a message saying "You must sign in or sign up to participate"](https://github.com/consuldemocracy/consuldemocracy/assets/35156/31f06f8e-8513-4a1d-8552-14ba45a01fd5)

For the "Voter Origin Voting in booth" test failure:

![The sign in page contains the message "You must sign in or register to continue"](https://github.com/consuldemocracy/consuldemocracy/assets/35156/613d0dfe-5d4a-43e4-97ee-f8e02e52f534)