### PR TITLE
Fix typo in between_ages spec

### DIFF
--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -472,7 +472,7 @@ describe User do
 
         travel_to "2024-02-29" do
           expect(User.between_ages(22, 23)).to eq [march_1st_user]
-          expect(User.between_ages(23, 24)).to eq [leap_day_user, march_1st_user]
+          expect(User.between_ages(23, 24)).to match_array [leap_day_user, march_1st_user]
           expect(User.between_ages(24, 25)).to eq [leap_day_user]
         end
 


### PR DESCRIPTION
## References

* The affected test was introduced in pull request #5569

## Objectives

* Make sure a test checking users between certain ages behaves consistently

## Notes

The test was failing sometimes because there's no guarantee that the `.between_ages` scope will return the records in a specific order.