### PR TITLE
Fix warning in hidden proposals spec

### DIFF
--- a/spec/factories/proposals.rb
+++ b/spec/factories/proposals.rb
@@ -80,6 +80,10 @@ FactoryBot.define do
       after(:create) { |proposal| create(:image, imageable: proposal) }
     end
 
+    trait :with_video do
+      video_url { "https://youtu.be/nhuNb0XtRhQ" }
+    end
+
     transient do
       voters { [] }
       followers { [] }

--- a/spec/system/admin/hidden_proposals_spec.rb
+++ b/spec/system/admin/hidden_proposals_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 describe "Admin hidden proposals", :admin do
   scenario "List shows all relevant info" do
-    proposal = create(:proposal, :hidden)
+    proposal = create(:proposal, :with_video, :hidden)
     visit admin_hidden_proposals_path
 
     expect(page).to have_content(proposal.title)


### PR DESCRIPTION
## References

* This issue was introduced in pull request #5688

## Objectives

* Fix a warning about checking for nil content in a hidden proposals spec