### PR TITLE
Make sure requests finish in ballots back link tests

### DIFF
--- a/app/views/layouts/_common_head.html.erb
+++ b/app/views/layouts/_common_head.html.erb
@@ -14,3 +14,7 @@
 <noscript>
   <%= stylesheet_link_tag "noscript" %>
 </noscript>
+
+<% if Rails.env.test? %>
+  <meta name="turbolinks-cache-control" content="no-preview">
+<% end %>

--- a/spec/system/budgets/ballots_spec.rb
+++ b/spec/system/budgets/ballots_spec.rb
@@ -444,6 +444,7 @@ describe "Ballots" do
       click_link "Go back"
 
       expect(page).to have_current_path(budget_investments_path(budget, heading_id: new_york.id))
+      expect(page).to have_link "Check my votes"
     end
 
     scenario "before adding any investments" do
@@ -459,6 +460,7 @@ describe "Ballots" do
       click_link "Go back"
 
       expect(page).to have_current_path(budget_investments_path(budget, heading_id: new_york.id))
+      expect(page).to have_link "Check my votes"
     end
   end
 


### PR DESCRIPTION
## References

* The test "Users Sign in, admin with password expired" failed in our [test run #8057, job 3](https://github.com/consuldemocracy/consuldemocracy/actions/runs/11342416001/job/31542766542) (see the [test run #8057, job 3 log](https://github.com/user-attachments/files/17376959/run_8057_job_3.txt))  due to this issue

## Objectives

* Make sure requests in ballots back link tests don't leak between tests

## Notes

We need two changes in order to fix this issue: disabling turbolinks previews and adding extra expectations. Check the commit messages for more details.

To reproduce the test that failed without these changes, run:

```bash
rspec spec/system/budgets/ballots_spec.rb:425 spec/system/users_auth_spec.rb:701 --seed 40358
```

The test failure was:

```
Failures:

  1) Users Sign in, admin with password expired
     Failure/Error: find_by(slug: slug_or_id) || find(slug_or_id)

     ActiveRecord::RecordNotFound:
       Couldn't find Budget with 'id'=31

     [Screenshot Image]: /home/runner/work/consuldemocracy/consuldemocracy/tmp/capybara/failures_r_spec_example_groups_users_sign_in__admin_with_password_expired_779.png


     # ./app/models/concerns/sluggable.rb:12:in `find_by_slug_or_id!'
     # ./app/controllers/budgets/investments_controller.rb:141:in `load_budget'
     # ./app/controllers/application_controller.rb:50:in `switch_locale'
     # ------------------
     # --- Caused by: ---
     # Capybara::ExpectationNotMet:
     #   expected to find text "Password successfully updated" in "Puma caught this error: Couldn't find Budget with 'id'=31 (ActiveRecord::RecordNotFound)\n
```