### PR TITLE
Improve emails

### DIFF
--- a/app/views/mailer/budget_investment_created.html.erb
+++ b/app/views/mailer/budget_investment_created.html.erb
@@ -5,9 +5,7 @@
   </h1>
 
   <p style="<%= css_for_mailer_text %>">
-    <%= sanitize(
-      t("mailers.budget_investment_created.intro", author: @investment.author.name)
-    ) %>
+    <%= sanitize(t("mailers.budget_investment_created.hi", author: @investment.author.name)) %>
   </p>
 
   <p style="<%= css_for_mailer_text %>">

--- a/app/views/mailer/budget_investment_created.html.erb
+++ b/app/views/mailer/budget_investment_created.html.erb
@@ -43,6 +43,6 @@
   </table>
 
   <p style="<%= css_for_mailer_text %>">
-    <%= t("mailers.budget_investment_created.sincerely") %>
+    <%= t("mailers.sincerely") %>
   </p>
 </td>

--- a/app/views/mailer/budget_investment_selected.html.erb
+++ b/app/views/mailer/budget_investment_selected.html.erb
@@ -5,7 +5,7 @@
   </h1>
 
   <p style="<%= css_for_mailer_text %>">
-    <%= t("mailers.budget_investment_selected.hi") %>
+    <%= sanitize(t("mailers.budget_investment_selected.hi", author: @investment.author.name)) %>
   </p>
 
   <p style="<%= css_for_mailer_text %>">

--- a/app/views/mailer/budget_investment_selected.html.erb
+++ b/app/views/mailer/budget_investment_selected.html.erb
@@ -29,6 +29,6 @@
   </p>
 
   <p style="<%= css_for_mailer_text %>">
-    <%= t("mailers.budget_investment_selected.sincerely") %>
+    <%= t("mailers.sincerely") %>
   </p>
 </td>

--- a/app/views/mailer/budget_investment_unfeasible.html.erb
+++ b/app/views/mailer/budget_investment_unfeasible.html.erb
@@ -29,6 +29,6 @@
   </p>
 
   <p style="<%= css_for_mailer_text %>">
-    <%= t("mailers.budget_investment_unfeasible.sincerely") %>
+    <%= t("mailers.sincerely") %>
   </p>
 </td>

--- a/app/views/mailer/budget_investment_unfeasible.html.erb
+++ b/app/views/mailer/budget_investment_unfeasible.html.erb
@@ -5,7 +5,7 @@
   </h1>
 
   <p style="<%= css_for_mailer_text %>">
-    <%= t("mailers.budget_investment_unfeasible.hi") %>
+    <%= sanitize(t("mailers.budget_investment_unfeasible.hi", author: @investment.author.name)) %>
   </p>
 
   <p style="<%= css_for_mailer_text + css_for_mailer_quote %>">

--- a/app/views/mailer/budget_investment_unselected.html.erb
+++ b/app/views/mailer/budget_investment_unselected.html.erb
@@ -13,6 +13,6 @@
   </p>
 
   <p style="<%= css_for_mailer_text %>">
-    <%= t("mailers.budget_investment_unselected.sincerely") %>
+    <%= t("mailers.sincerely") %>
   </p>
 </td>

--- a/app/views/mailer/budget_investment_unselected.html.erb
+++ b/app/views/mailer/budget_investment_unselected.html.erb
@@ -5,7 +5,7 @@
   </h1>
 
   <p style="<%= css_for_mailer_text %>">
-    <%= t("mailers.budget_investment_unselected.hi") %>
+    <%= sanitize(t("mailers.budget_investment_unselected.hi", author: @investment.author.name)) %>
   </p>
 
   <p style="<%= css_for_mailer_text %>">

--- a/app/views/mailer/comment.html.erb
+++ b/app/views/mailer/comment.html.erb
@@ -31,4 +31,8 @@
       attributes: %w[href style]
     ) %>
   </p>
+
+  <p style="<%= css_for_mailer_text %>">
+    <%= t("mailers.sincerely") %>
+  </p>
 </td>

--- a/app/views/mailer/direct_message_for_receiver.html.erb
+++ b/app/views/mailer/direct_message_for_receiver.html.erb
@@ -3,6 +3,10 @@
     <%= @direct_message.title %>
   </h1>
 
+  <p style="<%= css_for_mailer_text %>">
+    <%= sanitize(t("mailers.direct_message_for_receiver.hi", receiver: @direct_message.receiver.name)) %>
+  </p>
+
   <div style="<%= css_for_mailer_text %>">
     <%= mailer_simple_format(@direct_message.body) %>
   </div>

--- a/app/views/mailer/direct_message_for_receiver.html.erb
+++ b/app/views/mailer/direct_message_for_receiver.html.erb
@@ -33,4 +33,8 @@
       attributes: %w[href style]
     ) %>
   </p>
+
+  <p style="<%= css_for_mailer_text %>">
+    <%= t("mailers.sincerely") %>
+  </p>
 </td>

--- a/app/views/mailer/direct_message_for_sender.html.erb
+++ b/app/views/mailer/direct_message_for_sender.html.erb
@@ -5,6 +5,10 @@
   </h1>
 
   <p style="<%= css_for_mailer_text %>">
+    <%= sanitize(t("mailers.direct_message_for_sender.hi", sender: @direct_message.sender.name)) %>
+  </p>
+
+  <p style="<%= css_for_mailer_text %>">
     <%= sanitize(t("mailers.direct_message_for_sender.text", receiver: @direct_message.receiver.name)) %>
   </p>
 

--- a/app/views/mailer/direct_message_for_sender.html.erb
+++ b/app/views/mailer/direct_message_for_sender.html.erb
@@ -15,4 +15,8 @@
   <div style="<%= css_for_mailer_text %>">
     <%= mailer_simple_format(@direct_message.body) %>
   </div>
+
+  <p style="<%= css_for_mailer_text %>">
+    <%= t("mailers.sincerely") %>
+  </p>
 </td>

--- a/app/views/mailer/email_verification.html.erb
+++ b/app/views/mailer/email_verification.html.erb
@@ -5,6 +5,10 @@
   </h1>
 
   <p style="<%= css_for_mailer_text %>">
+    <%= sanitize(t("mailers.email_verification.hi", user: @user.name)) %>
+  </p>
+
+  <p style="<%= css_for_mailer_text %>">
     <%= t("mailers.email_verification.text") %>
   </p>
 

--- a/app/views/mailer/email_verification.html.erb
+++ b/app/views/mailer/email_verification.html.erb
@@ -33,4 +33,8 @@
   <p style="<%= css_for_mailer_text %>">
     <%= t("mailers.email_verification.thanks") %>
   </p>
+
+  <p style="<%= css_for_mailer_text %>">
+    <%= t("mailers.sincerely") %>
+  </p>
 </td>

--- a/app/views/mailer/evaluation_comment.html.erb
+++ b/app/views/mailer/evaluation_comment.html.erb
@@ -23,4 +23,8 @@
   <div style="<%= css_for_mailer_text + css_for_mailer_quote %>">
     <%= mailer_simple_format(@email.comment.body) %>
   </div>
+
+  <p style="<%= css_for_mailer_text %>">
+    <%= t("mailers.sincerely") %>
+  </p>
 </td>

--- a/app/views/mailer/reply.html.erb
+++ b/app/views/mailer/reply.html.erb
@@ -31,4 +31,8 @@
       attributes: %w[href style]
     ) %>
   </p>
+
+  <p style="<%= css_for_mailer_text %>">
+    <%= t("mailers.sincerely") %>
+  </p>
 </td>

--- a/app/views/mailer/user_invite.html.erb
+++ b/app/views/mailer/user_invite.html.erb
@@ -18,4 +18,8 @@
   <p style="<%= css_for_mailer_text %>">
     <%= t("mailers.user_invite.thanks") %>
   </p>
+
+  <p style="<%= css_for_mailer_text %>">
+    <%= t("mailers.sincerely") %>
+  </p>
 </td>

--- a/config/locales/en/mailers.yml
+++ b/config/locales/en/mailers.yml
@@ -16,6 +16,7 @@ en:
       notifications_link: Notifications
       unsubscribe_text: 'To unsubscribe from these emails, visit %{notifications} and uncheck "%{notification}".'
     email_verification:
+      hi: "Hi <strong>%{user}</strong>,"
       click_here_to_verify: this link
       instructions_2: This email will verify your account with <b>%{document_type} %{document_number}</b>. If these don't belong to you, please don't click on the previous link and ignore this email.
       instructions: To complete the verification of your user account you must click %{verification_link}.
@@ -38,10 +39,12 @@ en:
     direct_message_for_receiver:
       subject: "You have received a new private message"
       reply: Reply to %{sender}
+      hi: "Hi <strong>%{receiver}</strong>,"
       unsubscribe_text: "If you don't want to receive direct messages, visit %{notifications} and uncheck 'Receive emails about direct messages'."
     direct_message_for_sender:
       subject: "You have sent a new private message"
       title: "You have sent a new private message"
+      hi: "Hi <strong>%{sender}</strong>,"
       text: "You have sent a new private message to <strong>%{receiver}</strong> with the content:"
     user_invite:
       ignore: "If you have not requested this invitation don't worry, you can ignore this email."
@@ -53,14 +56,14 @@ en:
     budget_investment_created:
       subject: "Thank you for creating an investment!"
       title: "Thank you for creating an investment!"
-      intro: "Hi <strong>%{author}</strong>,"
+      hi: "Hi <strong>%{author}</strong>,"
       text: "Thank you for creating your investment <strong>%{investment}</strong> for Participatory Budgets <strong>%{budget}</strong>."
       follow: "We will inform you about how the process progresses, which you can also follow on <strong>%{link}</strong>."
       follow_link: "Participatory Budgets"
       share: "Share your project"
     budget_investment_unfeasible:
       title: "Your investment project has been marked as unfeasible"
-      hi: "Dear user,"
+      hi: "Hi <strong>%{author}</strong>,"
       new: "For all these, we invite you to elaborate a <strong>new investment</strong> that adjusts to the conditions of this process. You can do it following this link: %{url}."
       new_href: "new investment project"
       sorry: "Sorry for the inconvenience and we again thank you for your invaluable participation."
@@ -68,14 +71,14 @@ en:
     budget_investment_selected:
       subject: "Your investment project '%{code}' has been selected"
       title: "Your investment project has been selected"
-      hi: "Dear user,"
+      hi: "Hi <strong>%{author}</strong>,"
       share: "Start to get votes, share your investment project on social networks. Share is essential to make it a reality."
       share_button: "Share your investment project"
       thanks: "Thank you again for participating."
     budget_investment_unselected:
       subject: "Your investment project '%{code}' has not been selected"
       title: "Your investment project has not been selected"
-      hi: "Dear user,"
+      hi: "Hi <strong>%{author}</strong>,"
       thanks: "Thank you again for participating."
     evaluation_comment:
       subject: "New evaluation comment"

--- a/config/locales/en/mailers.yml
+++ b/config/locales/en/mailers.yml
@@ -2,6 +2,7 @@ en:
   mailers:
     title: "Open Government"
     no_reply: "This message was sent from an email address that does not accept replies."
+    sincerely: "Sincerely"
     already_confirmed:
       info: "We've received a request to send you instructions to confirm your account. However, your account is already confirmed, so there's no need to do so again."
       new_password: "If you've forgotten your password, you can reset it at the following link:"
@@ -56,14 +57,12 @@ en:
       text: "Thank you for creating your investment <strong>%{investment}</strong> for Participatory Budgets <strong>%{budget}</strong>."
       follow: "We will inform you about how the process progresses, which you can also follow on <strong>%{link}</strong>."
       follow_link: "Participatory Budgets"
-      sincerely: "Sincerely,"
       share: "Share your project"
     budget_investment_unfeasible:
       title: "Your investment project has been marked as unfeasible"
       hi: "Dear user,"
       new: "For all these, we invite you to elaborate a <strong>new investment</strong> that adjusts to the conditions of this process. You can do it following this link: %{url}."
       new_href: "new investment project"
-      sincerely: "Sincerely"
       sorry: "Sorry for the inconvenience and we again thank you for your invaluable participation."
       subject: "Your investment project '%{code}' has been marked as unfeasible"
     budget_investment_selected:
@@ -73,13 +72,11 @@ en:
       share: "Start to get votes, share your investment project on social networks. Share is essential to make it a reality."
       share_button: "Share your investment project"
       thanks: "Thank you again for participating."
-      sincerely: "Sincerely"
     budget_investment_unselected:
       subject: "Your investment project '%{code}' has not been selected"
       title: "Your investment project has not been selected"
       hi: "Dear user,"
       thanks: "Thank you again for participating."
-      sincerely: "Sincerely"
     evaluation_comment:
       subject: "New evaluation comment"
       title: New evaluation comment for %{investment}

--- a/config/locales/es/mailers.yml
+++ b/config/locales/es/mailers.yml
@@ -2,6 +2,7 @@ es:
   mailers:
     title: "Gobierno abierto"
     no_reply: "Este mensaje se ha enviado desde una dirección de correo electrónico que no admite respuestas."
+    sincerely: "Atentamente"
     already_confirmed:
       info: "Hemos recibido una solicitud para enviarte instrucciones para confirmar tu cuenta. Sin embargo, tu cuenta ya está confirmada, por lo que no es necesario volver a hacerlo."
       new_password: "Si has olvidado tu contraseña, puedes restablecerla en el siguiente enlace:"
@@ -56,14 +57,12 @@ es:
       text: "Muchas gracias por crear tu proyecto <strong>%{investment}</strong> para los Presupuestos Participativos <strong>%{budget}</strong>."
       follow: "Te informaremos de cómo avanza el proceso, que también puedes seguir en la página de <strong>%{link}</strong>."
       follow_link: "Presupuestos participativos"
-      sincerely: "Atentamente,"
       share: "Comparte tu proyecto"
     budget_investment_unfeasible:
       title: "Tu proyecto de gasto ha sido marcado como inviable"
       hi: "Estimado/a usuario/a"
       new: "Por todo ello, te invitamos a que elabores un <strong>nuevo proyecto de gasto</strong> que se ajuste a las condiciones de este proceso. Esto lo puedes hacer en este enlace: %{url}."
       new_href: "nuevo proyecto de gasto"
-      sincerely: "Atentamente"
       sorry: "Sentimos las molestias ocasionadas y volvemos a darte las gracias por tu inestimable participación."
       subject: "Tu proyecto de gasto '%{code}' ha sido marcado como inviable"
     budget_investment_selected:
@@ -73,13 +72,11 @@ es:
       share: "Empieza ya a conseguir votos, comparte tu proyecto de gasto en redes sociales. La difusión es fundamental para conseguir que se haga realidad."
       share_button: "Comparte tu proyecto"
       thanks: "Gracias de nuevo por tu participación."
-      sincerely: "Atentamente"
     budget_investment_unselected:
       subject: "Tu proyecto de gasto '%{code}' no ha sido seleccionado"
       title: "Tu proyecto de gasto no ha sido seleccionado"
       hi: "Estimado/a usuario/a"
       thanks: "Gracias de nuevo por tu participación."
-      sincerely: "Atentamente"
     evaluation_comment:
       subject: "Nuevo comentario de evaluación"
       title: Nuevo comentario de evaluación para %{investment}

--- a/config/locales/es/mailers.yml
+++ b/config/locales/es/mailers.yml
@@ -16,6 +16,7 @@ es:
       notifications_link: Notificaciones
       unsubscribe_text: 'Para darse de baja de estos emails, puedes entrar en %{notifications} y desmarcar la opción "%{notification}".'
     email_verification:
+      hi: "Hola <strong>%{user}</strong>,"
       click_here_to_verify: en este enlace
       instructions_2: Este email es para verificar tu cuenta con <b>%{document_type} %{document_number}</b>. Si esos no son tus datos, por favor no pulses el enlace anterior e ignora este email.
       instructions: Para terminar de verificar tu cuenta de usuario pulsa %{verification_link}.
@@ -38,10 +39,12 @@ es:
     direct_message_for_receiver:
       subject: "Has recibido un nuevo mensaje privado"
       reply: Responder a %{sender}
+      hi: "Hola <strong>%{receiver}</strong>,"
       unsubscribe_text: "Si no quieres recibir mensajes privados, puedes entrar en %{notifications} y desmarcar la opción 'Recibir emails con mensajes privados'."
     direct_message_for_sender:
       subject: "Has enviado un nuevo mensaje privado"
       title: "Has enviado un nuevo mensaje privado"
+      hi: "Hola <strong>%{sender}</strong>,"
       text: "Has enviado un nuevo mensaje privado a <strong>%{receiver}</strong> con el siguiente contenido:"
     user_invite:
       ignore: "Si no has solicitado esta invitación no te preocupes, puedes ignorar este correo."
@@ -53,14 +56,14 @@ es:
     budget_investment_created:
       subject: "¡Gracias por crear un proyecto!"
       title: "¡Gracias por crear un proyecto!"
-      intro: "Hola <strong>%{author}</strong>,"
+      hi: "Hola <strong>%{author}</strong>,"
       text: "Muchas gracias por crear tu proyecto <strong>%{investment}</strong> para los Presupuestos Participativos <strong>%{budget}</strong>."
       follow: "Te informaremos de cómo avanza el proceso, que también puedes seguir en la página de <strong>%{link}</strong>."
       follow_link: "Presupuestos participativos"
       share: "Comparte tu proyecto"
     budget_investment_unfeasible:
       title: "Tu proyecto de gasto ha sido marcado como inviable"
-      hi: "Estimado/a usuario/a"
+      hi: "Hola <strong>%{author}</strong>,"
       new: "Por todo ello, te invitamos a que elabores un <strong>nuevo proyecto de gasto</strong> que se ajuste a las condiciones de este proceso. Esto lo puedes hacer en este enlace: %{url}."
       new_href: "nuevo proyecto de gasto"
       sorry: "Sentimos las molestias ocasionadas y volvemos a darte las gracias por tu inestimable participación."
@@ -68,14 +71,14 @@ es:
     budget_investment_selected:
       subject: "Tu proyecto de gasto '%{code}' ha sido seleccionado"
       title: "Tu proyecto de gasto ha sido seleccionado"
-      hi: "Estimado/a usuario/a"
+      hi: "Hola <strong>%{author}</strong>,"
       share: "Empieza ya a conseguir votos, comparte tu proyecto de gasto en redes sociales. La difusión es fundamental para conseguir que se haga realidad."
       share_button: "Comparte tu proyecto"
       thanks: "Gracias de nuevo por tu participación."
     budget_investment_unselected:
       subject: "Tu proyecto de gasto '%{code}' no ha sido seleccionado"
       title: "Tu proyecto de gasto no ha sido seleccionado"
-      hi: "Estimado/a usuario/a"
+      hi: "Hola <strong>%{author}</strong>,"
       thanks: "Gracias de nuevo por tu participación."
     evaluation_comment:
       subject: "Nuevo comentario de evaluación"

--- a/spec/system/admin/system_emails_spec.rb
+++ b/spec/system/admin/system_emails_spec.rb
@@ -117,6 +117,7 @@ describe "System Emails" do
 
       visit admin_system_email_view_path("budget_investment_selected")
 
+      expect(page).to have_content "John Doe"
       expect(page).to have_content "Your investment project '#{investment.code}' has been selected"
       expect(page).to have_content "Start to get votes, share your investment project"
       expect(page).to have_content "Sincerely"
@@ -130,6 +131,7 @@ describe "System Emails" do
 
       visit admin_system_email_view_path("budget_investment_unfeasible")
 
+      expect(page).to have_content "John Doe"
       expect(page).to have_content "Your investment project '#{investment.code}' "
       expect(page).to have_content "has been marked as unfeasible"
       expect(page).to have_content "Sincerely"
@@ -140,6 +142,7 @@ describe "System Emails" do
 
       visit admin_system_email_view_path("budget_investment_unselected")
 
+      expect(page).to have_content "John Doe"
       expect(page).to have_content "Your investment project '#{investment.code}' "
       expect(page).to have_content "has not been selected"
       expect(page).to have_content "Thank you again for participating."
@@ -211,10 +214,11 @@ describe "System Emails" do
     end
 
     scenario "#email_verification" do
-      create(:user, confirmed_at: nil, email_verification_token: "abc")
+      user = create(:user, confirmed_at: nil, email_verification_token: "abc")
 
       visit admin_system_email_view_path("email_verification")
 
+      expect(page).to have_content "Hi #{user.name}"
       expect(page).to have_content "Confirm your account using the following link"
 
       expect(page).to have_link "this link", href: email_url(email_verification_token: "abc", host: app_host)

--- a/spec/system/admin/system_emails_spec.rb
+++ b/spec/system/admin/system_emails_spec.rb
@@ -104,6 +104,7 @@ describe "System Emails" do
       expect(page).to have_content "John Doe"
       expect(page).to have_content "Cleaner city"
       expect(page).to have_content "Budget for 2019"
+      expect(page).to have_content "Sincerely"
 
       expect(page).to have_link "Participatory Budgets", href: budgets_url(host: app_host)
 
@@ -118,6 +119,7 @@ describe "System Emails" do
 
       expect(page).to have_content "Your investment project '#{investment.code}' has been selected"
       expect(page).to have_content "Start to get votes, share your investment project"
+      expect(page).to have_content "Sincerely"
 
       share_url = budget_investment_url(budget, investment, anchor: "social-share", host: app_host)
       expect(page).to have_link "Share your investment project", href: share_url
@@ -130,6 +132,7 @@ describe "System Emails" do
 
       expect(page).to have_content "Your investment project '#{investment.code}' "
       expect(page).to have_content "has been marked as unfeasible"
+      expect(page).to have_content "Sincerely"
     end
 
     scenario "#budget_investment_unselected" do
@@ -140,6 +143,7 @@ describe "System Emails" do
       expect(page).to have_content "Your investment project '#{investment.code}' "
       expect(page).to have_content "has not been selected"
       expect(page).to have_content "Thank you again for participating."
+      expect(page).to have_content "Sincerely"
     end
 
     scenario "#comment" do
@@ -159,6 +163,7 @@ describe "System Emails" do
       expect(page).to have_link("Notifications",
                                 href: edit_subscriptions_url(token: user.subscriptions_token,
                                                              host: app_host))
+      expect(page).to have_content "Sincerely"
     end
 
     scenario "#reply" do
@@ -179,6 +184,7 @@ describe "System Emails" do
       expect(page).to have_link("Notifications",
                                 href: edit_subscriptions_url(token: user.subscriptions_token,
                                                              host: app_host))
+      expect(page).to have_content "Sincerely"
     end
 
     scenario "#direct_message_for_receiver" do
@@ -192,6 +198,7 @@ describe "System Emails" do
       expect(page).to have_link("Notifications",
                                 href: edit_subscriptions_url(token: admin.user.subscriptions_token,
                                                              host: app_host))
+      expect(page).to have_content "Sincerely"
     end
 
     scenario "#direct_message_for_sender" do
@@ -200,6 +207,7 @@ describe "System Emails" do
       expect(page).to have_content "You have sent a new private message to #{admin.user.name}"
       expect(page).to have_content "Message's Title"
       expect(page).to have_content "This is a sample of message's content."
+      expect(page).to have_content "Sincerely"
     end
 
     scenario "#email_verification" do
@@ -210,6 +218,7 @@ describe "System Emails" do
       expect(page).to have_content "Confirm your account using the following link"
 
       expect(page).to have_link "this link", href: email_url(email_verification_token: "abc", host: app_host)
+      expect(page).to have_content "Sincerely"
     end
 
     scenario "#user_invite" do
@@ -219,6 +228,7 @@ describe "System Emails" do
       expect(page).to have_content "Invitation to CONSUL"
       expect(page).to have_content "Thank you for applying to join CONSUL!"
       expect(page).to have_link "Complete registration"
+      expect(page).to have_content "Sincerely"
     end
 
     scenario "show flash message if there is no sample data to render the email" do
@@ -278,6 +288,7 @@ describe "System Emails" do
                                     anchor: "comments",
                                     host: app_host
                                   )
+        expect(page).to have_content "Sincerely"
       end
 
       scenario "uses a current_user as a sample user for sample regular comments" do
@@ -287,6 +298,7 @@ describe "System Emails" do
 
         expect(page).to have_content "This is a sample comment"
         expect(page).to have_content admin.name
+        expect(page).to have_content "Sincerely"
       end
     end
   end

--- a/spec/system/emails_spec.rb
+++ b/spec/system/emails_spec.rb
@@ -235,6 +235,7 @@ describe "Emails" do
       email = unread_emails_for(receiver.email).first
 
       expect(email).to have_subject("You have received a new private message")
+      expect(email).to have_body_text(receiver.name)
       expect(email).to have_body_text(direct_message.title)
       expect(email).to have_body_text(direct_message.body)
       expect(email).to have_body_text(direct_message.sender.name)
@@ -251,6 +252,7 @@ describe "Emails" do
       email = unread_emails_for(sender.email).first
 
       expect(email).to have_subject("You have sent a new private message")
+      expect(email).to have_body_text(sender.name)
       expect(email).to have_body_text(direct_message.title)
       expect(email).to have_body_text(direct_message.body)
       expect(email).to have_body_text(direct_message.receiver.name)

--- a/spec/system/site_customization/information_texts_spec.rb
+++ b/spec/system/site_customization/information_texts_spec.rb
@@ -32,7 +32,7 @@ describe "Custom information texts", :admin do
     user = create(:user, username: "Rachel")
     create(:budget_investment, author_id: user.id)
 
-    intro_key = "mailers.budget_investment_created.intro"
+    intro_key = "mailers.budget_investment_created.hi"
     create(:i18n_content, key: intro_key, value_en: "Hi %{author}")
 
     visit admin_site_customization_information_texts_path(tab: "mailers")


### PR DESCRIPTION
## Objectives

To add a little more consistency the key `<%= t(“mailers.sincerely”) %>` has been unified into a single translation with the text `“Sincerely,”` and added to all emails.

Also to give a little more “personalization” a greeting has been added with the username.