### PR TITLE
User Account Personal Demographic Information

### DIFF
--- a/app/components/admin/settings/features_tab_component.rb
+++ b/app/components/admin/settings/features_tab_component.rb
@@ -26,6 +26,7 @@ class Admin::Settings::FeaturesTabComponent < ApplicationComponent
       feature.machine_learning
       feature.remove_investments_supports
       feature.dashboard.notification_emails
+      feature.demographics
     ]
   end
 end

--- a/app/controllers/account_controller.rb
+++ b/app/controllers/account_controller.rb
@@ -32,7 +32,8 @@ class AccountController < ApplicationController
       else
         [:username, :public_activity, :public_interests, :email_on_comment,
          :email_on_comment_reply, :email_on_direct_message, :email_digest, :newsletter,
-         :official_position_badge, :recommended_debates, :recommended_proposals, :date_of_birth, :gender, :geozone_id]
+         :official_position_badge, :recommended_debates, :recommended_proposals,
+         :date_of_birth, :gender, :geozone_id]
       end
     end
 end

--- a/app/controllers/account_controller.rb
+++ b/app/controllers/account_controller.rb
@@ -32,7 +32,7 @@ class AccountController < ApplicationController
       else
         [:username, :public_activity, :public_interests, :email_on_comment,
          :email_on_comment_reply, :email_on_direct_message, :email_digest, :newsletter,
-         :official_position_badge, :recommended_debates, :recommended_proposals]
+         :official_position_badge, :recommended_debates, :recommended_proposals, :date_of_birth, :gender, :geozone_id]
       end
     end
 end

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -89,6 +89,7 @@ class Setting < ApplicationRecord
         "feature.sdg": true,
         "feature.machine_learning": false,
         "feature.remove_investments_supports": true,
+        "feature.demographics": false,
         "homepage.widgets.feeds.debates": true,
         "homepage.widgets.feeds.processes": true,
         "homepage.widgets.feeds.proposals": true,

--- a/app/views/account/show.html.erb
+++ b/app/views/account/show.html.erb
@@ -30,6 +30,13 @@
 
             <% else %>
               <%= f.text_field :username, maxlength: User.username_max_length %>
+                <h3>About Me (Optional information)</h3>
+                <%= f.date_field :date_of_birth, include_blank: true, readonly: true %>
+                <%= f.select :gender, [['Select Gender', nil], ['Male', 'male'], ['Female', 'female'], ['Other', 'other']], {}, { class: 'gender-select', disabled: true } %>
+
+                <%= f.label :geozone_id, 'Your Geozone (Choose the Area in which you live or leave blank for none)' %>
+                <%= f.collection_select :geozone_id, Geozone.all, :id, :name, { include_blank: 'Select Geozone' }, { class: 'geozone-select', disabled: true } %>
+
             <% end %>
           </div>
 

--- a/app/views/account/show.html.erb
+++ b/app/views/account/show.html.erb
@@ -30,14 +30,16 @@
 
             <% else %>
               <%= f.text_field :username, maxlength: User.username_max_length %>
-                <h3>About Me (Optional information)</h3>
-                <%= f.date_field :date_of_birth, include_blank: true, readonly: true %>
-                <%= f.select :gender, [['Select Gender', nil], ['Male', 'male'], ['Female', 'female'], ['Other', 'other']], {}, { class: 'gender-select', disabled: true } %>
+              <h3>About Me (Optional information)</h3>
+               <% enabled = feature?(:demographics) %>
+              <%= f.date_field :date_of_birth, include_blank: true, readonly: !enabled %>
+  
+              <%= f.select :gender, [['Select Gender', nil], ['Male', 'male'], ['Female', 'female'], ['Other', 'other']], {}, { class: 'gender-select', disabled: !enabled } %>
+  
+              <%= f.label :geozone_id, 'Choose Area (or leave blank for none)' %>
+              <%= f.collection_select :geozone_id, Geozone.all, :id, :name, { include_blank: 'Select Geozone' }, { class: 'geozone-select', disabled: !enabled } %>
+             <% end %>
 
-                <%= f.label :geozone_id, 'Your Geozone (Choose the Area in which you live or leave blank for none)' %>
-                <%= f.collection_select :geozone_id, Geozone.all, :id, :name, { include_blank: 'Select Geozone' }, { class: 'geozone-select', disabled: true } %>
-
-            <% end %>
           </div>
 
           <div>

--- a/app/views/account/show.html.erb
+++ b/app/views/account/show.html.erb
@@ -33,11 +33,11 @@
               <h3>About Me (Optional information)</h3>
                <% enabled = feature?(:demographics) %>
               <%= f.date_field :date_of_birth, include_blank: true, readonly: !enabled %>
-  
-              <%= f.select :gender, [['Select Gender', nil], ['Male', 'male'], ['Female', 'female'], ['Other', 'other']], {}, { class: 'gender-select', disabled: !enabled } %>
-  
-              <%= f.label :geozone_id, 'Choose Area (or leave blank for none)' %>
-              <%= f.collection_select :geozone_id, Geozone.all, :id, :name, { include_blank: 'Select Geozone' }, { class: 'geozone-select', disabled: !enabled } %>
+
+              <%= f.select :gender, [["Select Gender", nil], ["Male", "male"], ["Female", "female"], ["Other", "other"]], {}, { class: "gender-select", disabled: !enabled } %>
+
+              <%= f.label :geozone_id, "Choose Area (or leave blank for none)" %>
+              <%= f.collection_select :geozone_id, Geozone.all, :id, :name, { include_blank: "Select Geozone" }, { class: "geozone-select", disabled: !enabled } %>
              <% end %>
 
           </div>

--- a/config/locales/en/settings.yml
+++ b/config/locales/en/settings.yml
@@ -136,6 +136,8 @@ en:
       remove_investments_supports_description: "Allow users to remove supports on participatory budgets investments during the selecting projects phase."
       sdg: SDG
       sdg_description: Enable Sustainable Development Goals sections in the administration menu and in the Global Settings.
+      demographics: "Demographics"
+      demographics_description: "Enable users to manage gender DOB and Geozone"
     remote_census:
       general:
         endpoint: "Endpoint"


### PR DESCRIPTION
## Objectives

This PR adds the ability for users to see  the Gender, Date of Birth and Geozone information which is held about them.

It also adds a feature setting which gives administrators the ability to make it possible for users to edit the information in these fields.

There are two main reasons for this code
1. to make it easier for users to see what data is held about them, this helps with GDPR
2. to provide an easy way for users to set their Geozone if they are registering with Oauth method which does not provide location information.

This is also enabling work for a separate planned functionality to derive a users geozone from their Postccode and to provide the ability to restrict access to all processes by segmented user groups based on geozone

## Visual Changes

![image](https://github.com/user-attachments/assets/7e27ad4a-2a25-4507-bf8b-97ccc91947e7)


![image](https://github.com/user-attachments/assets/054fc976-3e20-4df0-a0eb-5ccc856d70c4)


![image](https://github.com/user-attachments/assets/2eb9f4b0-6c96-43aa-ac53-bf8babebadfc)


![image](https://github.com/user-attachments/assets/5fbb2927-82fd-4865-98bb-7773a16481d2)


