### PR TITLE
Add Ruby version to Gemfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,6 +46,7 @@ RUN curl -sL https://github.com/nodenv/node-build/archive/master.tar.gz | tar xz
 
 # Use the Gemfiles as Docker cache markers. Always bundle before copying app src.
 # (the src likely changed and we don't want to invalidate Docker's cache too early)
+COPY .ruby-version ./
 COPY Gemfile* ./
 RUN bundle install
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,7 @@
 source "https://rubygems.org"
 
+ruby file: ".ruby-version"
+
 gem "rails", "7.0.8.7"
 
 gem "acts-as-taggable-on", "~> 11.0.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -804,5 +804,8 @@ DEPENDENCIES
   wicked_pdf (~> 2.8.1)
   wkhtmltopdf-binary (~> 0.12.6)
 
+RUBY VERSION
+   ruby 3.2.5p208
+
 BUNDLED WITH
    2.4.19

--- a/docs/en/installation/deploying-on-heroku.md
+++ b/docs/en/installation/deploying-on-heroku.md
@@ -58,7 +58,7 @@ This tutorial assumes that you have already managed to clone Consul Democracy on
 
   **Remember not to commit the file if you have any sensitive information in it!**
 
-6. To ensure Heroku correctly detects and uses the node.js and ruby versions defined in the project, we need to make the following changes:
+6. To ensure Heroku correctly detects and uses the node.js version defined in the project, we need to make the following changes:
 
   In package.json, add the node.js version:
 
@@ -72,18 +72,6 @@ This tutorial assumes that you have already managed to clone Consul Democracy on
 
   ```bash
   heroku buildpacks:add heroku/nodejs
-  ```
-
-  In _Gemfile_, add the ruby version and run bundle:
-
-  ```Gemfile
-  ruby file: ".ruby-version"
-  ```
-
-  and apply:
-
-  ```bash
-  heroku buildpacks:set heroku/ruby
   ```
 
 7. You can now push your app using:

--- a/docs/es/installation/deploying-on-heroku.md
+++ b/docs/es/installation/deploying-on-heroku.md
@@ -58,7 +58,7 @@ Este tutorial asume que ya has conseguido clonar Consul Democracy en tu máquina
 
   **¡Recuerda no añadir el archivo si tienes información sensible en él!**
 
-6. Para que Heroku detecte y utilice correctamente las versiones de node.js y ruby definidas en el proyecto deberemos añadir los siguientes cambios:
+6. Para que Heroku detecte y utilice correctamente la versión de node.js definida en el proyecto deberemos añadir los siguientes cambios:
 
   En el _package.json_  añadir la versión de node.js:
 
@@ -72,18 +72,6 @@ Este tutorial asume que ya has conseguido clonar Consul Democracy en tu máquina
 
   ```bash
   heroku buildpacks:add heroku/nodejs
-  ```
-
-  En el _Gemfile_ añadir la versión de ruby y ejecutar bundle:
-
-  ```Gemfile
-  ruby file: ".ruby-version"
-  ```
-
-  y aplicar:
-
-  ```bash
-  heroku buildpacks:set heroku/ruby
   ```
 
 7. Ahora ya puedes subir tu aplicación utilizando:


### PR DESCRIPTION
## References

* The `file` option in the `ruby` method is available since [Bundler 2.4.19](https://github.com/rubygems/rubygems/releases/tag/bundler-v2.4.19)

## Objectives

* Make sure people using RVM in development don't accidentally run the application using the wrong Ruby version
* Simplify configuration for services like Heroku

## Notes

The disadvantage of this system is that, now, every time we update the Ruby version, we have to remember to run `bundle` so our `Gemfile.lock` gets the new version.