### PR TITLE
Make "show proposal" tests pass on GitHub Actions

### DIFF
--- a/spec/factories/proposals.rb
+++ b/spec/factories/proposals.rb
@@ -3,7 +3,6 @@ FactoryBot.define do
     sequence(:title)     { |n| "Proposal #{n} title" }
     sequence(:summary)   { |n| "In summary, what we want is... #{n}" }
     description          { "Proposal description" }
-    video_url            { "https://youtu.be/nhuNb0XtRhQ" }
     responsible_name     { "John Snow" }
     terms_of_service     { "1" }
     published_at         { Time.current }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -126,7 +126,7 @@ RSpec.configure do |config|
 
   config.before(:each, :small_window) do
     @window_size = Capybara.current_window.size
-    Capybara.current_window.resize_to(639, 479)
+    Capybara.current_window.resize_to(320, 640)
   end
 
   config.after(:each, :small_window) do


### PR DESCRIPTION
## References

* An example of a test failing on the "show proposal" page ("Proposal Notifications Show notifications") can be found at our [test run #7681, job 2](https://github.com/consuldemocracy/consuldemocracy/actions/runs/10862891885/job/30146419342) (see the 
[test run 7681 job 2 log](https://github.com/user-attachments/files/17003035/test_run_7681_job_2.txt))
* An example of the "sticky support button on small screens" tests failing can be found at our [test run #7681, job 4](https://github.com/consuldemocracy/consuldemocracy/actions/runs/10862891885/job/30146419512) (see the [test run 7681 job 4 log](https://github.com/user-attachments/files/17003073/test_run_7681_job_4.txt))

## Objectives

* Make the tests clicking on elements in the "show proposal" action pass
* Make the tests showing the sticky "support proposal" button on small screens pass

## Test failure screenshots

This is the screenshot of the "Proposal Notifications Show notifications" failure mentioned above; note the page should be inside the "Notifications" tab at this point:

![The notifications link hasn't been clicked on the "show proposal" page](https://github.com/user-attachments/assets/7634f796-45a7-47a8-8dfc-d48d3e8fdaa2)

This is the screenshot of the "Proposals Show sticky support button on small screens After visiting another page" failure mentioned above; note the "Go back" button can't be clicked:

![On a very small screen, the sticky "support proposal" button makes it impossible to see anything else on the page](https://github.com/user-attachments/assets/c3b110f4-1e55-4814-8cd6-ab5f816a45a8)

## Notes

These tests started to fail on August 29, probably due to a change in the browser used by GitHub Actions (since branches whose code we didn't change were suddenly affected that day). Although every time the test suite is run different tests fail, on each run at least half a dozen tests fail.

Note that, even though we're changing the tests, the tests failed due to potential usability issues, and we aren't fixing those issues. We might remove the sticky "support proposal" button in the future, though.