### PR TITLE
Include voter initialization in officing voters lock

### DIFF
--- a/app/controllers/officing/voters_controller.rb
+++ b/app/controllers/officing/voters_controller.rb
@@ -13,16 +13,19 @@ class Officing::VotersController < Officing::BaseController
   def create
     @poll = Poll.find(voter_params[:poll_id])
     @user = User.find(voter_params[:user_id])
-    @voter = Poll::Voter.new(document_type: @user.document_type,
-                             document_number: @user.document_number,
-                             user: @user,
-                             poll: @poll,
-                             origin: "booth",
-                             officer: current_user.poll_officer,
-                             booth_assignment: current_booth.booth_assignments.find_by(poll: @poll),
-                             officer_assignment: officer_assignment(@poll))
 
-    @user.with_lock { @voter.save! }
+    @user.with_lock do
+      @voter = Poll::Voter.new(document_type: @user.document_type,
+                               document_number: @user.document_number,
+                               user: @user,
+                               poll: @poll,
+                               origin: "booth",
+                               officer: current_user.poll_officer,
+                               booth_assignment: current_booth.booth_assignments.find_by(poll: @poll),
+                               officer_assignment: officer_assignment(@poll))
+
+      @voter.save!
+    end
   end
 
   private

--- a/spec/controllers/officing/voters_controller_spec.rb
+++ b/spec/controllers/officing/voters_controller_spec.rb
@@ -15,7 +15,7 @@ describe Officing::VotersController do
             voter: { poll_id: poll.id, user_id: user.id },
             format: :js
           }
-        rescue ActionDispatch::IllegalStateError
+        rescue ActionDispatch::IllegalStateError, ActiveRecord::RecordInvalid
         end
       end.each(&:join)
 


### PR DESCRIPTION
## References

* We introduced this lock in pull request #5532
* The controller test has failed a few times in our CI, like in our [test run 8034, job 1](https://github.com/consuldemocracy/consuldemocracy/actions/runs/11322923408/job/31484548790) (see our [test run 8034, job 1 log](https://github.com/user-attachments/files/17545863/run_8034_job_1.txt))
* This code will be replaced when we add a unique index to the `poll_voters` table in pull request TODO

## Objectives

* Make the code handling simultaneous requests to create poll voters more predictable
* Reduce the number of random failures in our test suite

## Notes

For the reasons explained in the commit message the test wasn't behaving as expected 95% of the time. 5% of the time (where it behaved as expected), we got a failure in the test:

```
  1) Officing::VotersController POST create does not create two records
     with two simultaneous requests
     Failure/Error: @user.with_lock { @voter.save! }

     ActiveRecord::RecordInvalid:
       Validation failed: User User has already voted
     # ./app/controllers/officing/voters_controller.rb:25:in `block in create'
     # ./app/controllers/officing/voters_controller.rb:25:in `create'
     # ./app/controllers/application_controller.rb:50:in `switch_locale'
     # ./spec/controllers/officing/voters_controller_spec.rb:15:in `block (5 levels) in <top (required)>'
```