### PR TITLE
Use a maintained version of PostgreSQL in Docker

### DIFF
--- a/.github/workflows/db_schema.yml
+++ b/.github/workflows/db_schema.yml
@@ -23,7 +23,6 @@ jobs:
           POSTGRES_PASSWORD: ""
     env:
       PGUSER: consul
-      POSTGRES_HOST: postgres
     steps:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1

--- a/.github/workflows/db_schema.yml
+++ b/.github/workflows/db_schema.yml
@@ -15,14 +15,15 @@ jobs:
     runs-on: ubuntu-latest
     services:
       postgres:
-        image: postgres:10.10
+        image: postgres:13.16
         ports: ["5432:5432"]
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
         env:
           POSTGRES_USER: consul
-          POSTGRES_PASSWORD: ""
+          POSTGRES_PASSWORD: password
     env:
       PGUSER: consul
+      PGPASSWORD: password
     steps:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,14 +19,15 @@ jobs:
     timeout-minutes: 60
     services:
       postgres:
-        image: postgres:10.10
+        image: postgres:13.16
         ports: ["5432:5432"]
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
         env:
           POSTGRES_USER: consul
-          POSTGRES_PASSWORD: ""
+          POSTGRES_PASSWORD: password
     env:
       PGUSER: consul
+      PGPASSWORD: password
       RAILS_ENV: test
     strategy:
       fail-fast: false

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,6 @@ jobs:
           POSTGRES_PASSWORD: ""
     env:
       PGUSER: consul
-      POSTGRES_HOST: postgres
       RAILS_ENV: test
     strategy:
       fail-fast: false

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,13 +6,14 @@ tests:
   image: "ruby:3.2.5"
   stage: test
   services:
-    - postgres:10.10
+    - postgres:13.16
   cache:
     key: consul
     paths:
       - vendor/
   variables:
     POSTGRES_USER: consul
+    POSTGRES_PASSWORD: password
     RAILS_ENV: test
     TEST_COVERAGE: 1
   parallel: 5

--- a/config/database.yml.gitlab
+++ b/config/database.yml.gitlab
@@ -5,7 +5,7 @@ default: &default
   pool: 5
   schema_search_path: "public,shared_extensions"
   username: consul
-  password:
+  password: password
 
 test:
   <<: *default

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
 
     # use the preferred version of the official Postgres image
     # see https://hub.docker.com/_/postgres/
-    image: postgres:9.6.21
+    image: postgres:13.16
     environment:
       - POSTGRES_PASSWORD=$POSTGRES_PASSWORD
     # persist the database between containers by storing it in a volume


### PR DESCRIPTION
## References

* [PostgreSQL versioning policy](https://www.postgresql.org/support/versioning/)

## Objectives

* Use a maintained version of PostgreSQL in Docker
* Use the same version of PostgreSQL in our CI as we use in Docker

