### PR TITLE
Adjust permissions in admin locales

### DIFF
--- a/app/components/admin/menu_component.rb
+++ b/app/components/admin/menu_component.rb
@@ -462,7 +462,7 @@ class Admin::MenuComponent < ApplicationComponent
           settings_link,
           tenants_link,
           tags_link,
-          locales_link,
+          (locales_link if I18n.available_locales.many?),
           geozones_link,
           local_census_records_link
         )

--- a/app/controllers/admin/locales_controller.rb
+++ b/app/controllers/admin/locales_controller.rb
@@ -1,6 +1,6 @@
 class Admin::LocalesController < Admin::BaseController
   before_action :set_locales_settings
-  authorize_resource :locales_settings
+  authorize_resource instance_name: :locales_settings, class: "Setting::LocalesSettings"
 
   def show
   end

--- a/spec/components/admin/menu_component_spec.rb
+++ b/spec/components/admin/menu_component_spec.rb
@@ -35,4 +35,28 @@ describe Admin::MenuComponent, controller: Admin::NewslettersController do
       expect(page).to have_css "[aria-current]", exact_text: "Polls"
     end
   end
+
+  describe "#locales_link" do
+    it "is present when two or more locales are available" do
+      render_inline Admin::MenuComponent.new
+
+      expect(page).to have_link "Languages"
+    end
+
+    it "is present when two or more locales are available but only one is enabled" do
+      Setting["locales.enabled"] = "en"
+
+      render_inline Admin::MenuComponent.new
+
+      expect(page).to have_link "Languages"
+    end
+
+    it "is not present when only one locale is available" do
+      allow(I18n).to receive(:available_locales).and_return([:en])
+
+      render_inline Admin::MenuComponent.new
+
+      expect(page).not_to have_link "Languages"
+    end
+  end
 end

--- a/spec/controllers/admin/locales_controller_spec.rb
+++ b/spec/controllers/admin/locales_controller_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+describe Admin::LocalesController do
+  describe "PATCH update" do
+    it "checks permissions to update locales settings" do
+      user = create(:administrator).user
+      restricted_ability = user.ability.tap { |ability| ability.cannot :update, Setting::LocalesSettings }
+
+      sign_in user
+      allow(controller).to receive(:current_ability).and_return(restricted_ability)
+      patch :update, params: { setting_locales_settings: { default: :es, enabled: [:en, :fr] }}
+
+      expect(response).to redirect_to "/"
+      expect(Setting.default_locale).to eq :en
+    end
+  end
+end


### PR DESCRIPTION
## References

* Continues pull request #5243

## Objectives

* Make sure administrators can't update locales if the abilities are configured so locales are read-only
* Hide the link to manage languages when there's only one language available