### PR TITLE
Add chromium-driver to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get update -qq \
     unzip
 
 # Install Chromium for E2E integration tests
-RUN apt-get update -qq && apt-get install -y chromium
+RUN apt-get update -qq && apt-get install -y chromium chromium-driver
 
 # Files created inside the container repect the ownership
 RUN adduser --shell /bin/bash --disabled-password --gecos "" consul \


### PR DESCRIPTION
## References

* Closes #5854

## Objectives

I followed the instructions in [`docker.md`](https://github.com/consuldemocracy/consuldemocracy/blob/master/docs/en/installation/docker.md) to install Consul on my Mac. It all worked, except that systems tests did not work due to a problem with chromedriver.

This PR adds `chromium-driver` to the Dockerfile. This fixed the problem for me. I also tested this version of the Dockerfile on a fresh machine (GitHub Codespaces) and it didn't cause problems there. However, on GitHub Codespaces the systems tests also work without installing chromium-driver in the Dockerfile, so the problem I have on my machine remains a little mysterious.