### PR TITLE
Make github actions workflows compatible with Ubuntu 24.04

### DIFF
--- a/.github/workflows/auto-author-assign.yml
+++ b/.github/workflows/auto-author-assign.yml
@@ -11,6 +11,6 @@ jobs:
   assign-author:
     name: Auto-assign pull request author
     if: github.repository_owner == 'consuldemocracy'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: toshimaru/auto-author-assign@v2.1.1

--- a/.github/workflows/auto-author-assign.yml
+++ b/.github/workflows/auto-author-assign.yml
@@ -11,6 +11,6 @@ jobs:
   assign-author:
     name: Auto-assign pull request author
     if: github.repository_owner == 'consuldemocracy'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: toshimaru/auto-author-assign@v2.1.1

--- a/.github/workflows/db_schema.yml
+++ b/.github/workflows/db_schema.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   schema:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     services:
       postgres:
         image: postgres:13.16

--- a/.github/workflows/db_schema.yml
+++ b/.github/workflows/db_schema.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   schema:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     services:
       postgres:
         image: postgres:13.16

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,7 +6,7 @@ permissions:
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,7 +6,7 @@ permissions:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -6,7 +6,7 @@ permissions:
 
 jobs:
   linters:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -6,7 +6,7 @@ permissions:
 
 jobs:
   linters:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/pronto.yml
+++ b/.github/workflows/pronto.yml
@@ -3,7 +3,7 @@ on: [pull_request]
 
 jobs:
   pronto:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name && github.actor != 'dependabot[bot]'
     steps:
       - name: Checkout code

--- a/.github/workflows/pronto.yml
+++ b/.github/workflows/pronto.yml
@@ -3,7 +3,7 @@ on: [pull_request]
 
 jobs:
   pronto:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     if: github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name && github.actor != 'dependabot[bot]'
     steps:
       - name: Checkout code

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 60
     services:
       postgres:
@@ -76,7 +76,7 @@ jobs:
   coveralls:
     permissions:
       contents: none
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: tests
     steps:
       - name: Finish coveralls

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   tests:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 60
     services:
       postgres:
@@ -46,6 +46,8 @@ jobs:
           node-version-file: ".node-version"
       - name: Install node packages
         run: npm clean-install
+      - name: Install ImageMagick
+        run: sudo apt-get install imagemagick
       - name: Copy secrets and database files
         run: for i in config/*.example; do cp "$i" "${i/.example}"; done
       - name: Setup database
@@ -76,7 +78,7 @@ jobs:
   coveralls:
     permissions:
       contents: none
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: tests
     steps:
       - name: Finish coveralls


### PR DESCRIPTION
## References

* [The ubuntu-latest image now uses Ubuntu 24.04](https://github.blog/changelog/2024-09-25-actions-new-images-and-ubuntu-latest-changes/)
* In our [test run #8035](https://github.com/consuldemocracy/consuldemocracy/actions/runs/11327093206), all tests depending on ImageMagick failed with Ubuntu 24.04

## Background

Back in pull request #4906, we decided to start using the latest version of the github actions Ubuntu images to make sure we'd never use a deprecated image.

This worked fine when these images were updated to use Ubuntu 20.04 and, later, Ubuntu 22.04. However, the Ubuntu 24.04 image introduces an incompatibility since it no longer includes ImageMagick, which is one of our dependencies.

## Objectives

* Make github actions workflows compatible with Ubuntu 24.04
* Use a specific version of Ubuntu in workflows so existing Consul Democracy installations don't suddenly stop working