### PR TITLE
Fix linters workflow on Dependabot pull requests

### DIFF
--- a/.github/workflows/pronto.yml
+++ b/.github/workflows/pronto.yml
@@ -4,7 +4,7 @@ on: [pull_request]
 jobs:
   pronto:
     runs-on: ubuntu-latest
-    if: github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name && github.actor != 'dependabot'
+    if: github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name && github.actor != 'dependabot[bot]'
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
## References

* Continues #5545

## Objectives

* Make sure Pronto doesn't run on Dependabot pull requests, since it always fails in that situation