### PR TITLE
Include stat graphs JavaScript in all admin stats actions 

### DIFF
--- a/app/components/admin/stats/budget_balloting_component.html.erb
+++ b/app/components/admin/stats/budget_balloting_component.html.erb
@@ -1,3 +1,5 @@
+<% include_stat_graphs_javascript %>
+
 <%= back_link_to budgets_admin_stats_path %>
 
 <h2><%= budget.name %> - <%= t("admin.stats.budget_balloting.title") %></h2>

--- a/app/components/admin/stats/budget_balloting_component.rb
+++ b/app/components/admin/stats/budget_balloting_component.rb
@@ -1,5 +1,6 @@
 class Admin::Stats::BudgetBallotingComponent < ApplicationComponent
   attr_reader :budget
+  use_helpers :include_stat_graphs_javascript
 
   def initialize(budget)
     @budget = budget

--- a/app/components/admin/stats/budget_supporting_component.html.erb
+++ b/app/components/admin/stats/budget_supporting_component.html.erb
@@ -1,6 +1,4 @@
-<% content_for :head do %>
-  <%= javascript_include_tag "stat_graphs", "data-turbolinks-track" => "reload" %>
-<% end %>
+<% include_stat_graphs_javascript %>
 
 <%= back_link_to budgets_admin_stats_path %>
 

--- a/app/components/admin/stats/budget_supporting_component.rb
+++ b/app/components/admin/stats/budget_supporting_component.rb
@@ -1,5 +1,6 @@
 class Admin::Stats::BudgetSupportingComponent < ApplicationComponent
   attr_reader :budget
+  use_helpers :include_stat_graphs_javascript
 
   def initialize(budget)
     @budget = budget

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -18,6 +18,12 @@ module ApplicationHelper
     WYSIWYGSanitizer.new.sanitize(text)
   end
 
+  def include_stat_graphs_javascript
+    content_for :head do
+      javascript_include_tag "stat_graphs", "data-turbolinks-track" => "reload"
+    end
+  end
+
   def author_of?(authorable, user)
     return false if authorable.blank? || user.blank?
 

--- a/app/views/admin/stats/budgets.html.erb
+++ b/app/views/admin/stats/budgets.html.erb
@@ -1,3 +1,5 @@
+<% include_stat_graphs_javascript %>
+
 <%= back_link_to admin_stats_path %>
 
 <h2><%= t("admin.stats.budgets.title") %></h2>

--- a/app/views/admin/stats/direct_messages.html.erb
+++ b/app/views/admin/stats/direct_messages.html.erb
@@ -1,3 +1,5 @@
+<% include_stat_graphs_javascript %>
+
 <%= back_link_to admin_stats_path %>
 
 <h2><%= t("admin.stats.direct_messages.title") %></h2>

--- a/app/views/admin/stats/graph.html.erb
+++ b/app/views/admin/stats/graph.html.erb
@@ -1,6 +1,4 @@
-<% content_for :head do %>
-  <%= javascript_include_tag "stat_graphs", "data-turbolinks-track" => "reload" %>
-<% end %>
+<% include_stat_graphs_javascript %>
 
 <%= back_link_to admin_stats_path %>
 

--- a/app/views/admin/stats/polls.html.erb
+++ b/app/views/admin/stats/polls.html.erb
@@ -1,3 +1,5 @@
+<% include_stat_graphs_javascript %>
+
 <%= back_link_to admin_stats_path %>
 
 <h2 id="top"><%= t("admin.stats.polls.title") %></h2>

--- a/app/views/admin/stats/proposal_notifications.html.erb
+++ b/app/views/admin/stats/proposal_notifications.html.erb
@@ -1,3 +1,5 @@
+<% include_stat_graphs_javascript %>
+
 <%= back_link_to admin_stats_path %>
 
 <h2><%= t("admin.stats.proposal_notifications.title") %></h2>

--- a/app/views/admin/stats/sdg.html.erb
+++ b/app/views/admin/stats/sdg.html.erb
@@ -1,1 +1,3 @@
+<% include_stat_graphs_javascript %>
+
 <%= render Admin::Stats::SDGComponent.new(@goals) %>

--- a/app/views/admin/stats/show.html.erb
+++ b/app/views/admin/stats/show.html.erb
@@ -1,6 +1,4 @@
-<% content_for :head do %>
-  <%= javascript_include_tag "stat_graphs", "data-turbolinks-track" => "reload" %>
-<% end %>
+<% include_stat_graphs_javascript %>
 
 <div id="stats" class="stats">
   <div class="row">


### PR DESCRIPTION
## References

* Due to this issue, the test "Stats Budget investments Supporting phase Number of users and supports in investment projects" has failed several times, like in our [test run 8260, job 1](https://github.com/consuldemocracy/consuldemocracy/actions/runs/11723867084/job/32656471380) (see the [test run 8260, job 1 log](https://github.com/user-attachments/files/17682754/run_8260_job_1.txt))

## Objectives

* Reduce the number of "double requests" done by Turbolinks in the admin stats section
* Reduce the number of tests that fail sometimes in our test suite

## Notes

The mentioned test sometimes failed with this message:

```
  1) Stats Budget investments Supporting phase Number of users and supports in investment projects
     Failure/Error: raise ex, cause: cause

     Selenium::WebDriver::Error::UnknownError:
       unknown error: unhandled inspector error:
         {"code":-32000,"message":"Node with given id does not belong to the document"}
         (Session info: chrome=129.0.6668.89)
```