### PR TITLE
Bring back GraphQL security limits

### DIFF
--- a/app/graphql/consul_schema.rb
+++ b/app/graphql/consul_schema.rb
@@ -2,5 +2,7 @@ class ConsulSchema < GraphQL::Schema
   mutation(Types::MutationType)
   query(Types::QueryType)
 
+  default_max_page_size 25
+  max_complexity 2500
   max_depth 8
 end

--- a/app/graphql/consul_schema.rb
+++ b/app/graphql/consul_schema.rb
@@ -1,4 +1,6 @@
 class ConsulSchema < GraphQL::Schema
   mutation(Types::MutationType)
   query(Types::QueryType)
+
+  max_depth 8
 end

--- a/spec/graphql/consul_schema_spec.rb
+++ b/spec/graphql/consul_schema_spec.rb
@@ -34,4 +34,43 @@ describe ConsulSchema do
     expect(response["errors"]).not_to be nil
     expect(response["errors"].first["message"]).to match(/exceeds max depth/)
   end
+
+  it "returns an error for queries requesting all records from more than 2 collections" do
+    query = <<~GRAPHQL
+      {
+        users {
+          edges {
+            node {
+              public_debates {
+                edges {
+                  node {
+                    title
+                  }
+                }
+              }
+              public_proposals {
+                edges {
+                  node {
+                    title
+                  }
+                }
+              }
+              public_comments {
+                edges {
+                  node {
+                    body
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    GRAPHQL
+
+    response = execute(query)
+
+    expect(response["errors"]).not_to be nil
+    expect(response["errors"].first["message"]).to match(/Query has complexity/)
+  end
 end

--- a/spec/graphql/consul_schema_spec.rb
+++ b/spec/graphql/consul_schema_spec.rb
@@ -1,0 +1,37 @@
+require "rails_helper"
+
+describe ConsulSchema do
+  let(:user) { create(:user) }
+
+  it "returns an error for queries exceeding max depth" do
+    query = <<~GRAPHQL
+      {
+        user(id: #{user.id}) {
+          public_proposals {
+            edges {
+              node {
+                public_author {
+                  username
+                  public_proposals {
+                    edges {
+                      node {
+                        public_author {
+                          username
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    GRAPHQL
+
+    response = execute(query)
+
+    expect(response["errors"]).not_to be nil
+    expect(response["errors"].first["message"]).to match(/exceeds max depth/)
+  end
+end


### PR DESCRIPTION
## References

* Depends on pull request #5637
* We accidentally removed these limits in commit c984e666f from pull request #4766

## Objectives

* Limit the maximum depth of the queries
* Limit the amount of information that is possible to request in a query