### PR TITLE
Fix environment variables and version warnings in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ruby:3.2.5-bullseye
 
-ENV DEBIAN_FRONTEND noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
 
 # Install essential Linux packages
 RUN apt-get update -qq \
@@ -29,7 +29,7 @@ RUN echo 'Defaults secure_path="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bi
 RUN chmod 0440 /etc/sudoers.d/secure_path
 
 # Define where our application will live inside the image
-ENV RAILS_ROOT /var/www/consul
+ENV RAILS_ROOT=/var/www/consul
 
 # Create application home. App server will need the pids dir so just create everything in one shot
 RUN mkdir -p $RAILS_ROOT/tmp/pids

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   # service configuration for our database
   database:


### PR DESCRIPTION
## References

* [LegacyKeyValueFormat documentation](https://docs.docker.com/reference/build-checks/legacy-key-value-format/)
* [The version top-level element is obsolete](https://docs.docker.com/reference/compose-file/version-and-name/#version-top-level-element-obsolete)

## Background

We were getting warnings in our CI:

> Legacy key/value format with whitespace separator should not be used
> LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy
> "ENV key value" format

We were also getting a warning in Docker Compose:

```
docker-compose.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion
```

## Objectives

* Use the right format when declaring environment variables in Dockerfile
* Remove an obsolete attribute in docker-compose that results in a warning