### PR TITLE
 Use dependabot to update github actions dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,8 @@ updates:
   schedule:
     interval: monthly
   open-pull-requests-limit: 50
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: monthly
+  open-pull-requests-limit: 50

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,8 @@ updates:
   schedule:
     interval: monthly
   open-pull-requests-limit: 50
+  labels:
+    - "dependencies"
 - package-ecosystem: npm
   directory: "/"
   schedule:


### PR DESCRIPTION
## Objectives

* Make it easier to maintain our github actions dependencies
* Remove redundant "ruby" label in dependabot pull requests