### PR TITLE
Use Debian Bookworm in our Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.2.5-bullseye
+FROM ruby:3.2.5-bookworm
 
 ENV DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
## References

* [Debian 11 ("bullseye") has been superseded by Debian 12 ("bookworm")](https://www.debian.org/releases/bullseye/)
* [Debian 12 was released on June 10th, 2023](https://www.debian.org/releases/bookworm/)

## Objectives

* Use the latest stable version of the operating system used in our Dockerfile