### PR TITLE
Reduce code duplication in Graphql

### DIFF
--- a/app/graphql/types/base_object.rb
+++ b/app/graphql/types/base_object.rb
@@ -24,5 +24,11 @@ module Types
         define_method(field_name) { object.send(field_name).public_for_api }
       end
     end
+
+    def self.object_by_id_field(field_name, type, description, null:)
+      field field_name, type, description, null: null do
+        argument :id, ID, required: true, default_value: false
+      end
+    end
   end
 end

--- a/app/graphql/types/base_object.rb
+++ b/app/graphql/types/base_object.rb
@@ -30,5 +30,9 @@ module Types
         argument :id, ID, required: true, default_value: false
       end
     end
+
+    def self.collection_field(field_name, type, ...)
+      field(field_name, type.connection_type, ...)
+    end
   end
 end

--- a/app/graphql/types/budget_investment_type.rb
+++ b/app/graphql/types/budget_investment_type.rb
@@ -7,8 +7,8 @@ module Types
     field :title, String, null: true
     field :description, String, null: true
     field :location, String, null: true
-    field :comments, Types::CommentType.connection_type, null: true
+    collection_field :comments, Types::CommentType, null: true
     field :comments_count, Integer, null: true
-    field :milestones, Types::MilestoneType.connection_type, null: true
+    collection_field :milestones, Types::MilestoneType, null: true
   end
 end

--- a/app/graphql/types/budget_type.rb
+++ b/app/graphql/types/budget_type.rb
@@ -4,9 +4,7 @@ module Types
     field :name, String, null: true
     field :phase, String, null: true
     field :investments, Types::BudgetInvestmentType.connection_type, "Returns all investments", null: false
-    field :investment, Types::BudgetInvestmentType, null: false do
-      argument :id, ID, required: true, default_value: false
-    end
+    object_by_id_field :investment, Types::BudgetInvestmentType, "Returns investment for ID", null: false
 
     def investments
       Budget::Investment.public_for_api

--- a/app/graphql/types/budget_type.rb
+++ b/app/graphql/types/budget_type.rb
@@ -3,7 +3,7 @@ module Types
     field :id, ID, null: false
     field :name, String, null: true
     field :phase, String, null: true
-    field :investments, Types::BudgetInvestmentType.connection_type, "Returns all investments", null: false
+    collection_field :investments, Types::BudgetInvestmentType, "Returns all investments", null: false
     object_by_id_field :investment, Types::BudgetInvestmentType, "Returns investment for ID", null: false
 
     def investments

--- a/app/graphql/types/comment_type.rb
+++ b/app/graphql/types/comment_type.rb
@@ -11,6 +11,6 @@ module Types
     field :id, ID, null: false
     field :public_author, Types::UserType, null: true
     field :public_created_at, String, null: true
-    field :votes_for, Types::VoteType.connection_type, null: true
+    collection_field :votes_for, Types::VoteType, null: true
   end
 end

--- a/app/graphql/types/debate_type.rb
+++ b/app/graphql/types/debate_type.rb
@@ -3,7 +3,7 @@ module Types
     field :cached_votes_down, Integer, null: true
     field :cached_votes_total, Integer, null: true
     field :cached_votes_up, Integer, null: true
-    field :comments, Types::CommentType.connection_type, null: true
+    collection_field :comments, Types::CommentType, null: true
     field :comments_count, Integer, null: true
     field :confidence_score, Integer, null: true
     field :description, String, null: true
@@ -11,9 +11,9 @@ module Types
     field :id, ID, null: false
     field :public_author, Types::UserType, null: true
     field :public_created_at, String, null: true
-    field :tags, Types::TagType.connection_type, null: true
+    collection_field :tags, Types::TagType, null: true
     field :title, String, null: true
-    field :votes_for, Types::VoteType.connection_type, null: true
+    collection_field :votes_for, Types::VoteType, null: true
 
     def tags
       object.tags.public_for_api

--- a/app/graphql/types/proposal_type.rb
+++ b/app/graphql/types/proposal_type.rb
@@ -1,7 +1,7 @@
 module Types
   class ProposalType < Types::BaseObject
     field :cached_votes_up, Integer, null: true
-    field :comments, Types::CommentType.connection_type, null: true
+    collection_field :comments, Types::CommentType, null: true
     field :comments_count, Integer, null: true
     field :confidence_score, Integer, null: true
     field :description, String, null: true
@@ -9,18 +9,18 @@ module Types
     field :geozone_id, Integer, null: true
     field :hot_score, Integer, null: true
     field :id, ID, null: false
-    field :proposal_notifications, Types::ProposalNotificationType.connection_type, null: true
+    collection_field :proposal_notifications, Types::ProposalNotificationType, null: true
     field :public_author, Types::UserType, null: true
     field :public_created_at, String, null: true
     field :retired_at, GraphQL::Types::ISO8601DateTime, null: true
     field :retired_explanation, String, null: true
     field :retired_reason, String, null: true
     field :summary, String, null: true
-    field :tags, Types::TagType.connection_type, null: true
+    collection_field :tags, Types::TagType, null: true
     field :title, String, null: true
     field :video_url, String, null: true
-    field :votes_for, Types::VoteType.connection_type, null: true
-    field :milestones, Types::MilestoneType.connection_type, null: true
+    collection_field :votes_for, Types::VoteType, null: true
+    collection_field :milestones, Types::MilestoneType, null: true
 
     def tags
       object.tags.public_for_api

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -1,61 +1,41 @@
 module Types
   class QueryType < Types::BaseObject
     field :budgets, Types::BudgetType.connection_type, "Returns all budgets", null: false
-    field :budget, Types::BudgetType, "Returns budget for ID", null: false do
-      argument :id, ID, required: true, default_value: false
-    end
+    object_by_id_field :budget, Types::BudgetType, "Returns budget for ID", null: false
 
     field :comments, Types::CommentType.connection_type, "Returns all comments", null: false
-    field :comment, Types::CommentType, "Returns comment for ID", null: false do
-      argument :id, ID, required: true, default_value: false
-    end
+    object_by_id_field :comment, Types::CommentType, "Returns comment for ID", null: false
 
     field :debates, Types::DebateType.connection_type, "Returns all debates", null: false
-    field :debate, Types::DebateType, "Returns debate for ID", null: false do
-      argument :id, ID, required: true, default_value: false
-    end
+    object_by_id_field :debate, Types::DebateType, "Returns debate for ID", null: false
 
     field :geozones, Types::GeozoneType.connection_type, "Returns all geozones", null: false
-    field :geozone, Types::GeozoneType, "Returns geozone for ID", null: false do
-      argument :id, ID, required: true, default_value: false
-    end
+    object_by_id_field :geozone, Types::GeozoneType, "Returns geozone for ID", null: false
 
     field :milestones, Types::MilestoneType.connection_type, "Returns all milestones", null: false
-    field :milestone, Types::MilestoneType, "Returns milestone for ID", null: false do
-      argument :id, ID, required: true, default_value: false
-    end
+    object_by_id_field :milestone, Types::MilestoneType, "Returns milestone for ID", null: false
 
     field :proposals, Types::ProposalType.connection_type, "Returns all proposals", null: false
-    field :proposal, Types::ProposalType, "Returns proposal for ID", null: false do
-      argument :id, ID, required: true, default_value: false
-    end
+    object_by_id_field :proposal, Types::ProposalType, "Returns proposal for ID", null: false
 
     field :proposal_notifications,
           Types::ProposalNotificationType.connection_type,
           "Returns all proposal notifications",
           null: false
 
-    field :proposal_notification,
+    object_by_id_field :proposal_notification,
           Types::ProposalNotificationType,
           "Returns proposal notification for ID",
-          null: false do
-      argument :id, ID, required: true, default_value: false
-    end
+          null: false
 
     field :tags, Types::TagType.connection_type, "Returns all tags", null: false
-    field :tag, Types::TagType, "Returns tag for ID", null: false do
-      argument :id, ID, required: true, default_value: false
-    end
+    object_by_id_field :tag, Types::TagType, "Returns tag for ID", null: false
 
     field :users, Types::UserType.connection_type, "Returns all users", null: false
-    field :user, Types::UserType, "Returns user for ID", null: false do
-      argument :id, ID, required: true, default_value: false
-    end
+    object_by_id_field :user, Types::UserType, "Returns user for ID", null: false
 
     field :votes, Types::VoteType.connection_type, "Returns all votes", null: false
-    field :vote, Types::VoteType, "Returns vote for ID", null: false do
-      argument :id, ID, required: true, default_value: false
-    end
+    object_by_id_field :vote, Types::VoteType, "Returns vote for ID", null: false
 
     def budgets
       Budget.public_for_api

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -1,10 +1,7 @@
 module Types
   class QueryType < Types::BaseObject
     def self.collection_and_object_by_id_fields(name, type)
-      field name.to_s.pluralize.to_sym,
-            type.connection_type,
-            "Returns all #{name.to_s.pluralize}",
-             null: false
+      collection_field name.to_s.pluralize.to_sym, type, "Returns all #{name.to_s.pluralize}", null: false
       object_by_id_field name, type, "Returns #{name} for ID", null: false
     end
 

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -1,41 +1,23 @@
 module Types
   class QueryType < Types::BaseObject
-    field :budgets, Types::BudgetType.connection_type, "Returns all budgets", null: false
-    object_by_id_field :budget, Types::BudgetType, "Returns budget for ID", null: false
+    def self.collection_and_object_by_id_fields(name, type)
+      field name.to_s.pluralize.to_sym,
+            type.connection_type,
+            "Returns all #{name.to_s.pluralize}",
+             null: false
+      object_by_id_field name, type, "Returns #{name} for ID", null: false
+    end
 
-    field :comments, Types::CommentType.connection_type, "Returns all comments", null: false
-    object_by_id_field :comment, Types::CommentType, "Returns comment for ID", null: false
-
-    field :debates, Types::DebateType.connection_type, "Returns all debates", null: false
-    object_by_id_field :debate, Types::DebateType, "Returns debate for ID", null: false
-
-    field :geozones, Types::GeozoneType.connection_type, "Returns all geozones", null: false
-    object_by_id_field :geozone, Types::GeozoneType, "Returns geozone for ID", null: false
-
-    field :milestones, Types::MilestoneType.connection_type, "Returns all milestones", null: false
-    object_by_id_field :milestone, Types::MilestoneType, "Returns milestone for ID", null: false
-
-    field :proposals, Types::ProposalType.connection_type, "Returns all proposals", null: false
-    object_by_id_field :proposal, Types::ProposalType, "Returns proposal for ID", null: false
-
-    field :proposal_notifications,
-          Types::ProposalNotificationType.connection_type,
-          "Returns all proposal notifications",
-          null: false
-
-    object_by_id_field :proposal_notification,
-          Types::ProposalNotificationType,
-          "Returns proposal notification for ID",
-          null: false
-
-    field :tags, Types::TagType.connection_type, "Returns all tags", null: false
-    object_by_id_field :tag, Types::TagType, "Returns tag for ID", null: false
-
-    field :users, Types::UserType.connection_type, "Returns all users", null: false
-    object_by_id_field :user, Types::UserType, "Returns user for ID", null: false
-
-    field :votes, Types::VoteType.connection_type, "Returns all votes", null: false
-    object_by_id_field :vote, Types::VoteType, "Returns vote for ID", null: false
+    collection_and_object_by_id_fields :budget, Types::BudgetType
+    collection_and_object_by_id_fields :comment, Types::CommentType
+    collection_and_object_by_id_fields :debate, Types::DebateType
+    collection_and_object_by_id_fields :geozone, Types::GeozoneType
+    collection_and_object_by_id_fields :milestone, Types::MilestoneType
+    collection_and_object_by_id_fields :proposal, Types::ProposalType
+    collection_and_object_by_id_fields :proposal_notification, Types::ProposalNotificationType
+    collection_and_object_by_id_fields :tag, Types::TagType
+    collection_and_object_by_id_fields :user, Types::UserType
+    collection_and_object_by_id_fields :vote, Types::VoteType
 
     def budgets
       Budget.public_for_api

--- a/app/graphql/types/user_type.rb
+++ b/app/graphql/types/user_type.rb
@@ -1,9 +1,9 @@
 module Types
   class UserType < Types::BaseObject
     field :id, ID, null: false
-    field :public_comments, Types::CommentType.connection_type, null: true
-    field :public_debates, Types::DebateType.connection_type, null: true
-    field :public_proposals, Types::ProposalType.connection_type, null: true
+    collection_field :public_comments, Types::CommentType, null: true
+    collection_field :public_debates, Types::DebateType, null: true
+    collection_field :public_proposals, Types::ProposalType, null: true
     field :username, String, null: true
   end
 end


### PR DESCRIPTION
## References
Bump graphql from 1.13.22 to 2.0.31 #5748 

## Objectives

Apply refactors to reduce code duplication:
  - Introduce a helper method to handle connection_type fields more efficiently.
  - Simplify the definition of id-based fields using a new id_field helper, reducing redundancy in the QueryType and other types.
