### PR TITLE
Use buttons for actions requiring confirmation

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -56,6 +56,7 @@
 @import "sdg_management/**/*";
 @import "shared/**/*";
 @import "subscriptions";
+@import "users/**/*";
 @import "widgets/**/*";
 
 @import "custom";

--- a/app/assets/stylesheets/dashboard.scss
+++ b/app/assets/stylesheets/dashboard.scss
@@ -442,6 +442,14 @@
   .button {
     font-weight: bold;
   }
+
+  button {
+    cursor: pointer;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
 }
 
 .community-poll {

--- a/app/assets/stylesheets/debates/mark_featured_action.scss
+++ b/app/assets/stylesheets/debates/mark_featured_action.scss
@@ -1,0 +1,7 @@
+.debate-show .mark-featured-action {
+  display: inline;
+
+  &::before {
+    @include vertical-separator;
+  }
+}

--- a/app/assets/stylesheets/debates/mark_featured_action.scss
+++ b/app/assets/stylesheets/debates/mark_featured_action.scss
@@ -4,4 +4,12 @@
   &::before {
     @include vertical-separator;
   }
+
+  form {
+    display: inline;
+  }
+
+  button {
+    @include link;
+  }
 }

--- a/app/assets/stylesheets/documents/document.scss
+++ b/app/assets/stylesheets/documents/document.scss
@@ -3,7 +3,7 @@
     margin-top: calc(#{$line-height} / 3);
   }
 
-  a:first-of-type {
+  a {
     word-wrap: break-word;
 
     .document-metadata {
@@ -17,5 +17,9 @@
         @include vertical-separator;
       }
     }
+  }
+
+  button {
+    cursor: pointer;
   }
 }

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -1543,8 +1543,13 @@ table {
     }
   }
 
+  .delete-comment-form {
+    display: inline;
+  }
+
   .delete-comment {
     @include has-fa-icon(trash-alt, regular);
+    cursor: pointer;
 
     &:not(:hover):not(:active) {
       color: $delete;

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -1245,7 +1245,7 @@ table {
   }
 
   .button {
-    margin: 0;
+    margin-bottom: 0;
   }
 }
 

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -1943,10 +1943,18 @@ table {
 
 .hide-recommendations {
   color: $text-light;
+  cursor: pointer;
+  font-size: $small-font-size;
+  line-height: inherit;
   position: absolute;
   right: 12px;
   top: -18px;
   z-index: 2;
+
+  &:focus,
+  &:hover {
+    @include anchor-color-hover;
+  }
 }
 
 // 20. Documents

--- a/app/assets/stylesheets/users/budget_investment_table_actions.scss
+++ b/app/assets/stylesheets/users/budget_investment_table_actions.scss
@@ -1,0 +1,3 @@
+.user-budget-investment-table-actions {
+  @include flex-with-gap($line-height * 0.25);
+}

--- a/app/components/debates/mark_featured_action_component.html.erb
+++ b/app/components/debates/mark_featured_action_component.html.erb
@@ -1,16 +1,17 @@
-&nbsp;|&nbsp;
-<% if debate.featured? %>
-  <%= link_to t("admin.actions.unmark_featured").capitalize,
-              unmark_featured_debate_path(debate),
-              method: :put,
-              data: { confirm: t("admin.actions.confirm_action",
-                                 action: t("admin.actions.unmark_featured"),
-                                 name: debate.title) } %>
-<% else %>
-  <%= link_to t("admin.actions.mark_featured").capitalize,
-              mark_featured_debate_path(debate),
-              method: :put,
-              data: { confirm: t("admin.actions.confirm_action",
-                                 action: t("admin.actions.mark_featured"),
-                                 name: debate.title) } %>
-<% end %>
+<div class="mark-featured-action">
+  <% if debate.featured? %>
+    <%= link_to t("admin.actions.unmark_featured").capitalize,
+                unmark_featured_debate_path(debate),
+                method: :put,
+                data: { confirm: t("admin.actions.confirm_action",
+                                   action: t("admin.actions.unmark_featured"),
+                                   name: debate.title) } %>
+  <% else %>
+    <%= link_to t("admin.actions.mark_featured").capitalize,
+                mark_featured_debate_path(debate),
+                method: :put,
+                data: { confirm: t("admin.actions.confirm_action",
+                                   action: t("admin.actions.mark_featured"),
+                                   name: debate.title) } %>
+  <% end %>
+</div>

--- a/app/components/debates/mark_featured_action_component.html.erb
+++ b/app/components/debates/mark_featured_action_component.html.erb
@@ -1,17 +1,17 @@
 <div class="mark-featured-action">
   <% if debate.featured? %>
-    <%= link_to t("admin.actions.unmark_featured").capitalize,
-                unmark_featured_debate_path(debate),
-                method: :put,
-                data: { confirm: t("admin.actions.confirm_action",
-                                   action: t("admin.actions.unmark_featured"),
-                                   name: debate.title) } %>
+    <%= button_to t("admin.actions.unmark_featured").capitalize,
+                  unmark_featured_debate_path(debate),
+                  method: :put,
+                  data: { confirm: t("admin.actions.confirm_action",
+                                     action: t("admin.actions.unmark_featured"),
+                                     name: debate.title) } %>
   <% else %>
-    <%= link_to t("admin.actions.mark_featured").capitalize,
-                mark_featured_debate_path(debate),
-                method: :put,
-                data: { confirm: t("admin.actions.confirm_action",
-                                   action: t("admin.actions.mark_featured"),
-                                   name: debate.title) } %>
+    <%= button_to t("admin.actions.mark_featured").capitalize,
+                  mark_featured_debate_path(debate),
+                  method: :put,
+                  data: { confirm: t("admin.actions.confirm_action",
+                                     action: t("admin.actions.mark_featured"),
+                                     name: debate.title) } %>
   <% end %>
 </div>

--- a/app/components/debates/mark_featured_action_component.html.erb
+++ b/app/components/debates/mark_featured_action_component.html.erb
@@ -1,0 +1,16 @@
+&nbsp;|&nbsp;
+<% if debate.featured? %>
+  <%= link_to t("admin.actions.unmark_featured").capitalize,
+              unmark_featured_debate_path(debate),
+              method: :put,
+              data: { confirm: t("admin.actions.confirm_action",
+                                 action: t("admin.actions.unmark_featured"),
+                                 name: debate.title) } %>
+<% else %>
+  <%= link_to t("admin.actions.mark_featured").capitalize,
+              mark_featured_debate_path(debate),
+              method: :put,
+              data: { confirm: t("admin.actions.confirm_action",
+                                 action: t("admin.actions.mark_featured"),
+                                 name: debate.title) } %>
+<% end %>

--- a/app/components/debates/mark_featured_action_component.rb
+++ b/app/components/debates/mark_featured_action_component.rb
@@ -1,0 +1,12 @@
+class Debates::MarkFeaturedActionComponent < ApplicationComponent
+  attr_reader :debate
+  use_helpers :can?
+
+  def initialize(debate)
+    @debate = debate
+  end
+
+  def render
+    can? :mark_featured, debate
+  end
+end

--- a/app/components/documents/document_component.html.erb
+++ b/app/components/documents/document_component.html.erb
@@ -8,10 +8,10 @@
   <% end %>
 
   <% if show_destroy_link? && can?(:destroy, document) %>
-    <%= link_to t("documents.buttons.destroy_document"),
-                document,
-                method: :delete,
-                data: { confirm: t("documents.actions.destroy.confirm") },
-                class: "delete" %>
+    <%= button_to t("documents.buttons.destroy_document"),
+                  document,
+                  method: :delete,
+                  data: { confirm: t("documents.actions.destroy.confirm") },
+                  class: "delete" %>
   <% end %>
 </div>

--- a/app/components/users/budget_investment_table_actions_component.html.erb
+++ b/app/components/users/budget_investment_table_actions_component.html.erb
@@ -1,11 +1,9 @@
 <div class="user-budget-investment-table-actions">
   <% if can? :update, investment %>
-    <%= link_to t("shared.edit"), edit_budget_investment_path(investment.budget, investment),
-                class: "button hollow" %>
+    <%= edit_link %>
   <% end %>
+
   <% if can? :destroy, investment %>
-    <%= button_to t("shared.delete"), budget_investment_path(investment.budget, investment),
-                  method: :delete, class: "button hollow alert",
-                  data: { confirm: t("users.show.delete_alert") } %>
+    <%= destroy_button %>
   <% end %>
 </div>

--- a/app/components/users/budget_investment_table_actions_component.html.erb
+++ b/app/components/users/budget_investment_table_actions_component.html.erb
@@ -1,0 +1,9 @@
+<% if can? :update, investment %>
+  <%= link_to t("shared.edit"), edit_budget_investment_path(investment.budget, investment),
+              class: "button hollow" %>
+<% end %>
+<% if can? :destroy, investment %>
+  <%= link_to t("shared.delete"), budget_investment_path(investment.budget, investment),
+              method: :delete, class: "button hollow alert",
+              data: { confirm: t("users.show.delete_alert") } %>
+<% end %>

--- a/app/components/users/budget_investment_table_actions_component.html.erb
+++ b/app/components/users/budget_investment_table_actions_component.html.erb
@@ -1,9 +1,11 @@
-<% if can? :update, investment %>
-  <%= link_to t("shared.edit"), edit_budget_investment_path(investment.budget, investment),
-              class: "button hollow" %>
-<% end %>
-<% if can? :destroy, investment %>
-  <%= link_to t("shared.delete"), budget_investment_path(investment.budget, investment),
-              method: :delete, class: "button hollow alert",
-              data: { confirm: t("users.show.delete_alert") } %>
-<% end %>
+<div class="user-budget-investment-table-actions">
+  <% if can? :update, investment %>
+    <%= link_to t("shared.edit"), edit_budget_investment_path(investment.budget, investment),
+                class: "button hollow" %>
+  <% end %>
+  <% if can? :destroy, investment %>
+    <%= button_to t("shared.delete"), budget_investment_path(investment.budget, investment),
+                  method: :delete, class: "button hollow alert",
+                  data: { confirm: t("users.show.delete_alert") } %>
+  <% end %>
+</div>

--- a/app/components/users/budget_investment_table_actions_component.rb
+++ b/app/components/users/budget_investment_table_actions_component.rb
@@ -11,6 +11,7 @@ class Users::BudgetInvestmentTableActionsComponent < ApplicationComponent
     def edit_link
       link_to t("shared.edit"),
               edit_budget_investment_path(investment.budget, investment),
+              "aria-label": action_label(t("shared.edit")),
               class: "button hollow"
     end
 
@@ -18,7 +19,12 @@ class Users::BudgetInvestmentTableActionsComponent < ApplicationComponent
       button_to t("shared.delete"),
                 budget_investment_path(investment.budget, investment),
                 method: :delete,
+                "aria-label": action_label(t("shared.delete")),
                 class: "button hollow alert",
                 data: { confirm: t("users.show.delete_alert") }
+    end
+
+    def action_label(action_text)
+      t("shared.actions.label", action: action_text, name: investment.title)
     end
 end

--- a/app/components/users/budget_investment_table_actions_component.rb
+++ b/app/components/users/budget_investment_table_actions_component.rb
@@ -5,4 +5,20 @@ class Users::BudgetInvestmentTableActionsComponent < ApplicationComponent
   def initialize(investment)
     @investment = investment
   end
+
+  private
+
+    def edit_link
+      link_to t("shared.edit"),
+              edit_budget_investment_path(investment.budget, investment),
+              class: "button hollow"
+    end
+
+    def destroy_button
+      button_to t("shared.delete"),
+                budget_investment_path(investment.budget, investment),
+                method: :delete,
+                class: "button hollow alert",
+                data: { confirm: t("users.show.delete_alert") }
+    end
 end

--- a/app/components/users/budget_investment_table_actions_component.rb
+++ b/app/components/users/budget_investment_table_actions_component.rb
@@ -1,0 +1,8 @@
+class Users::BudgetInvestmentTableActionsComponent < ApplicationComponent
+  attr_reader :investment
+  use_helpers :can?
+
+  def initialize(investment)
+    @investment = investment
+  end
+end

--- a/app/views/comments/_actions.html.erb
+++ b/app/views/comments/_actions.html.erb
@@ -5,10 +5,10 @@
 <% if can?(:hide, comment) || can?(:hide, comment.user) %>
   <% if comment.author == current_user %>
     <span class="divider">&nbsp;&bull;&nbsp;</span>
-    <%= link_to t("comments.actions.delete"),
-                hide_comment_path(comment),
-                method: :put, remote: true, class: "delete-comment",
-                data: { confirm: t("comments.actions.confirm_delete") } %>
+    <%= button_to t("comments.actions.delete"),
+                  hide_comment_path(comment),
+                  method: :put, remote: true, class: "delete-comment", form_class: "delete-comment-form",
+                  data: { confirm: t("comments.actions.confirm_delete") } %>
   <% else %>
     <%= render Shared::ModerationActionsComponent.new(comment) %>
   <% end %>

--- a/app/views/dashboard/polls/_poll.html.erb
+++ b/app/views/dashboard/polls/_poll.html.erb
@@ -27,10 +27,10 @@
     <% end %>
     <p class="help-text"><%= t("dashboard.polls.poll.show_results_help") %></p>
 
-    <%= link_to t("dashboard.polls.poll.delete"),
-                proposal_dashboard_poll_path(proposal, poll),
-                method: :delete,
-                "data-confirm": t("dashboard.polls.poll.alert_notice"),
-                class: "delete" %>
+    <%= button_to t("dashboard.polls.poll.delete"),
+                  proposal_dashboard_poll_path(proposal, poll),
+                  method: :delete,
+                  "data-confirm": t("dashboard.polls.poll.alert_notice"),
+                  class: "delete" %>
   </div>
 </div>

--- a/app/views/debates/_actions.html.erb
+++ b/app/views/debates/_actions.html.erb
@@ -1,18 +1,2 @@
 <%= render Shared::ModerationActionsComponent.new(debate) %>
-
-<% if can? :mark_featured, debate %>
-  &nbsp;|&nbsp;
-  <% if debate.featured? %>
-    <%= link_to t("admin.actions.unmark_featured").capitalize, unmark_featured_debate_path(debate),
-                method: :put,
-                data: { confirm: t("admin.actions.confirm_action",
-                                   action: t("admin.actions.unmark_featured"),
-                                   name: debate.title) } %>
-  <% else %>
-    <%= link_to t("admin.actions.mark_featured").capitalize, mark_featured_debate_path(debate),
-                method: :put,
-                data: { confirm: t("admin.actions.confirm_action",
-                                   action: t("admin.actions.mark_featured"),
-                                   name: debate.title) } %>
-  <% end %>
-<% end %>
+<%= render Debates::MarkFeaturedActionComponent.new(debate) %>

--- a/app/views/management/users/_erase_user_account.html.erb
+++ b/app/views/management/users/_erase_user_account.html.erb
@@ -5,5 +5,5 @@
     <%= t("management.users.erase_warning") %>
   </div>
 
-  <%= link_to t("management.users.erase_submit"), erase_management_users_path, method: :delete, class: "button hollow alert", data: { confirm: t("management.users.erase_account_confirm") } %>
+  <%= button_to t("management.users.erase_submit"), erase_management_users_path, method: :delete, class: "button hollow alert", data: { confirm: t("management.users.erase_account_confirm") } %>
 </div>

--- a/app/views/shared/_recommended_index.html.erb
+++ b/app/views/shared/_recommended_index.html.erb
@@ -5,13 +5,13 @@
     </div>
 
     <div id="recommendations" data-toggler=".hide">
-      <%= link_to disable_recommendations_path, title: t("shared.recommended_index.hide"),
-                                                class: "float-right-medium small hide-recommendations",
-                                                data: {
-                                                  toggle: "recommendations",
-                                                  confirm: t("#{namespace}.index.recommendations.disable")
-                                                },
-                                                method: :put do %>
+      <%= button_to disable_recommendations_path, title: t("shared.recommended_index.hide"),
+                                                  class: "float-right-medium hide-recommendations",
+                                                  data: {
+                                                    toggle: "recommendations",
+                                                    confirm: t("#{namespace}.index.recommendations.disable")
+                                                  },
+                                                  method: :put do %>
         <span class="icon-x"></span>
         <span class="show-for-sr"><%= t("shared.recommended_index.hide") %></span>
       <% end %>

--- a/app/views/shared/_recommended_index.html.erb
+++ b/app/views/shared/_recommended_index.html.erb
@@ -6,7 +6,7 @@
 
     <div id="recommendations" data-toggler=".hide">
       <%= button_to disable_recommendations_path, title: t("shared.recommended_index.hide"),
-                                                  class: "float-right-medium hide-recommendations",
+                                                  class: "hide-recommendations",
                                                   data: {
                                                     toggle: "recommendations",
                                                     confirm: t("#{namespace}.index.recommendations.disable")

--- a/app/views/users/_budget_investment.html.erb
+++ b/app/views/users/_budget_investment.html.erb
@@ -3,14 +3,6 @@
     <%= link_to budget_investment.title, budget_investment_path(budget_investment.budget, budget_investment) %>
   </td>
   <td>
-    <% if can? :update, budget_investment %>
-      <%= link_to t("shared.edit"), edit_budget_investment_path(budget_investment.budget, budget_investment),
-                  class: "button hollow" %>
-    <% end %>
-    <% if can? :destroy, budget_investment %>
-      <%= link_to t("shared.delete"), budget_investment_path(budget_investment.budget, budget_investment),
-                  method: :delete, class: "button hollow alert",
-                  data: { confirm: t("users.show.delete_alert") } %>
-    <% end %>
+    <%= render Users::BudgetInvestmentTableActionsComponent.new(budget_investment) %>
   </td>
 </tr>

--- a/config/locales/en/general.yml
+++ b/config/locales/en/general.yml
@@ -644,6 +644,8 @@ en:
     show:
       back: "Go back to my content"
   shared:
+    actions:
+      label: "%{action} %{name}"
     edit: "Edit"
     filter: "Filter"
     save: "Save"

--- a/config/locales/es/general.yml
+++ b/config/locales/es/general.yml
@@ -644,6 +644,8 @@ es:
     show:
       back: "Volver a mi contenido"
   shared:
+    actions:
+      label: "%{action} %{name}"
     edit: "Editar"
     filter: "Filtrar"
     save: "Guardar"

--- a/spec/components/users/budget_investment_table_actions_component_spec.rb
+++ b/spec/components/users/budget_investment_table_actions_component_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+describe Users::BudgetInvestmentTableActionsComponent do
+  let(:user) { create(:user, :level_two) }
+  let(:budget) { create(:budget, :accepting) }
+  let(:investment) { create(:budget_investment, budget: budget, author: user, title: "User investment") }
+
+  describe "#edit_link" do
+    it "generates an aria-label attribute" do
+      sign_in(user)
+
+      render_inline Users::BudgetInvestmentTableActionsComponent.new(investment)
+
+      expect(page).to have_link count: 1
+      expect(page).to have_link "Edit"
+      expect(page).to have_css "a[aria-label='Edit User investment']"
+    end
+  end
+
+  describe "#destroy_button" do
+    it "generates an aria-label attribute" do
+      sign_in(user)
+
+      render_inline Users::BudgetInvestmentTableActionsComponent.new(investment)
+
+      expect(page).to have_button count: 1
+      expect(page).to have_button "Delete"
+      expect(page).to have_css "button[aria-label='Delete User investment']"
+    end
+  end
+end

--- a/spec/shared/system/documentable.rb
+++ b/spec/shared/system/documentable.rb
@@ -25,27 +25,27 @@ shared_examples "documentable" do |documentable_factory_name, documentable_path,
       scenario "Should not be able when no user logged in" do
         visit send(documentable_path, arguments)
 
-        expect(page).not_to have_link("Delete document")
+        expect(page).not_to have_button "Delete document"
       end
 
       scenario "Should be able when documentable author is logged in" do
         login_as documentable.author
         visit send(documentable_path, arguments)
 
-        expect(page).to have_link("Delete document")
+        expect(page).to have_button "Delete document"
       end
 
       scenario "Administrators cannot destroy documentables they have not authored", :admin do
         visit send(documentable_path, arguments)
 
-        expect(page).not_to have_link("Delete document")
+        expect(page).not_to have_button "Delete document"
       end
 
       scenario "Users cannot destroy documentables they have not authored" do
         login_as(create(:user))
         visit send(documentable_path, arguments)
 
-        expect(page).not_to have_link("Delete document")
+        expect(page).not_to have_button "Delete document"
       end
     end
 
@@ -93,7 +93,7 @@ shared_examples "documentable" do |documentable_factory_name, documentable_path,
       visit send(documentable_path, arguments)
 
       within "#document_#{document.id}" do
-        accept_confirm { click_link "Delete document" }
+        accept_confirm { click_button "Delete document" }
       end
 
       expect(page).to have_content "Document was deleted successfully."
@@ -105,7 +105,7 @@ shared_examples "documentable" do |documentable_factory_name, documentable_path,
       visit send(documentable_path, arguments)
 
       within "#document_#{document.id}" do
-        accept_confirm { click_link "Delete document" }
+        accept_confirm { click_button "Delete document" }
       end
 
       expect(page).not_to have_content "Documents (0)"
@@ -117,7 +117,7 @@ shared_examples "documentable" do |documentable_factory_name, documentable_path,
       visit send(documentable_path, arguments)
 
       within "#document_#{document.id}" do
-        accept_confirm { click_link "Delete document" }
+        accept_confirm { click_button "Delete document" }
       end
 
       within "##{ActionView::RecordIdentifier.dom_id(documentable)}" do

--- a/spec/system/budgets/investments_spec.rb
+++ b/spec/system/budgets/investments_spec.rb
@@ -1170,7 +1170,7 @@ describe "Budget Investments" do
       within("#budget_investment_#{investment1.id}") do
         expect(page).to have_content(investment1.title)
 
-        accept_confirm { click_link("Delete") }
+        accept_confirm { click_button "Delete" }
       end
 
       expect(page).to have_content "Investment project deleted successfully"

--- a/spec/system/comments_spec.rb
+++ b/spec/system/comments_spec.rb
@@ -336,16 +336,16 @@ describe "Comments" do
       visit polymorphic_path(resource)
 
       accept_confirm("Are you sure? This action will delete this comment. You can't undo this action.") do
-        within(".comment-body", text: "This was a mistake") { click_link "Delete comment" }
+        within(".comment-body", text: "This was a mistake") { click_button "Delete comment" }
       end
 
       expect(page).not_to have_content "This was a mistake"
-      expect(page).not_to have_link "Delete comment"
+      expect(page).not_to have_button "Delete comment"
 
       refresh
 
       expect(page).not_to have_content "This was a mistake"
-      expect(page).not_to have_link "Delete comment"
+      expect(page).not_to have_button "Delete comment"
 
       logout
       login_as(admin)
@@ -363,7 +363,7 @@ describe "Comments" do
       visit polymorphic_path(resource)
 
       accept_confirm("Are you sure? This action will delete this comment. You can't undo this action.") do
-        within(".comment-body", text: "Wrong comment") { click_link "Delete comment" }
+        within(".comment-body", text: "Wrong comment") { click_button "Delete comment" }
       end
 
       within "#comments > .comment-list > li", text: "Right reply" do

--- a/spec/system/dashboard/polls_spec.rb
+++ b/spec/system/dashboard/polls_spec.rb
@@ -199,7 +199,7 @@ describe "Polls" do
     visit proposal_dashboard_polls_path(proposal)
 
     within("#poll_#{poll.id}") do
-      accept_confirm { click_link "Delete survey" }
+      accept_confirm { click_button "Delete survey" }
     end
 
     expect(page).to have_content("Survey deleted successfully")
@@ -214,7 +214,7 @@ describe "Polls" do
     visit proposal_dashboard_polls_path(proposal)
 
     within("#poll_#{poll.id}") do
-      accept_confirm { click_link "Delete survey" }
+      accept_confirm { click_button "Delete survey" }
     end
 
     expect(page).to have_content("You cannot destroy a survey that has responses")

--- a/spec/system/debates_spec.rb
+++ b/spec/system/debates_spec.rb
@@ -521,7 +521,7 @@ describe "Debates" do
           expect(page).to have_content("Medium")
           expect(page).to have_css(".recommendation", count: 3)
 
-          accept_confirm { click_link "Hide recommendations" }
+          accept_confirm { click_button "Hide recommendations" }
         end
 
         expect(page).not_to have_link("recommendations")

--- a/spec/system/debates_spec.rb
+++ b/spec/system/debates_spec.rb
@@ -748,7 +748,7 @@ describe "Debates" do
     end
 
     click_link debate.title
-    accept_confirm("Are you sure? Featured") { click_link "Featured" }
+    accept_confirm("Are you sure? Featured") { click_button "Featured" }
 
     within("#debates") do
       expect(page).to have_content "FEATURED"
@@ -760,7 +760,7 @@ describe "Debates" do
       click_link debate.title
     end
 
-    accept_confirm("Are you sure? Unmark featured") { click_link "Unmark featured" }
+    accept_confirm("Are you sure? Unmark featured") { click_button "Unmark featured" }
 
     within("#debates") do
       expect(page).not_to have_content "FEATURED"

--- a/spec/system/management/users_spec.rb
+++ b/spec/system/management/users_spec.rb
@@ -82,7 +82,7 @@ describe "Users" do
     expect(page).to have_content "This user can participate in the website with the following permissions"
 
     click_link "Delete user"
-    accept_confirm { click_link "Delete account" }
+    accept_confirm { click_button "Delete account" }
 
     expect(page).to have_content "User account deleted."
 

--- a/spec/system/proposals_spec.rb
+++ b/spec/system/proposals_spec.rb
@@ -937,7 +937,7 @@ describe "Proposals" do
           expect(page).to have_content("Medium")
           expect(page).to have_css(".recommendation", count: 3)
 
-          accept_confirm { click_link "Hide recommendations" }
+          accept_confirm { click_button "Hide recommendations" }
         end
 
         expect(page).not_to have_link("recommendations")

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -131,12 +131,12 @@ describe "Users" do
       expect(page).to have_link budget_investment.title
 
       within("#budget_investment_#{budget_investment.id}") do
-        dismiss_confirm { click_link "Delete" }
+        dismiss_confirm { click_button "Delete" }
       end
       expect(page).to have_link budget_investment.title
 
       within("#budget_investment_#{budget_investment.id}") do
-        accept_confirm { click_link "Delete" }
+        accept_confirm { click_button "Delete" }
       end
       expect(page).not_to have_link budget_investment.title
     end

--- a/spec/system/valuation/budget_investments_spec.rb
+++ b/spec/system/valuation/budget_investments_spec.rb
@@ -410,7 +410,7 @@ describe "Valuation budget investments" do
       visit valuation_budget_budget_investment_path(budget, investment)
       click_link "Edit dossier"
 
-      accept_confirm { find_field("budget_investment[valuation_finished]").click }
+      accept_confirm { check "Valuation finished" }
       click_button "Save changes"
 
       expect(page).to have_content "Dossier updated"


### PR DESCRIPTION
## References

* This pull request addresses some of the issues in pull request #5461
* We described the problems of using links for actions in commit 5311daadf from pull request #4665
* Using `click_link` with confirmation dialogs made it harder to test accessibility issues with the code in pull request #5739, which we're using while developing pull request #5509

## Objectives

* Make it easier for people using screen readers to know they're about to perform an action
* Make it easier to run automatic accessibility tests