### PR TITLE
Don't overwrite node_modules with Docker Compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,8 +33,10 @@ services:
     volumes:
       - .:/var/www/consul
       - bundle:/usr/local/bundle
+      - node_modules:/var/www/consul/node_modules
     environment:
       - POSTGRES_PASSWORD=$POSTGRES_PASSWORD
 volumes:
   db_data: {}
   bundle: {}
+  node_modules: {}


### PR DESCRIPTION
## References

* We missed this issue when we introduced NPM packages in pull request #5159

## Background

When creating the Dockerfile, we run `npm install`, which creates a `node_modules` folder inside the working directory.

However, when using docker-compose, we overwrite the contents of that working directory (/var/www/consul) with the contents of the host machine's working directory. This means that, unless the `npm install` command is run on the host machine to create a `node_modules` folder on the host machine (which would pretty much defeat the point of using Docker), the container won't have a `node_modules` folder and the application won't run.

## Objectives

* Make sure node packages are installed when using Docker Compose

## Notes

We didn't detect this issue because everything works fine if the host machine contains a `node_modules` folder, which is usually our case during development :sweat_smile:. To reproduce it, delete the `node_modules` folder on your machine's working directory :wink:.