### PR TITLE
Don't update Spanish in Crowdin

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -3,6 +3,8 @@ files:
     translation: /config/locales/%locale%/%original_file_name%
     ignore:
       - /config/locales/**/rails_date_order.yml
+    excluded_target_languages:
+      - es
     update_option: update_as_unapproved
     languages_mapping:
       locale:


### PR DESCRIPTION
## Objectives

* (Hopefully) Make sure pull requests updating translations from Crowdin don't include texts in Spanish, since we maintain this language ourselves