### PR TITLE
Add missing expectation in users test

### DIFF
--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -159,10 +159,12 @@ describe "Users" do
       uncheck "account_public_activity"
       click_button "Save changes"
 
-      logout
+      expect(page).to have_content "Changes saved"
 
+      logout
       visit user_path(user)
-      expect(page).to have_content("activity list private")
+
+      expect(page).to have_content "activity list private"
     end
 
     scenario "is always visible for the owner" do
@@ -183,11 +185,13 @@ describe "Users" do
       uncheck "account_public_activity"
       click_button "Save changes"
 
-      logout
+      expect(page).to have_content "Changes saved"
 
+      logout
       login_as(create(:administrator).user)
       visit user_path(user)
-      expect(page).not_to have_content("activity list private")
+
+      expect(page).not_to have_content "activity list private"
     end
 
     scenario "is always visible for moderators" do
@@ -197,11 +201,13 @@ describe "Users" do
       uncheck "account_public_activity"
       click_button "Save changes"
 
-      logout
+      expect(page).to have_content "Changes saved"
 
+      logout
       login_as(create(:moderator).user)
       visit user_path(user)
-      expect(page).not_to have_content("activity list private")
+
+      expect(page).not_to have_content "activity list private"
     end
 
     describe "User email" do
@@ -461,8 +467,9 @@ describe "Users" do
       check "account_public_interests"
       click_button "Save changes"
 
-      logout
+      expect(page).to have_content "Changes saved"
 
+      logout
       visit user_path(user, filter: "follows")
 
       expect(page).to have_css "#public_interests"
@@ -479,10 +486,12 @@ describe "Users" do
       check "account_public_interests"
       click_button "Save changes"
 
-      logout
+      expect(page).to have_content "Changes saved"
 
+      logout
       visit user_path(user)
-      expect(page).not_to have_content("Sport")
+
+      expect(page).not_to have_content "Sport"
     end
   end
 end


### PR DESCRIPTION
## References

* This test failed in our [test run #8140, job 3](https://github.com/consuldemocracy/consuldemocracy/actions/runs/11522413004/job/32078230958) (see the [test run #8140, job 3 logs](https://github.com/user-attachments/files/17526551/run_8140_job_3.txt))

## Objectives

* Reduce the number of tests that fail sometimes

## Notes

The test failed with the following message:

```
Failures:

  1) Users Public activity user can hide public page
     Failure/Error: expect(page).to have_content("activity list private")
       expected to find text "activity list private" in "Language: \n
       \nEnglish\nDeutsch\nEspañol\nFrançais\nNederlands\nPortuguês
       brasileiro\n中文\n       Notifications\nYou are in\nMy content\nMy
       account\nSign out\nDebates\nProposals\nVoting\nCollaborative
       legislation\nParticipatory budgeting\nSDG\nHelp\nM\nManuela124\nUser has
       no public activity\nOpen government\nThis portal uses the CONSUL
       DEMOCRACY application which is open-source
       software.\nParticipation\nDecide how to shape the city you want to live
       in.\nCONSUL DEMOCRACY, 2024 Privacy Policy Terms and conditions of use
       Accessibility"

     # ./spec/system/users_spec.rb:165:in `block (3 levels) in <top (required)>'
     # ./spec/spec_helper.rb:41:in `block (3 levels) in <top (required)>'
     # ./spec/spec_helper.rb:40:in `block (2 levels) in <top (required)>'
```