### PR TITLE
Track ahoy visits on the server side

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -58,7 +58,6 @@
 //= require ckeditor/loader
 //= require_directory ./ckeditor
 //= require social-share-button
-//= require ahoy
 //= require app
 //= require check_all_none
 //= require comments

--- a/config/initializers/ahoy.rb
+++ b/config/initializers/ahoy.rb
@@ -1,5 +1,3 @@
-Ahoy.api = true
-Ahoy.server_side_visits = :when_needed
 Ahoy.mask_ips = true
 Ahoy.cookies = :none
 

--- a/db/migrate/20241026111636_remove_search_keyword_from_visits.rb
+++ b/db/migrate/20241026111636_remove_search_keyword_from_visits.rb
@@ -1,0 +1,5 @@
+class RemoveSearchKeywordFromVisits < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :visits, :search_keyword, :string
+  end
+end

--- a/db/migrate/20241026112901_add_tokens_to_visits.rb
+++ b/db/migrate/20241026112901_add_tokens_to_visits.rb
@@ -1,0 +1,11 @@
+class AddTokensToVisits < ActiveRecord::Migration[7.0]
+  def change
+    change_table :visits do |t|
+      t.string :visit_token
+      t.string :visitor_token
+    end
+
+    add_index :visits, :visit_token, unique: true
+    add_index :visits, [:visitor_token, :started_at]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_10_26_111636) do
+ActiveRecord::Schema[7.0].define(version: 2024_10_26_112901) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
   enable_extension "plpgsql"
@@ -1703,9 +1703,13 @@ ActiveRecord::Schema[7.0].define(version: 2024_10_26_111636) do
     t.string "utm_content"
     t.string "utm_campaign"
     t.datetime "started_at", precision: nil
+    t.string "visit_token"
+    t.string "visitor_token"
     t.index ["started_at"], name: "index_visits_on_started_at"
     t.index ["user_id"], name: "index_visits_on_user_id"
+    t.index ["visit_token"], name: "index_visits_on_visit_token", unique: true
     t.index ["visitor_id", "started_at"], name: "index_visits_on_visitor_id_and_started_at"
+    t.index ["visitor_token", "started_at"], name: "index_visits_on_visitor_token_and_started_at"
   end
 
   create_table "votation_types", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_05_13_135357) do
+ActiveRecord::Schema[7.0].define(version: 2024_10_26_111636) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
   enable_extension "plpgsql"
@@ -1686,7 +1686,6 @@ ActiveRecord::Schema[7.0].define(version: 2024_05_13_135357) do
     t.text "landing_page"
     t.integer "user_id"
     t.string "referring_domain"
-    t.string "search_keyword"
     t.string "browser"
     t.string "os"
     t.string "device_type"

--- a/spec/system/admin/stats_spec.rb
+++ b/spec/system/admin/stats_spec.rb
@@ -13,7 +13,32 @@ describe "Stats", :admin do
       expect(page).to have_content "DEBATES\n1"
       expect(page).to have_content "PROPOSALS\n2"
       expect(page).to have_content "COMMENTS\n3"
-      expect(page).to have_content "VISITS\n4"
+      expect(page).to have_content "VISITS\n5"
+    end
+
+    scenario "Visits" do
+      visit admin_stats_path
+      refresh
+
+      expect(page).to have_content "VISITS\n1"
+
+      allow_any_instance_of(ActionDispatch::Request).to receive(:user_agent).and_return("Different")
+
+      in_browser(:different) do
+        visit root_path
+
+        click_link "Debates"
+        expect(page).to have_link "Start a debate"
+
+        click_link "Proposals"
+        expect(page).to have_link "Create a proposal"
+      end
+
+      allow_any_instance_of(ActionDispatch::Request).to receive(:user_agent).and_call_original
+
+      refresh
+
+      expect(page).to have_content "VISITS\n2"
     end
 
     scenario "Votes" do


### PR DESCRIPTION
## References

* The visits count doesn't correctly work since we stopped using Ahoy cookies in pull request #5504
* Fixes (for the most part; see the issue) issue #5155

## Objectives

* Fix the way we count visits to our website
* Reduce the number of random failures in multitenancy (and maybe other) tests
* Remove the Ahoy cookie that was set and quickly unset during requests

## Notes

For two years, we've been seeing random failures in the `system/admin/tenants_spec.rb` tests, with messages like:

```
1) Tenants Create Tenant with subdomain
     Failure/Error:
       raise TenantNotFound, <<~EXCEPTION_MESSAGE
         Could not set search path to schemas, they may be invalid: "#{tenant}" #{full_search_path}.
         Original error: #{exception.class}: #{exception}
       EXCEPTION_MESSAGE

     Apartment::TenantNotFound:
       Could not set search path to schemas, they may be invalid: "earth" "public", "shared_extensions".
       Original error: ActiveRecord::StatementInvalid: Could not find schema earth
```

And we've found one of the causes: the AJAX requests done by Ahoy to track visits. Sometimes a test that creates or updates a tenant finishes but the Ahoy AJAX request to, say, `http://earth.lvh.me/ahoy/visits`, is handled by the next test, when the `earth` schema no longer exists, thus raising an `Apartment::TenantNotFound` exception.

So by disabling these AJAX requests and tracking the visits in the server instead, we're killing two birds in one stone: we're fixing the bug regarding the visits count and we're reducing the flakiness in our test suite.