### PR TITLE
Budgets: allow admins to change winners & make columns adaptive to current phase

### DIFF
--- a/app/assets/javascripts/columns_selector.js
+++ b/app/assets/javascripts/columns_selector.js
@@ -2,15 +2,12 @@
   "use strict";
   App.ColumnsSelector = {
     initColumns: function() {
-      var c_value, columns;
+      var columns;
       App.ColumnsSelector.hideAll();
-      c_value = App.ColumnsSelector.currentValue();
-      if (c_value.length === 0) {
-        c_value = $("#js-columns-selector").data("default");
-        App.Cookies.saveCookie($("#js-columns-selector").data("cookie"), c_value, 30);
-      }
-      columns = c_value.split(",");
-      columns.forEach(function(column) {
+      columns =
+        App.Cookies.getCookie($("#js-columns-selector").data("cookie")) ||
+        $("#js-columns-selector").data("default");
+      columns.split(",").forEach(function(column) {
         $("[data-field=" + column + "]").removeClass("hidden");
         $("#column_selector_" + column).prop("checked", true);
       });
@@ -50,22 +47,18 @@
       } else {
         $("[data-field=" + column + "]").addClass("hidden");
       }
-      value = App.ColumnsSelector.updateItem(column);
+      App.ColumnsSelector.saveCookie();
+    },
+    saveCookie: function() {
+      var shownColumns, value;
+      shownColumns = [];
+      $(".column-selector-item input").each(function() {
+        if ($(this).prop("checked")) {
+          shownColumns.push($(this).data("column"));
+        }
+      });
+      value = shownColumns.join(",");
       App.Cookies.saveCookie($("#js-columns-selector").data("cookie"), value, 30);
-    },
-    updateItem: function(value) {
-      var index, values;
-      values = App.ColumnsSelector.currentValue().split(",");
-      index = values.indexOf(value);
-      if (index >= 0) {
-        values.splice(index, 1);
-      } else {
-        values.push(value);
-      }
-      return values.join(",");
-    },
-    currentValue: function() {
-      return App.Cookies.getCookie($("#js-columns-selector").data("cookie"));
     },
     initialize: function() {
       App.ColumnsSelector.initChecks();

--- a/app/components/admin/budget_investments/investments_component.html.erb
+++ b/app/components/admin/budget_investments/investments_component.html.erb
@@ -10,8 +10,8 @@
   <% if investments.any? %>
     <h3 class="inline-block"><%= page_entries_info investments %></h3>
     <%= render "admin/shared/columns_selector",
-               cookie: "investments-columns",
-               default: %w[id title supports admin valuator geozone feasibility price valuation_finished visible_to_valuators selected incompatible] %>
+               cookie: cookie,
+               default: default_columns %>
     <br>
 
     <%= render "filters_description", i18n_namespace: "admin.budget_investments.index" %>
@@ -19,7 +19,7 @@
     <table class="table-for-mobile column-selectable">
       <thead>
         <tr>
-          <th><%= link_to_investments_sorted_by :id %></th>
+          <th data-field="id"><%= link_to_investments_sorted_by :id %></th>
           <th data-field="title"><%= link_to_investments_sorted_by :title %></th>
           <th data-field="supports"><%= link_to_investments_sorted_by :supports %></th>
           <th data-field="admin"><%= t("admin.budget_investments.index.list.admin") %></th>
@@ -45,6 +45,8 @@
           <% if params[:advanced_filters]&.include?("selected") %>
             <th data-field="incompatible"><%= t("admin.budget_investments.index.list.incompatible") %></th>
           <% end %>
+          <th data-field="ballot_lines_count"><%= link_to_investments_sorted_by :ballot_lines_count %></th>
+          <th data-field="winner"><%= t("admin.budget_investments.index.list.winner") %></th>
         </tr>
       </thead>
 

--- a/app/components/admin/budget_investments/investments_component.rb
+++ b/app/components/admin/budget_investments/investments_component.rb
@@ -27,4 +27,26 @@ class Admin::BudgetInvestments::InvestmentsComponent < ApplicationComponent
         admin_budget_budget_investments_path(sort_by: column, direction: direction)
       )
     end
+
+    def cookie
+      "investments-columns-#{budget.current_phase.kind}"
+    end
+
+    def default_columns
+      base_columns = ["id", "title", "geozone", "price", "selected", "incompatible"]
+      if budget.selecting? || budget.valuating? || budget.publishing_prices?
+        base_columns += ["supports"]
+      end
+      if budget.accepting? || budget.reviewing? || budget.selecting? ||
+         budget.valuating? || budget.publishing_prices?
+        base_columns += ["feasibility", "admin", "valuator", "valuation_finished", "visible_to_valuators"]
+      end
+      if budget.balloting? || budget.reviewing_ballots? || budget.finished?
+        base_columns += ["ballot_lines_count"]
+      end
+      if budget.reviewing_ballots? || budget.finished?
+        base_columns += ["winner"]
+      end
+      base_columns
+    end
 end

--- a/app/components/admin/budget_investments/row_component.html.erb
+++ b/app/components/admin/budget_investments/row_component.html.erb
@@ -54,4 +54,12 @@
       <%= investment.incompatible? ? t("shared.yes") : t("shared.no") %>
     </td>
   <% end %>
+
+  <td data-field="ballot_lines_count">
+    <%= investment.ballot_lines_count %>
+  </td>
+
+  <td data-field="winner">
+    <%= render Admin::BudgetInvestments::ToggleWinnerComponent.new(investment) %>
+  </td>
 </tr>

--- a/app/components/admin/budget_investments/toggle_winner_component.html.erb
+++ b/app/components/admin/budget_investments/toggle_winner_component.html.erb
@@ -1,0 +1,5 @@
+<% if can?(action, investment) %>
+  <%= render Admin::ToggleSwitchComponent.new(action, investment, pressed: winner?, **options) %>
+<% elsif winner? %>
+  <%= winner_text %>
+<% end %>

--- a/app/components/admin/budget_investments/toggle_winner_component.rb
+++ b/app/components/admin/budget_investments/toggle_winner_component.rb
@@ -1,0 +1,50 @@
+class Admin::BudgetInvestments::ToggleWinnerComponent < ApplicationComponent
+  attr_reader :investment
+  use_helpers :can?
+  delegate :winner?, to: :investment
+
+  def initialize(investment)
+    @investment = investment
+  end
+
+  private
+
+    def winner_text
+      t("admin.budget_investments.index.winner")
+    end
+
+    def action
+      if winner?
+        :unmark_as_winner
+      else
+        :mark_as_winner
+      end
+    end
+
+    def path
+      url_for({
+        controller: "admin/budget_investments",
+        action: action,
+        budget_id: investment.budget,
+        id: investment,
+        filter: params[:filter],
+        sort_by: params[:sort_by],
+        min_total_supports: params[:min_total_supports],
+        max_total_supports: params[:max_total_supports],
+        advanced_filters: params[:advanced_filters],
+        page: params[:page]
+      })
+    end
+
+    def options
+      {
+        "aria-label": label,
+        form_class: "toggle-winner",
+        path: path
+      }
+    end
+
+    def label
+      t("admin.actions.label", action: t("admin.actions.mark_as_winner"), name: investment.title)
+    end
+end

--- a/app/controllers/admin/budget_investments_controller.rb
+++ b/app/controllers/admin/budget_investments_controller.rb
@@ -92,6 +92,26 @@ class Admin::BudgetInvestmentsController < Admin::BaseController
     end
   end
 
+  def mark_as_winner
+    authorize! :mark_as_winner, @investment
+    @investment.update!(winner: true)
+
+    respond_to do |format|
+      format.html { redirect_to request.referer, notice: t("flash.actions.update.budget_investment") }
+      format.js { render :toggle_winner }
+    end
+  end
+
+  def unmark_as_winner
+    authorize! :unmark_as_winner, @investment
+    @investment.update!(winner: false)
+
+    respond_to do |format|
+      format.html { redirect_to request.referer, notice: t("flash.actions.update.budget_investment") }
+      format.js { render :toggle_winner }
+    end
+  end
+
   private
 
     def load_comments

--- a/app/models/abilities/administrator.rb
+++ b/app/models/abilities/administrator.rb
@@ -78,6 +78,9 @@ module Abilities
       can [:select, :deselect], Budget::Investment do |investment|
         investment.feasible? && investment.valuation_finished? && !investment.budget.finished?
       end
+      can [:mark_as_winner, :unmark_as_winner], Budget::Investment do |investment|
+        investment.feasible? && investment.valuation_finished? && investment.budget.reviewing_ballots?
+      end
 
       can :create, Budget::ValuatorAssignment
 

--- a/app/models/budget/investment.rb
+++ b/app/models/budget/investment.rb
@@ -1,6 +1,6 @@
 class Budget
   class Investment < ApplicationRecord
-    SORTING_OPTIONS = { id: "id", supports: "cached_votes_up" }.freeze
+    SORTING_OPTIONS = { id: "id", supports: "cached_votes_up", ballot_lines_count: "ballot_lines_count" }.freeze
 
     include Measurable
     include Sanitizable

--- a/app/views/admin/budget_investments/toggle_winner.js.erb
+++ b/app/views/admin/budget_investments/toggle_winner.js.erb
@@ -1,0 +1,4 @@
+<%= render "admin/shared/toggle_switch",
+           record: @investment,
+           form_class: "toggle-winner",
+           new_content: render(Admin::BudgetInvestments::ToggleWinnerComponent.new(@investment)) %>

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -18,6 +18,7 @@ en:
       configure: Configure
       select: Select
       show_to_valuators: "Show %{name} to valuators"
+      mark_as_winner: "Mark as winner"
     officing_booth:
       title: "You are officing the booth located at %{booth}. If this is not correct, do not continue and call the help phone number. Thank you."
     banners:
@@ -288,6 +289,8 @@ en:
           incompatible: Incompatible
           price: Price
           author: Author
+          ballot_lines_count: Votes
+          winner: Winner
         cannot_calculate_winners: The budget has to stay on phase "%{phase}" in order to calculate winners projects
         see_results: "See results"
         milestone_tags_filter_all: "All milestone tags"

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -18,6 +18,7 @@ es:
       configure: Configurar
       select: Seleccionar
       show_to_valuators: "Mostrar %{name} a evaluadores"
+      mark_as_winner: Marcar como ganador
     officing_booth:
       title: "Estás ahora mismo en la mesa ubicada en %{booth}. Si esto no es correcto no sigas adelante y llama al teléfono de incidencias. Gracias."
     banners:
@@ -288,6 +289,8 @@ es:
           incompatible: Incompatible
           price: Precio
           author: Autor
+          ballot_lines_count: Votos
+          winner: Ganadores
         cannot_calculate_winners: El presupuesto debe estar en la fase "%{phase}" para poder calcular las propuestas ganadoras
         see_results: "Ver resultados"
         milestone_tags_filter_all: "Todas las etiquetas de seguimiento"

--- a/config/routes/admin.rb
+++ b/config/routes/admin.rb
@@ -84,6 +84,8 @@ namespace :admin do
           patch :deselect
           patch :show_to_valuators
           patch :hide_from_valuators
+          patch :mark_as_winner
+          patch :unmark_as_winner
         end
 
         resources :audits, only: :show, controller: "budget_investment_audits"

--- a/spec/factories/budgets.rb
+++ b/spec/factories/budgets.rb
@@ -223,6 +223,10 @@ FactoryBot.define do
       after(:create) { |investment| create(:image, imageable: investment) }
     end
 
+    trait :valuation_finished do
+      valuation_finished { true }
+    end
+
     transient do
       voters { [] }
       followers { [] }

--- a/spec/system/admin/budget_investments_spec.rb
+++ b/spec/system/admin/budget_investments_spec.rb
@@ -22,6 +22,7 @@ describe "Admin budget investments", :admin do
 
   context "Index" do
     scenario "Displaying investments" do
+      budget.update!(phase: "selecting")
       budget_investment = create(:budget_investment, budget: budget, cached_votes_up: 77)
       visit admin_budget_budget_investments_path(budget_id: budget.id)
       expect(page).to have_content(budget_investment.title)
@@ -44,6 +45,7 @@ describe "Admin budget investments", :admin do
     end
 
     scenario "Display admin and valuator assignments" do
+      budget.update!(phase: "valuating")
       olga = create(:user, username: "Olga")
       miriam = create(:user, username: "Miriam")
       valuator1 = create(:valuator, user: olga, description: "Valuator Olga")
@@ -788,9 +790,9 @@ describe "Admin budget investments", :admin do
 
   context "Sorting" do
     before do
-      create(:budget_investment, title: "B First Investment", budget: budget, cached_votes_up: 50)
-      create(:budget_investment, title: "A Second Investment", budget: budget, cached_votes_up: 25)
-      create(:budget_investment, title: "C Third Investment", budget: budget, cached_votes_up: 10)
+      create(:budget_investment, title: "B First Investment", budget: budget, cached_votes_up: 50, ballot_lines_count: 40)
+      create(:budget_investment, title: "A Second Investment", budget: budget, cached_votes_up: 25, ballot_lines_count: 20)
+      create(:budget_investment, title: "C Third Investment", budget: budget, cached_votes_up: 10, ballot_lines_count: 30)
     end
 
     scenario "Default" do
@@ -825,11 +827,23 @@ describe "Admin budget investments", :admin do
       end
 
       scenario "Sort by supports" do
+        budget.update!(phase: "valuating")
         visit admin_budget_budget_investments_path(budget, sort_by: "supports", direction: "asc")
 
         expect("C Third Investment").to appear_before("A Second Investment")
         expect("A Second Investment").to appear_before("B First Investment")
         within("th", text: "Supports") do
+          expect(page).to have_css ".icon-sortable.desc", visible: :all
+        end
+      end
+
+      scenario "Sort by votes" do
+        budget.update!(phase: "reviewing_ballots")
+        visit admin_budget_budget_investments_path(budget, sort_by: "ballot_lines_count", direction: "asc")
+
+        expect("A Second Investment").to appear_before("C Third Investment")
+        expect("C Third Investment").to appear_before("B First Investment")
+        within("th", text: "Votes") do
           expect(page).to have_css ".icon-sortable.desc", visible: :all
         end
       end
@@ -857,11 +871,23 @@ describe "Admin budget investments", :admin do
       end
 
       scenario "Sort by supports" do
+        budget.update!(phase: "valuating")
         visit admin_budget_budget_investments_path(budget, sort_by: "supports", direction: "desc")
 
         expect("B First Investment").to appear_before("A Second Investment")
         expect("A Second Investment").to appear_before("C Third Investment")
         within("th", text: "Supports") do
+          expect(page).to have_css ".icon-sortable.asc", visible: :all
+        end
+      end
+
+      scenario "Sort by votes" do
+        budget.update!(phase: "reviewing_ballots")
+        visit admin_budget_budget_investments_path(budget, sort_by: "ballot_lines_count", direction: "desc")
+
+        expect("B First Investment").to appear_before("C Third Investment")
+        expect("C Third Investment").to appear_before("A Second Investment")
+        within("th", text: "Votes") do
           expect(page).to have_css ".icon-sortable.asc", visible: :all
         end
       end
@@ -889,11 +915,23 @@ describe "Admin budget investments", :admin do
       end
 
       scenario "Sort by supports" do
+        budget.update!(phase: "valuating")
         visit admin_budget_budget_investments_path(budget, sort_by: "supports")
 
         expect("C Third Investment").to appear_before("A Second Investment")
         expect("A Second Investment").to appear_before("B First Investment")
         within("th", text: "Supports") do
+          expect(page).to have_css ".icon-sortable.desc", visible: :all
+        end
+      end
+
+      scenario "Sort by votes" do
+        budget.update!(phase: "reviewing_ballots")
+        visit admin_budget_budget_investments_path(budget, sort_by: "ballot_lines_count")
+
+        expect("A Second Investment").to appear_before("C Third Investment")
+        expect("C Third Investment").to appear_before("B First Investment")
+        within("th", text: "Votes") do
           expect(page).to have_css ".icon-sortable.desc", visible: :all
         end
       end
@@ -1491,6 +1529,89 @@ describe "Admin budget investments", :admin do
     end
   end
 
+  context "Mark as winner" do
+    let!(:selected_bi) do
+      create(:budget_investment, :selected, budget: budget, title: "Selected project")
+    end
+
+    let!(:winner_bi) do
+      create(:budget_investment, :winner, budget: budget, title: "Winning project")
+    end
+
+    scenario "Marking an investment as winner" do
+      budget.update!(phase: "reviewing_ballots")
+      visit admin_budget_budget_investments_path(budget)
+
+      expect(page).to have_content "Winner"
+
+      within("tr", text: "Selected project") do
+        within("[data-field=winner]") do
+          expect(page).to have_content "No"
+          expect(page).not_to have_content "Yes"
+
+          click_button "No"
+
+          expect(page).to have_content "Yes"
+          expect(page).not_to have_content "No"
+
+          expect(selected_bi.reload).to be_winner
+        end
+      end
+    end
+
+    scenario "Unmarking an investment as winner" do
+      budget.update!(phase: "reviewing_ballots")
+      visit admin_budget_budget_investments_path(budget)
+
+      within("tr", text: "Winning project") do
+        within("[data-field=winner]") do
+          expect(page).to have_content "Yes"
+          expect(page).not_to have_content "No"
+
+          click_button "Yes"
+
+          expect(page).to have_content "No"
+          expect(page).not_to have_content "Yes"
+
+          expect(winner_bi.reload).not_to be_winner
+        end
+      end
+    end
+
+    scenario "Cannot mark unselected investment as winner" do
+      create(:budget_investment, budget: budget, title: "Unselected project")
+      budget.update!(phase: "reviewing_ballots")
+      visit admin_budget_budget_investments_path(budget)
+
+      within("tr", text: "Unselected project") do
+        within("[data-field=winner]") do
+          expect(page).not_to have_content "Yes"
+          expect(page).not_to have_content "No"
+          expect(page).not_to have_button
+        end
+      end
+    end
+
+    scenario "Cannot mark as winner on finished budgets" do
+      budget.update!(phase: "finished")
+      visit admin_budget_budget_investments_path(budget)
+
+      within("tr", text: "Winning project") do
+        within("[data-field=winner]") do
+          expect(page).to have_content "Winner"
+          expect(page).not_to have_button
+        end
+      end
+
+      within("tr", text: "Selected project") do
+        within("[data-field=winner]") do
+          expect(page).not_to have_content "Winner"
+          expect(page).not_to have_button
+        end
+      end
+    end
+  end
+
   context "Mark as visible to valuators" do
     let(:valuator) { create(:valuator) }
     let(:admin) { create(:administrator) }
@@ -1590,6 +1711,11 @@ describe "Admin budget investments", :admin do
       create(:budget_investment, budget: budget, title: "Invisible", visible_to_valuators: false)
 
       visit admin_budget_budget_investments_path(budget)
+
+      click_button "Columns"
+      within("#js-columns-selector-wrapper") do
+        check "Show to valuators"
+      end
 
       within "tr", text: "Visible" do
         within "[data-field=visible_to_valuators]" do
@@ -1726,29 +1852,51 @@ describe "Admin budget investments", :admin do
              budget: budget,
              author: create(:user, username: "Jon Doe"))
     end
-    let(:default_columns) do
-      %w[id title supports admin valuator geozone feasibility price
-         valuation_finished visible_to_valuators selected]
+    let(:all_columns) do
+      %w[id title supports admin author valuator geozone feasibility price
+         valuation_finished visible_to_valuators selected incompatible ballot_lines_count winner]
     end
     let(:selectable_columns) do
       %w[title supports admin author valuator geozone feasibility price
-         valuation_finished visible_to_valuators selected]
+         valuation_finished visible_to_valuators selected ballot_lines_count winner]
     end
 
-    scenario "Display default columns" do
-      visit admin_budget_budget_investments_path(budget)
+    scenario "Display default columns for each phase" do
+      {
+        "informing" => %w[id title geozone price selected],
+        "accepting" => %w[id title geozone price selected feasibility admin valuator valuation_finished \
+                          visible_to_valuators],
+        "reviewing" => %w[id title geozone price selected feasibility admin valuator valuation_finished \
+                          visible_to_valuators],
+        "selecting" => %w[id title geozone price selected feasibility admin valuator valuation_finished \
+                          visible_to_valuators supports],
+        "valuating" => %w[id title geozone price selected feasibility admin valuator valuation_finished \
+                          visible_to_valuators supports],
+        "publishing_prices" => %w[id title geozone price selected feasibility admin valuator \
+                                  valuation_finished visible_to_valuators supports],
+        "balloting" => %w[id title geozone price selected ballot_lines_count],
+        "reviewing_ballots" => %w[id title geozone price selected ballot_lines_count winner],
+        "finished" => %w[id title geozone price selected ballot_lines_count winner]
+      }.each do |phase, columns|
+        budget.update!(phase: phase)
+        visit admin_budget_budget_investments_path(budget)
 
-      within("table.column-selectable") do
-        default_columns.each do |default_column|
-          columns_header = I18n.t("admin.budget_investments.index.list.#{default_column}")
-          expect(page).to have_content(columns_header)
+        within("table.column-selectable") do
+          all_columns.each do |column|
+            header = I18n.t("admin.budget_investments.index.list.#{column}")
+            if columns.include?(column)
+              expect(page).to have_content(header)
+            else
+              expect(page).not_to have_content(header)
+            end
+          end
+
+          expect(page).to have_content(investment.title)
         end
-
-        expect(page).to have_content(investment.title)
       end
     end
 
-    scenario "Display incompatible column as default if selected filter was set" do
+    scenario "Display incompatible column as default if and only if selected filter was set" do
       visit admin_budget_budget_investments_path(budget, advanced_filters: ["selected"])
 
       within("table.column-selectable") do
@@ -1758,13 +1906,10 @@ describe "Admin budget investments", :admin do
       expect(page).to have_content(investment.title)
     end
 
-    scenario "Set cookie with default columns value if undefined" do
+    scenario "Do not set cookie if column selector is not used" do
       visit admin_budget_budget_investments_path(budget)
 
-      cookie_value = cookie_by_name("investments-columns")[:value]
-
-      expect(cookie_value).to eq("id,title,supports,admin,valuator,geozone,feasibility,price," \
-                                 "valuation_finished,visible_to_valuators,selected,incompatible")
+      expect(cookie_by_name("investments-columns")).to be(nil)
     end
 
     scenario "Use column selector to display visible columns" do
@@ -1798,6 +1943,8 @@ describe "Admin budget investments", :admin do
     end
 
     scenario "Cookie will be updated after change columns selection" do
+      budget.update!(phase: "balloting")
+      # default columns: id title geozone price selected ballot_lines_count
       visit admin_budget_budget_investments_path(budget)
 
       click_button "Columns"
@@ -1805,21 +1952,18 @@ describe "Admin budget investments", :admin do
       within("#js-columns-selector-wrapper") do
         uncheck "Title"
         uncheck "Price"
-        uncheck "Valuation Group / Valuator"
         check "Author"
       end
 
-      cookie_value = cookie_by_name("investments-columns")[:value]
+      cookie_value = cookie_by_name("investments-columns-balloting")[:value]
 
-      expect(cookie_value).to eq("id,supports,admin,geozone,feasibility,valuation_finished," \
-                                 "visible_to_valuators,selected,incompatible,author")
+      expect(cookie_value).to eq("id,author,geozone,selected,ballot_lines_count")
 
       visit admin_budget_budget_investments_path(budget)
 
-      cookie_value = cookie_by_name("investments-columns")[:value]
+      cookie_value = cookie_by_name("investments-columns-balloting")[:value]
 
-      expect(cookie_value).to eq("id,supports,admin,geozone,feasibility,valuation_finished," \
-                                 "visible_to_valuators,selected,incompatible,author")
+      expect(cookie_value).to eq("id,author,geozone,selected,ballot_lines_count")
     end
 
     scenario "Select an investment when some columns are not displayed" do


### PR DESCRIPTION
## Objectives

Consul currently determines the winners in a participatory budget by an algorithm triggered by clicking the "calculate winning investments" button. It does not allow admins to change which projects win. But in many context, being able to change the winners would be useful:
* Some cities have rules like "projects must receive at least 100 votes to win"
* Some projects may be incompatible with each other, so if both are selected as winner by the algorithm, this needs to be overridden
* Maybe some project almost fit in the budget but overshot it a bit. The city may have the flexibility to increase the available budget slightly, and make the project win after all.
* The city may want to use an entirely different winner determination method such as the Method of Equal Shares.

To allow this, this PR adds a toggle for each project in the budget investments table, allowing admins to change which projects win. This is the same style of toggle already used for whether a project is selected, and whether it is shown to valuators.

**Changes to columns**. In addition, this PR adds a column "Votes" showing the number of votes each project received during the balloting phase. Adding two more columns (votes and winner toggle) makes the table a bit overwhelming, so I added logic that decides which columns to show based on the phase of the budget. For example, once we reach balloting, columns related to valuation are not shown anymore. And the two new columns are not shown until we start balloting. The columns shown can still be customized, and the state is saved in a cookie as before, except that the cookie is not specific to each phase.

## References

No directly relevant issue, but the possibility of adding a winner toggle is mentioned at the bottom of https://github.com/consuldemocracy/consuldemocracy/issues/5501

## Visual Changes

Investment projects view during "Reviewing ballots" phase: (note no winner toggle for projects that are not selected)
<img width="1274" alt="image" src="https://github.com/user-attachments/assets/3950508a-2a2b-41f6-aea6-59e8b010bb21" />

During the "valuating projects" phase, showing different default columns:
<img width="1273" alt="image" src="https://github.com/user-attachments/assets/8a68e08a-7aff-434e-8c19-77d67d1ff4c6" />

During the "finished" phase:
<img width="1280" alt="image" src="https://github.com/user-attachments/assets/39159294-a1ad-490b-8b27-357e378ce742" />

## Future

I'm working on the [Method of Equal Shares](https://equalshares.net/) method, which is a voting method for participatory budgets that provides proportional representation. Some cities using Consul have expressed interest in using this method, so I'm working on features that make this possible. Next steps would be:
* Implement an export feature that exports (anonymized) raw votes so the voting outcome can be computed by an external tool
* Perhaps: Implement the Method of Equal Shares directly in Consul, with admins able to select their desired winner determination method in the settings.