### PR TITLE
Fix crash in legislation proposals with videos

### DIFF
--- a/app/models/legislation/proposal.rb
+++ b/app/models/legislation/proposal.rb
@@ -10,6 +10,7 @@ class Legislation::Proposal < ApplicationRecord
   include Followable
   include Communitable
   include Documentable
+  include Videoable
   include Notifiable
   include Imageable
   include Randomizable

--- a/spec/models/legislation/proposal_spec.rb
+++ b/spec/models/legislation/proposal_spec.rb
@@ -27,6 +27,18 @@ describe Legislation::Proposal do
     expect(proposal).not_to be_valid
   end
 
+  describe "#video_url" do
+    it "is not valid when URL is not from Youtube or Vimeo" do
+      proposal.video_url = "https://twitter.com"
+      expect(proposal).not_to be_valid
+    end
+
+    it "is valid when URL is from Youtube or Vimeo" do
+      proposal.video_url = "https://vimeo.com/112681885"
+      expect(proposal).to be_valid
+    end
+  end
+
   describe "#hot_score" do
     let(:now) { Time.current }
 

--- a/spec/system/legislation/proposals_spec.rb
+++ b/spec/system/legislation/proposals_spec.rb
@@ -304,4 +304,34 @@ describe "Legislation Proposals" do
 
     expect(page).not_to have_field("Scope of operation")
   end
+
+  context "Embedded video" do
+    scenario "Show YouTube video" do
+      proposal = create(:legislation_proposal, video_url: "http://www.youtube.com/watch?v=a7UFm6ErMPU")
+
+      visit legislation_process_proposal_path(proposal.process, proposal)
+
+      within "#js-embedded-video" do
+        expect(page).to have_css "iframe[src='https://www.youtube-nocookie.com/embed/a7UFm6ErMPU']"
+      end
+    end
+
+    scenario "Show Vimeo video" do
+      proposal = create(:legislation_proposal, video_url: "https://vimeo.com/7232823")
+
+      visit legislation_process_proposal_path(proposal.process, proposal)
+
+      within "#js-embedded-video" do
+        expect(page).to have_css "iframe[src='https://player.vimeo.com/video/7232823?dnt=1']"
+      end
+    end
+
+    scenario "Dont show video" do
+      proposal = create(:legislation_proposal, video_url: nil)
+
+      visit legislation_process_proposal_path(proposal.process, proposal)
+
+      expect(page).not_to have_css "#js-embedded-video"
+    end
+  end
 end


### PR DESCRIPTION
## References

* We introduced this bug in pull request #5548 

## Objectives

Since the PR "Do not use third-party cookies in embedded videos #5548", the logic from "embed_videos_helper" was extracted to the "embedded_video_component" and the "videoable" model concern.

However, during this refactor, the "regex" method, which uses record.class:: to handle video embeds, was left inaccessible for Legislation Proposals.

This commit fixes the issue by including the concern in the Legislation Proposal model.