### PR TITLE
Fix custom locales not taking precedence

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -113,7 +113,9 @@ module Consul
       "val" => "es"
     }]
 
-    config.i18n.load_path += Dir[Rails.root.join("config", "locales", "**[^custom]*", "*.{rb,yml}")]
+    initializer :exclude_custom_locales_automatic_loading, before: :add_locales do
+      paths.add "config/locales", glob: "**[^custom]*/*.{rb,yml}"
+    end
     config.i18n.load_path += Dir[Rails.root.join("config", "locales", "custom", "**", "*.{rb,yml}")]
 
     config.after_initialize do


### PR DESCRIPTION
## References

* This bug was introduced in pull request #5465

## Background

When we upgraded to Rails 7 in commit 8596f1539, we broke the custom locales since now all nested folders in `config/locales/` are loaded by the default (see rails/rails#41872). This meant that the custom folder was now loaded before any languages whose code alphabetically goes after the word "custom".

## Objectives

* Make sure custom locales take precedence over regular locales

## Notes

Unfortunately, I haven't found a way to add a test for this behavior, since we would need to add a file in `config/locales/custom` that overwrites an internationalization key for an existing language, but only during a specific test, and the i18n load path is evaluated when the application starts up.