### PR TITLE
Exclude irrelevant Consul Democracy tests in knapsack

### DIFF
--- a/bin/knapsack_pro_rspec
+++ b/bin/knapsack_pro_rspec
@@ -4,7 +4,7 @@ if [ "$KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC" = "" ]; then
     KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC=disabled-for-fork \
     KNAPSACK_PRO_MAX_REQUEST_RETRIES=0 \
     KNAPSACK_PRO_CI_NODE_RETRY_COUNT=0 \
-    bundle exec rake knapsack_pro:queue:rspec
+    bundle exec rake "knapsack_pro:queue:rspec[--tag ~consul]"
 else
-  bundle exec rake knapsack_pro:queue:rspec
+  bundle exec rake "knapsack_pro:queue:rspec[--tag ~consul]"
 fi


### PR DESCRIPTION
## References

* We introduced this issue in commit 070cb3185
* Knapsack Pro changed the way to exclude RSpec tags in Queue Mode in [Knapsack Pro 7.0.0](https://github.com/KnapsackPro/knapsack_pro-ruby/blob/master/CHANGELOG.md#700)

## Objectives

* Make sure irrelevant tests are ignored when running the test in a custom version of Consul Democracy