### PR TITLE
include physical ballots in total number of voters

### DIFF
--- a/app/models/budget/stats.rb
+++ b/app/models/budget/stats.rb
@@ -50,7 +50,11 @@ class Budget::Stats
   end
 
   def total_participants_vote_phase
-    (balloters + poll_ballot_voters).uniq.count
+    (balloters + poll_ballot_voters).uniq.count + total_physical_balloters
+  end
+  
+  def total_physical_balloters
+    budget.ballots.where(physical: true).count
   end
 
   def total_budget_investments


### PR DESCRIPTION

## Objectives

In Participatory Budgeting
When uploading ballot sheets the ballots are correctly counted

In stats the number of votes is correctly displayed

The number of participants is not updated to reflect offline or physical voters.


![locality stats](https://github.com/user-attachments/assets/107965fb-019c-44e8-8d46-45a14724b910)

This change assumes each line in a ballot sheet represents a participant and includes physical voters in the final total

## Notes

This only partially improves the PB stats.
The participants per district table is not updated because there is no way to associate the Polling Booth Location with the district.

The solution to this will be to make the Polling Booth Location selectable from a drop down of either Budget Heading Scope of Operation or from the list of geozones. This would then allow the ballot sheets to be counted by location allowing the update of participants by district

There may be some redundant code here still as it refers to poll_ballot_voters and as far as I can see that isn't used anywhere?
