### PR TITLE
Remove instance_double usage in CommentsHelper tests

### DIFF
--- a/spec/helpers/comments_helper_spec.rb
+++ b/spec/helpers/comments_helper_spec.rb
@@ -12,25 +12,26 @@ require "rails_helper"
 # end
 RSpec.describe CommentsHelper do
   describe "#user_level_class" do
-    def comment_double(as_administrator: false, as_moderator: false, official: false)
-      user = instance_double(User, official?: official, official_level: "Y")
-      instance_double(Comment, as_administrator?: as_administrator, as_moderator?: as_moderator, user: user)
+    def comment_double(**attributes)
+      defaults = { as_administrator?: false, as_moderator?: false, user: double(official?: false) }
+
+      double(defaults.merge(attributes))
     end
 
     it "returns is-admin for comment done as administrator" do
-      comment = comment_double(as_administrator: true)
+      comment = comment_double(as_administrator?: true)
 
       expect(helper.user_level_class(comment)).to eq("is-admin")
     end
 
     it "returns is-moderator for comment done as moderator" do
-      comment = comment_double(as_moderator: true)
+      comment = comment_double(as_moderator?: true)
 
       expect(helper.user_level_class(comment)).to eq("is-moderator")
     end
 
     it "returns level followed by official level if user is official" do
-      comment = comment_double(official: true)
+      comment = comment_double(user: double(official?: true, official_level: "Y"))
 
       expect(helper.user_level_class(comment)).to eq("level-Y")
     end
@@ -45,14 +46,14 @@ RSpec.describe CommentsHelper do
   describe "#comment_author_class" do
     it "returns is-author if author is the commenting user" do
       author_id = 42
-      comment = instance_double(Comment, user_id: author_id)
+      comment = double(user_id: author_id)
 
       expect(helper.comment_author_class(comment, author_id)).to eq("is-author")
     end
 
     it "returns an empty string if commenter is not the author" do
       author_id = 42
-      comment = instance_double(Comment, user_id: author_id - 1)
+      comment = double(user_id: author_id - 1)
 
       expect(helper.comment_author_class(comment, author_id)).to eq("")
     end

--- a/spec/models/verification/management/document_spec.rb
+++ b/spec/models/verification/management/document_spec.rb
@@ -84,40 +84,34 @@ describe Verification::Management::Document do
 
       describe "#valid_age?" do
         it "returns false when the user is younger than the user's minimum required age" do
-          census_response = instance_double(CensusApi::Response,
-                                            date_of_birth: under_minium_age_date_of_birth)
+          census_response = double(date_of_birth: under_minium_age_date_of_birth)
           expect(Verification::Management::Document.new.valid_age?(census_response)).to be false
         end
 
         it "returns true when the user has the user's minimum required age" do
-          census_response = instance_double(CensusApi::Response,
-                                            date_of_birth: just_minium_age_date_of_birth)
+          census_response = double(date_of_birth: just_minium_age_date_of_birth)
           expect(Verification::Management::Document.new.valid_age?(census_response)).to be true
         end
 
         it "returns true when the user is older than the user's minimum required age" do
-          census_response = instance_double(CensusApi::Response,
-                                            date_of_birth: over_minium_age_date_of_birth)
+          census_response = double(date_of_birth: over_minium_age_date_of_birth)
           expect(Verification::Management::Document.new.valid_age?(census_response)).to be true
         end
       end
 
       describe "#under_age?" do
         it "returns true when the user is younger than the user's minimum required age" do
-          census_response = instance_double(CensusApi::Response,
-                                            date_of_birth: under_minium_age_date_of_birth)
+          census_response = double(date_of_birth: under_minium_age_date_of_birth)
           expect(Verification::Management::Document.new.under_age?(census_response)).to be true
         end
 
         it "returns false when the user is user's minimum required age" do
-          census_response = instance_double(CensusApi::Response,
-                                            date_of_birth: just_minium_age_date_of_birth)
+          census_response = double(date_of_birth: just_minium_age_date_of_birth)
           expect(Verification::Management::Document.new.under_age?(census_response)).to be false
         end
 
         it "returns false when the user is older than user's minimum required age" do
-          census_response = instance_double(CensusApi::Response,
-                                            date_of_birth: over_minium_age_date_of_birth)
+          census_response = double(date_of_birth: over_minium_age_date_of_birth)
           expect(Verification::Management::Document.new.under_age?(census_response)).to be false
         end
       end

--- a/spec/models/verification/management/document_spec.rb
+++ b/spec/models/verification/management/document_spec.rb
@@ -75,43 +75,43 @@ describe Verification::Management::Document do
     end
 
     describe "Allowed Age" do
-      let(:min_age)                        { User.minimum_required_age }
-      let(:over_minium_age_date_of_birth)  { Date.new((min_age + 10).years.ago.year, 12, 31) }
-      let(:under_minium_age_date_of_birth) { Date.new(min_age.years.ago.year, 12, 31) }
-      let(:just_minium_age_date_of_birth) do
+      let(:min_age)                         { User.minimum_required_age }
+      let(:over_minimum_age_date_of_birth)  { Date.new((min_age + 10).years.ago.year, 12, 31) }
+      let(:under_minimum_age_date_of_birth) { Date.new(min_age.years.ago.year, 12, 31) }
+      let(:just_minimum_age_date_of_birth) do
         Date.new(min_age.years.ago.year, min_age.years.ago.month, min_age.years.ago.day)
       end
 
       describe "#valid_age?" do
         it "returns false when the user is younger than the user's minimum required age" do
-          census_response = double(date_of_birth: under_minium_age_date_of_birth)
+          census_response = double(date_of_birth: under_minimum_age_date_of_birth)
           expect(Verification::Management::Document.new.valid_age?(census_response)).to be false
         end
 
         it "returns true when the user has the user's minimum required age" do
-          census_response = double(date_of_birth: just_minium_age_date_of_birth)
+          census_response = double(date_of_birth: just_minimum_age_date_of_birth)
           expect(Verification::Management::Document.new.valid_age?(census_response)).to be true
         end
 
         it "returns true when the user is older than the user's minimum required age" do
-          census_response = double(date_of_birth: over_minium_age_date_of_birth)
+          census_response = double(date_of_birth: over_minimum_age_date_of_birth)
           expect(Verification::Management::Document.new.valid_age?(census_response)).to be true
         end
       end
 
       describe "#under_age?" do
         it "returns true when the user is younger than the user's minimum required age" do
-          census_response = double(date_of_birth: under_minium_age_date_of_birth)
+          census_response = double(date_of_birth: under_minimum_age_date_of_birth)
           expect(Verification::Management::Document.new.under_age?(census_response)).to be true
         end
 
         it "returns false when the user is user's minimum required age" do
-          census_response = double(date_of_birth: just_minium_age_date_of_birth)
+          census_response = double(date_of_birth: just_minimum_age_date_of_birth)
           expect(Verification::Management::Document.new.under_age?(census_response)).to be false
         end
 
         it "returns false when the user is older than user's minimum required age" do
-          census_response = double(date_of_birth: over_minium_age_date_of_birth)
+          census_response = double(date_of_birth: over_minimum_age_date_of_birth)
           expect(Verification::Management::Document.new.under_age?(census_response)).to be false
         end
       end


### PR DESCRIPTION
## References

* These CommentsHelper tests have recently failed a few times, like in our [test run #8137, job 1](https://github.com/consuldemocracy/consuldemocracy/actions/runs/11520867616/job/32074273413) (see the  [test run #8137, job 1 log](https://github.com/user-attachments/files/17526298/test_run_8137_job_1.txt))
* We upgrade rspec-rails (which might or might not be related to this failure) in pull request #5720
* The same error message (although the cause might not be the same) is mentioned in rspec/rspec-mocks#1587

## Objectives

* Reduce the number of tests that fail sometimes in our test suite
* Make stubbing in tests more consistent

## Notes

The tests failed with the following messages:

```
Failures:

  1) CommentsHelper#comment_author_class returns is-author if author is the commenting user
     Failure/Error: comment = instance_double(Comment, user_id: author_id)
       the Comment class does not implement the instance method: user_id
     # ./spec/helpers/comments_helper_spec.rb:48:in `block (3 levels) in <top (required)>'
     # ./spec/spec_helper.rb:40:in `block (3 levels) in <top (required)>'
     # ./spec/spec_helper.rb:39:in `block (2 levels) in <top (required)>'

  2) CommentsHelper#comment_author_class returns an empty string if commenter is not the author
     Failure/Error: comment = instance_double(Comment, user_id: author_id - 1)
       the Comment class does not implement the instance method: user_id
     # ./spec/helpers/comments_helper_spec.rb:55:in `block (3 levels) in <top (required)>'
     # ./spec/spec_helper.rb:40:in `block (3 levels) in <top (required)>'
     # ./spec/spec_helper.rb:39:in `block (2 levels) in <top (required)>'
```