### PR TITLE
Directly select language in remotely translatable tests

### DIFF
--- a/spec/shared/system/remotely_translatable.rb
+++ b/spec/shared/system/remotely_translatable.rb
@@ -135,15 +135,6 @@ shared_examples "remotely_translatable" do |factory_name, path_name, path_argume
 
   context "After click remote translations button" do
     describe "with delayed jobs", :delay_jobs do
-      scenario "the remote translation button should not be present" do
-        visit path
-        select "Español", from: "Language:"
-
-        click_button "Traducir página"
-
-        expect(page).not_to have_button "Traducir página"
-      end
-
       scenario "the remote translation is pending to translate" do
         visit path
         select "Español", from: "Language:"
@@ -151,45 +142,27 @@ shared_examples "remotely_translatable" do |factory_name, path_name, path_argume
         expect { click_button "Traducir página" }.to change { RemoteTranslation.count }.from(0).to(1)
       end
 
-      scenario "should be present enqueued notice and informative text" do
+      scenario "shows informative text when content is enqueued" do
         visit path
         select "Español", from: "Language:"
 
         click_button "Traducir página"
 
-        expect(page).to have_content "Se han solicitado correctamente las traducciones."
-        expect(page).to have_content "En un breve periodo de tiempo refrescando la página " \
-                                     "podrá ver todo el contenido en su idioma"
-      end
-
-      scenario "should be present only informative text when user visit page with all content enqueued" do
-        visit path
-        select "Español", from: "Language:"
-        click_button "Traducir página"
-        expect(page).to have_content "Se han solicitado correctamente las traducciones."
-
-        visit path
-        select "Español", from: "Idioma:"
-
-        expect(page).to have_content "En un breve periodo de tiempo refrescando la página " \
-                                     "podrá ver todo el contenido en su idioma"
         expect(page).not_to have_button "Traducir página"
+        expect(page).to have_content "Se han solicitado correctamente las traducciones."
+        expect(page).to have_content "En un breve periodo de tiempo refrescando la página " \
+                                     "podrá ver todo el contenido en su idioma"
+
+        refresh
+
         expect(page).not_to have_content "Se han solicitado correctamente las traducciones."
+        expect(page).not_to have_button "Traducir página"
+        expect(page).to have_content "En un breve periodo de tiempo refrescando la página " \
+                                     "podrá ver todo el contenido en su idioma"
       end
     end
 
     describe "without delayed jobs" do
-      scenario "the remote translation button should not be present" do
-        response = generate_response(resource)
-        expect_any_instance_of(RemoteTranslations::Microsoft::Client).to receive(:call).and_return(response)
-        visit path
-        select "Español", from: "Language:"
-
-        click_button "Traducir página"
-
-        expect(page).not_to have_button "Traducir página"
-      end
-
       scenario "the remote translation has been translated and destoyed" do
         response = generate_response(resource)
         expect_any_instance_of(RemoteTranslations::Microsoft::Client).to receive(:call).and_return(response)

--- a/spec/shared/system/remotely_translatable.rb
+++ b/spec/shared/system/remotely_translatable.rb
@@ -38,6 +38,7 @@ shared_examples "remotely_translatable" do |factory_name, path_name, path_argume
 
       select "Español", from: "Language:"
 
+      expect(page).to have_select "Idioma:"
       expect(page).not_to have_button("Traducir página")
     end
 
@@ -47,6 +48,7 @@ shared_examples "remotely_translatable" do |factory_name, path_name, path_argume
 
       select "Español", from: "Language:"
 
+      expect(page).to have_select "Idioma:"
       expect(page).not_to have_button("Traducir página")
     end
 
@@ -57,9 +59,9 @@ shared_examples "remotely_translatable" do |factory_name, path_name, path_argume
 
         select "Español", from: "Language:"
 
-        expect(page).not_to have_button("Traducir página")
         expect(page).to have_content "En un breve periodo de tiempo refrescando la página " \
                                      "podrá ver todo el contenido en su idioma"
+        expect(page).not_to have_button("Traducir página")
       end
     end
 
@@ -73,6 +75,7 @@ shared_examples "remotely_translatable" do |factory_name, path_name, path_argume
 
         select "Español", from: "Language:"
 
+        expect(page).to have_select "Idioma:"
         expect(page).not_to have_button("Traducir página")
       end
     end
@@ -97,6 +100,7 @@ shared_examples "remotely_translatable" do |factory_name, path_name, path_argume
 
         select "Español", from: "Language:"
 
+        expect(page).to have_select "Idioma:"
         expect(page).not_to have_button("Traducir página")
       end
     end
@@ -167,10 +171,10 @@ shared_examples "remotely_translatable" do |factory_name, path_name, path_argume
         visit path
         select "Español", from: "Idioma:"
 
-        expect(page).not_to have_button "Traducir página"
-        expect(page).not_to have_content "Se han solicitado correctamente las traducciones."
         expect(page).to have_content "En un breve periodo de tiempo refrescando la página " \
                                      "podrá ver todo el contenido en su idioma"
+        expect(page).not_to have_button "Traducir página"
+        expect(page).not_to have_content "Se han solicitado correctamente las traducciones."
       end
     end
 

--- a/spec/shared/system/remotely_translatable.rb
+++ b/spec/shared/system/remotely_translatable.rb
@@ -20,7 +20,7 @@ shared_examples "remotely_translatable" do |factory_name, path_name, path_argume
     scenario "should not be present when current locale translation exists" do
       visit path
 
-      expect(page).not_to have_button("Translate page")
+      expect(page).not_to have_button "Translate page"
     end
 
     scenario "should be present when current locale translation does not exists" do
@@ -28,18 +28,18 @@ shared_examples "remotely_translatable" do |factory_name, path_name, path_argume
 
       select "Español", from: "Language:"
 
-      expect(page).to have_button("Traducir página")
+      expect(page).to have_button "Traducir página"
     end
 
     scenario "should not be present when new current locale translation exists" do
       add_translations(resource, :es)
       visit path
-      expect(page).not_to have_button("Translate page")
+      expect(page).not_to have_button "Translate page"
 
       select "Español", from: "Language:"
 
       expect(page).to have_select "Idioma:"
-      expect(page).not_to have_button("Traducir página")
+      expect(page).not_to have_button "Traducir página"
     end
 
     scenario "should not be present when there are no resources to translate", if: index_path?(path_name) do
@@ -49,7 +49,7 @@ shared_examples "remotely_translatable" do |factory_name, path_name, path_argume
       select "Español", from: "Language:"
 
       expect(page).to have_select "Idioma:"
-      expect(page).not_to have_button("Traducir página")
+      expect(page).not_to have_button "Traducir página"
     end
 
     describe "with delayed job active", :delay_jobs do
@@ -61,7 +61,7 @@ shared_examples "remotely_translatable" do |factory_name, path_name, path_argume
 
         expect(page).to have_content "En un breve periodo de tiempo refrescando la página " \
                                      "podrá ver todo el contenido en su idioma"
-        expect(page).not_to have_button("Traducir página")
+        expect(page).not_to have_button "Traducir página"
       end
     end
 
@@ -71,12 +71,12 @@ shared_examples "remotely_translatable" do |factory_name, path_name, path_argume
         add_translations(resource, :es)
         create(:comment, commentable: resource)
         visit path
-        expect(page).not_to have_button("Translate page")
+        expect(page).not_to have_button "Translate page"
 
         select "Español", from: "Language:"
 
         expect(page).to have_select "Idioma:"
-        expect(page).not_to have_button("Traducir página")
+        expect(page).not_to have_button "Traducir página"
       end
     end
 
@@ -85,23 +85,23 @@ shared_examples "remotely_translatable" do |factory_name, path_name, path_argume
         add_translations(resource, :es)
         create(:comment, commentable: resource)
         visit path
-        expect(page).not_to have_button("Translate page")
+        expect(page).not_to have_button "Translate page"
 
         select "Español", from: "Language:"
 
-        expect(page).to have_button("Traducir página")
+        expect(page).to have_button "Traducir página"
       end
 
       scenario "not display when exists resource translations but his comment has tanslations" do
         add_translations(resource, :es)
         create_comment_with_translations(resource, :es)
         visit path
-        expect(page).not_to have_button("Translate page")
+        expect(page).not_to have_button "Translate page"
 
         select "Español", from: "Language:"
 
         expect(page).to have_select "Idioma:"
-        expect(page).not_to have_button("Traducir página")
+        expect(page).not_to have_button "Traducir página"
       end
     end
 
@@ -110,11 +110,11 @@ shared_examples "remotely_translatable" do |factory_name, path_name, path_argume
         add_translations(resource, :es)
         create_featured_debates
         visit path
-        expect(page).not_to have_button("Translate page")
+        expect(page).not_to have_button "Translate page"
 
         select "Español", from: "Language:"
 
-        expect(page).to have_button("Traducir página")
+        expect(page).to have_button "Traducir página"
       end
     end
 
@@ -124,11 +124,11 @@ shared_examples "remotely_translatable" do |factory_name, path_name, path_argume
         add_translations(resource, :es)
         create_featured_proposals
         visit path
-        expect(page).not_to have_button("Translate page")
+        expect(page).not_to have_button "Translate page"
 
         select "Español", from: "Language:"
 
-        expect(page).to have_button("Traducir página")
+        expect(page).to have_button "Traducir página"
       end
     end
   end
@@ -141,7 +141,7 @@ shared_examples "remotely_translatable" do |factory_name, path_name, path_argume
 
         click_button "Traducir página"
 
-        expect(page).not_to have_button("Traducir página")
+        expect(page).not_to have_button "Traducir página"
       end
 
       scenario "the remote translation is pending to translate" do
@@ -166,7 +166,7 @@ shared_examples "remotely_translatable" do |factory_name, path_name, path_argume
         visit path
         select "Español", from: "Language:"
         click_button "Traducir página"
-        expect(page).to have_content("Se han solicitado correctamente las traducciones.")
+        expect(page).to have_content "Se han solicitado correctamente las traducciones."
 
         visit path
         select "Español", from: "Idioma:"
@@ -187,7 +187,7 @@ shared_examples "remotely_translatable" do |factory_name, path_name, path_argume
 
         click_button "Traducir página"
 
-        expect(page).not_to have_button("Traducir página")
+        expect(page).not_to have_button "Traducir página"
       end
 
       scenario "the remote translation has been translated and destoyed" do


### PR DESCRIPTION
## References

* Depends on #5688
* The test "request a translation of an already translated text" has failed a few times, like in our [test run 7687, job 3](https://github.com/consuldemocracy/consuldemocracy/actions/runs/10866044747/job/30153146652) (see the [test run 7687, job 3 log](https://github.com/user-attachments/files/17004098/run_7687_job_3.txt))

## Objectives

* Make sure that tests using remote translations always pass on our CI
* Simplify remotely translatable tests

## Notes

Just like the tests mentioned in pull request #5688, this test started to fail on August 29, probably due to a change in the browser used by GitHub Actions (since branches whose code we didn't change were suddenly affected that day).

The test failed with the message:

```
  1) Welcome screen behaves like remotely_translatable After click remote translations button without delayed jobs request a translation of an already translated text
     Failure/Error: expect(page).to have_content "Se han solicitado correctamente las traducciones"
       expected to find text "Se han solicitado correctamente las traducciones" in "Idioma: \n        \nEnglish\nDeutsch\nEspañol\nFrançais\nNederlands\nPortuguês brasileiro\n中文\n       Entrar\nRegistrarse\nDebates\nPropuestas\nVotaciones\nLegislación colaborativa\nPresupuestos participativos\nODS\nAyuda\n×\nTranslations have been correctly requested.\nPropuestas más activas\nAhora mismo no hay propuestas\nDebates más activos\nndfrrqufrp\nVer todos los debates\nProcesos abiertos\nAhora mismo no hay procesos abiertos\nGobierno abierto\nEste portal usa la aplicación CONSUL DEMOCRACY que es software de código abierto.\nParticipación\nDecide cómo debe ser la ciudad que quieres.\nCONSUL DEMOCRACY, 2024 Política de privacidad Condiciones de uso Accesibilidad"
```

Note that the text "Translations have been correctly requested" is in English, but it should be in Spanish, like the rest of the texts. While the root cause is unknown, debugging shows that sometimes (usually the first time this test is executed on our CI, and only the first time, since running it 600 tests in a row also resulted in only one failure) the request done by clicking on "Traducir página" is done with a user session where the locale is in English.

This doesn't make much sense, since both user sessions are already in Spanish (and we had either explicit or implicit expectations to confirm that), and debugging shows that the session is indeed in Spanish during the previous request.

In any case, we're solving it by never using English during the test, since it wasn't necessary; it was only done that way because all the tests on this file used the language selector to get to the Spanish pages. We're simplifying some of the other tests the same way.