### PR TITLE
Use bundle exec to run delayed jobs on reboot

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -37,5 +37,5 @@ end
 
 every :reboot do
   # Number of workers must be kept in sync with capistrano's delayed_job_workers
-  command "cd #{@path} && RAILS_ENV=#{@environment} bin/delayed_job -m -n 2 restart"
+  command "cd #{@path} && RAILS_ENV=#{@environment} bundle exec bin/delayed_job -m -n 2 restart"
 end


### PR DESCRIPTION
## References

* We introduced the line causing the error when replacing SassC with Dart Sass in pull request #5477
* We fixed a similar issue in the installer in consuldemocracy/installer@3dc69eb6

## Objectives

* Make sure delayed job is properly running after rebooting a production system

## Notes

When deploying with Capistrano, we were already using `bundle exec bin/delayed_job`, so the deployment process wasn't affected by this issue.