### PR TITLE
Bump foundation-sites from 6.7.5 to 6.8.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
       "name": "consuldemocracy",
       "dependencies": {
         "blueimp-file-upload": "^10.32.0",
-        "foundation-sites": "^6.7.5",
+        "foundation-sites": "^6.8.1",
         "jquery": "^3.7.1",
         "jquery-ui": "^1.13.3",
         "jquery-ujs": "^1.2.3",
@@ -1173,11 +1173,11 @@
       "dev": true
     },
     "node_modules/foundation-sites": {
-      "version": "6.7.5",
-      "resolved": "https://registry.npmjs.org/foundation-sites/-/foundation-sites-6.7.5.tgz",
-      "integrity": "sha512-MEjAENdF/IV2XQvlQmg20o+iDTyyWu0N/j440e8fKbEylbKxARzgg5S7vcnxtjukC1Lqg+rRm7ZDSSyGhVVoUQ==",
+      "version": "6.8.1",
+      "resolved": "https://registry.npmjs.org/foundation-sites/-/foundation-sites-6.8.1.tgz",
+      "integrity": "sha512-9JAuLqVgzf7EIRUqVKeYN68dU/SGe0aNJPgnejdfJKSWnBFdQLF3Zvy9WEQ1gE/gnyvwG3Ia3LkkEd9774n0bQ==",
       "engines": {
-        "node": ">=12.0"
+        "node": ">=16.0"
       },
       "peerDependencies": {
         "jquery": ">=3.6.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "consuldemocracy",
   "dependencies": {
     "blueimp-file-upload": "^10.32.0",
-    "foundation-sites": "^6.7.5",
+    "foundation-sites": "^6.8.1",
     "jquery": "^3.7.1",
     "jquery-ui": "^1.13.3",
     "jquery-ujs": "^1.2.3",


### PR DESCRIPTION
## References

Related PR: Bump foundation-sites from 6.7.5 to 6.9.0 #5724 

## Objectives

Update the foundation-sites incrementally from version 6.7.5 to 6.8.1, ensuring everything works smoothly with this intermediate version before proceeding to further updates.