### PR TITLE
Fix invalid HTML caused by the dev seeds

### DIFF
--- a/db/dev_seeds/settings.rb
+++ b/db/dev_seeds/settings.rb
@@ -2,21 +2,21 @@ section "Creating Settings" do
   Setting.reset_defaults
 
   {
-    "facebook_handle": "CONSUL DEMOCRACY",
+    "facebook_handle": "CONSULDEMOCRACY",
     "feature.featured_proposals": "true",
     "feature.map": "true",
-    "instagram_handle": "CONSUL DEMOCRACY",
+    "instagram_handle": "CONSULDEMOCRACY",
     "meta_description": "Citizen participation tool for an open, " \
                         "transparent and democratic government",
     "meta_keywords": "citizen participation, open government",
     "meta_title": "CONSUL DEMOCRACY",
     "proposal_code_prefix": "MAD",
     "proposal_notification_minimum_interval_in_days": 0,
-    "telegram_handle": "CONSUL DEMOCRACY",
+    "telegram_handle": "CONSULDEMOCRACY",
     "twitter_handle": "@consuldemocracy_dev",
     "twitter_hashtag": "#consuldemocracy_dev",
     "votes_for_proposal_success": "100",
-    "youtube_handle": "CONSUL DEMOCRACY"
+    "youtube_handle": "CONSULDEMOCRACY"
   }.each do |name, value|
     Setting[name] = value
   end


### PR DESCRIPTION
## Objectives

* Make sure that by default developers visit a page containing valid HTML
* Reduce the amount of noise we get when debugging HTML