### PR TITLE
Wait for suggestions in multitenancy and document tests

### DIFF
--- a/spec/system/documents_spec.rb
+++ b/spec/system/documents_spec.rb
@@ -6,7 +6,7 @@ describe "Documents" do
       login_as(create(:user))
       visit new_proposal_path
 
-      fill_in "Proposal title", with: "debate"
+      fill_in_new_proposal_title with: "debate"
       fill_in "Proposal summary", with: "In summary, what we want is..."
       fill_in "Full name of the person submitting the proposal", with: "Isabel Garcia"
       documentable_attach_new_file(file_fixture("logo_with_metadata.pdf"))

--- a/spec/system/multitenancy_spec.rb
+++ b/spec/system/multitenancy_spec.rb
@@ -45,7 +45,7 @@ describe "Multitenancy", :seed_tenants do
 
     with_subdomain("mars") do
       visit new_proposal_path
-      fill_in "Proposal title", with: "Use the unaccent extension in Mars"
+      fill_in_new_proposal_title with: "Use the unaccent extension in Mars"
       fill_in "Proposal summary", with: "tsvector for María the Martian"
       check "I agree to the Privacy Policy and the Terms and conditions of use"
 
@@ -73,7 +73,7 @@ describe "Multitenancy", :seed_tenants do
 
     with_subdomain("mars") do
       visit new_debate_path
-      fill_in "Debate title", with: "Found any water here?"
+      fill_in_new_debate_title with: "Found any water here?"
       fill_in_ckeditor "Initial debate text", with: "Found any water here?"
       check "I agree to the Privacy Policy and the Terms and conditions of use"
 


### PR DESCRIPTION
## References

* We fixed similar issues in pull request #4703

## Objectives

* Avoid having simultaneous requests in tests, particularly in multitenancy tests where we use different subdomains for different requests, which might cause test failures