### PR TITLE
Add missing text to links with no text

### DIFF
--- a/app/assets/javascripts/managers.js
+++ b/app/assets/javascripts/managers.js
@@ -39,14 +39,13 @@
         e.stopPropagation();
         $("#user_password").val(App.Managers.generatePassword());
       });
-      $(".show-password").on("click", function(e) {
-        e.preventDefault();
-        e.stopPropagation();
+      $(".show-password").on("click", function() {
         if ($("#user_password").is("input[type='password']")) {
           App.Managers.togglePassword("text");
         } else {
           App.Managers.togglePassword("password");
         }
+        $(this).attr("aria-pressed", !JSON.parse($(this).attr("aria-pressed")));
       });
     }
   };

--- a/app/assets/stylesheets/dashboard.scss
+++ b/app/assets/stylesheets/dashboard.scss
@@ -139,6 +139,11 @@
     }
   }
 
+  form {
+    display: inline;
+    vertical-align: top;
+  }
+
   .icon-check {
     display: inline-block;
     font-size: rem-calc(24);
@@ -147,7 +152,6 @@
 
   .unchecked-link {
     display: inline-block;
-    vertical-align: top;
   }
 
   .unchecked {

--- a/app/assets/stylesheets/dashboard.scss
+++ b/app/assets/stylesheets/dashboard.scss
@@ -142,25 +142,20 @@
   form {
     display: inline;
     vertical-align: top;
+
+    button {
+      font-size: 1.5em;
+    }
   }
 
-  .icon-check {
-    display: inline-block;
-    font-size: rem-calc(24);
-    vertical-align: top;
+  .checked-link {
+    @include has-fa-icon(check, solid);
+    color: $check;
   }
 
   .unchecked-link {
-    display: inline-block;
-  }
-
-  .unchecked {
-    border: 1px solid $border;
-    border-radius: rem-calc(4);
-    display: inline-block;
-    height: rem-calc(20);
-    margin-top: calc($line-height / 6);
-    width: rem-calc(20);
+    @include has-fa-icon(square, regular);
+    color: $border;
   }
 }
 

--- a/app/assets/stylesheets/dashboard.scss
+++ b/app/assets/stylesheets/dashboard.scss
@@ -150,12 +150,12 @@
 
   .checked-link {
     @include has-fa-icon(check, solid);
-    color: $check;
+    color: $color-success;
   }
 
   .unchecked-link {
     @include has-fa-icon(square, regular);
-    color: $border;
+    color: $dark-gray;
   }
 }
 

--- a/app/assets/stylesheets/legislation_process.scss
+++ b/app/assets/stylesheets/legislation_process.scss
@@ -596,12 +596,6 @@
           border-bottom: 1px solid $border;
           margin-bottom: rem-calc(16);
           padding-bottom: rem-calc(8);
-
-          a .icon-expand {
-            color: #838383;
-            float: right;
-            font-size: $small-font-size;
-          }
         }
 
         .comments-wrapper {

--- a/app/assets/stylesheets/management/account/edit_password_manually.scss
+++ b/app/assets/stylesheets/management/account/edit_password_manually.scss
@@ -5,6 +5,7 @@
   }
 
   .show-password {
+    @include has-fa-icon(eye, regular);
     cursor: pointer;
   }
 }

--- a/app/assets/stylesheets/management/account/edit_password_manually.scss
+++ b/app/assets/stylesheets/management/account/edit_password_manually.scss
@@ -3,4 +3,8 @@
   [type=text] {
     margin-bottom: 0 !important;
   }
+
+  .show-password {
+    cursor: pointer;
+  }
 }

--- a/app/assets/stylesheets/management/account/edit_password_manually.scss
+++ b/app/assets/stylesheets/management/account/edit_password_manually.scss
@@ -1,5 +1,6 @@
 .management-account-edit-password-manually {
-  [type=password] {
+  [type=password],
+  [type=text] {
     margin-bottom: 0 !important;
   }
 }

--- a/app/components/management/account/edit_password_manually_component.html.erb
+++ b/app/components/management/account/edit_password_manually_component.html.erb
@@ -10,7 +10,10 @@
     <div class="input-group">
       <%= f.password_field :password, class: "input-group-field", label: false, value: nil %>
       <span class="input-group-label">
-        <a href="#" class="show-password"><span class="icon-eye"></span></a>
+        <a href="#" class="show-password">
+          <span class="icon-eye"></span>
+          <span class="show-for-sr"><%= t("management.account.edit.password.show") %></span>
+        </a>
       </span>
     </div>
 

--- a/app/components/management/account/edit_password_manually_component.html.erb
+++ b/app/components/management/account/edit_password_manually_component.html.erb
@@ -10,10 +10,10 @@
     <div class="input-group">
       <%= f.password_field :password, class: "input-group-field", label: false, value: nil %>
       <span class="input-group-label">
-        <a href="#" class="show-password">
+        <button type="button" class="show-password" aria-pressed="false">
           <span class="icon-eye"></span>
           <span class="show-for-sr"><%= t("management.account.edit.password.show") %></span>
-        </a>
+        </button>
       </span>
     </div>
 

--- a/app/components/management/account/edit_password_manually_component.html.erb
+++ b/app/components/management/account/edit_password_manually_component.html.erb
@@ -11,7 +11,6 @@
       <%= f.password_field :password, class: "input-group-field", label: false, value: nil %>
       <span class="input-group-label">
         <button type="button" class="show-password" aria-pressed="false">
-          <span class="icon-eye"></span>
           <span class="show-for-sr"><%= t("management.account.edit.password.show") %></span>
         </button>
       </span>

--- a/app/components/shared/banner_component.html.erb
+++ b/app/components/shared/banner_component.html.erb
@@ -1,5 +1,3 @@
-<% if banner %>
-  <div class="banner" style="background-color:<%= banner.background_color %>;">
-    <%= sanitize link, attributes: %w[href style] %>
-  </div>
-<% end %>
+<div class="banner" style="background-color:<%= banner.background_color %>;">
+  <%= sanitize link, attributes: %w[href style] %>
+</div>

--- a/app/components/shared/banner_component.rb
+++ b/app/components/shared/banner_component.rb
@@ -13,6 +13,10 @@ class Shared::BannerComponent < ApplicationComponent
                 end
   end
 
+  def render?
+    banner && (banner.title.present? || banner.description.present?)
+  end
+
   private
 
     def link

--- a/app/models/legislation/process.rb
+++ b/app/models/legislation/process.rb
@@ -46,6 +46,7 @@ class Legislation::Process < ApplicationRecord
   validates_translation :title, presence: true
   validates :start_date, presence: true
   validates :end_date, presence: true
+  validates :result_publication_date, presence: true, if: :result_publication_enabled?
 
   %i[draft debate proposals_phase allegations].each do |phase_name|
     enabled_attribute = :"#{phase_name.to_s.gsub("_phase", "")}_phase_enabled?"

--- a/app/views/dashboard/_proposed_action.html.erb
+++ b/app/views/dashboard/_proposed_action.html.erb
@@ -6,7 +6,6 @@
         <span class="show-for-sr">
           <%= t("dashboard.recommended_actions.unexecute", name: proposed_action.title) %>
         </span>
-        <span class="icon-check"></span>
       <% end %>
     <% else %>
       <%= button_to execute_proposal_dashboard_action_path(proposal, proposed_action),
@@ -14,7 +13,6 @@
         <span class="show-for-sr">
           <%= t("dashboard.recommended_actions.execute", name: proposed_action.title) %>
         </span>
-        <span class="unchecked"></span>
       <% end %>
     <% end %>
     <div class="action-content">

--- a/app/views/dashboard/_proposed_action.html.erb
+++ b/app/views/dashboard/_proposed_action.html.erb
@@ -2,16 +2,20 @@
   <div class="action">
     <% if proposed_action.proposals.where(id: proposal.id).any? %>
       <%= link_to unexecute_proposal_dashboard_action_path(proposal, proposed_action),
-                  id: "#{dom_id(proposed_action)}_unexecute",
                   method: :post,
                   class: "checked-link" do %>
+        <span class="show-for-sr">
+          <%= t("dashboard.recommended_actions.unexecute", name: proposed_action.title) %>
+        </span>
         <span class="icon-check"></span>
       <% end %>
     <% else %>
       <%= link_to execute_proposal_dashboard_action_path(proposal, proposed_action),
-                  id: "#{dom_id(proposed_action)}_execute",
                   method: :post,
                   class: "unchecked-link" do %>
+        <span class="show-for-sr">
+          <%= t("dashboard.recommended_actions.execute", name: proposed_action.title) %>
+        </span>
         <span class="unchecked"></span>
       <% end %>
     <% end %>

--- a/app/views/dashboard/_proposed_action.html.erb
+++ b/app/views/dashboard/_proposed_action.html.erb
@@ -1,18 +1,16 @@
 <div id="<%= dom_id(proposed_action) %>">
   <div class="action">
     <% if proposed_action.proposals.where(id: proposal.id).any? %>
-      <%= link_to unexecute_proposal_dashboard_action_path(proposal, proposed_action),
-                  method: :post,
-                  class: "checked-link" do %>
+      <%= button_to unexecute_proposal_dashboard_action_path(proposal, proposed_action),
+                    class: "checked-link" do %>
         <span class="show-for-sr">
           <%= t("dashboard.recommended_actions.unexecute", name: proposed_action.title) %>
         </span>
         <span class="icon-check"></span>
       <% end %>
     <% else %>
-      <%= link_to execute_proposal_dashboard_action_path(proposal, proposed_action),
-                  method: :post,
-                  class: "unchecked-link" do %>
+      <%= button_to execute_proposal_dashboard_action_path(proposal, proposed_action),
+                    class: "unchecked-link" do %>
         <span class="show-for-sr">
           <%= t("dashboard.recommended_actions.execute", name: proposed_action.title) %>
         </span>

--- a/app/views/legislation/annotations/_annotation_link.html.erb
+++ b/app/views/legislation/annotations/_annotation_link.html.erb
@@ -1,3 +1,0 @@
-<%= link_to legislation_process_draft_version_annotation_path(annotation.draft_version.process, annotation.draft_version, annotation, sub_annotation_ids: "") do %>
-  <span class="icon-expand" aria-hidden="true"></span>
-<% end %>

--- a/app/views/legislation/annotations/_comment_header.html.erb
+++ b/app/views/legislation/annotations/_comment_header.html.erb
@@ -1,5 +1,8 @@
-<%= render Shared::CommentsCountComponent.new(annotation.comments.roots.count) %>
-
 <span id="annotation-link" data-sub-annotation-ids="8">
-  <%= render "annotation_link", annotation: annotation %>
+  <%= render Shared::CommentsCountComponent.new(
+    annotation.comments.roots.count,
+    url: legislation_process_draft_version_annotation_path(
+           annotation.draft_version.process, annotation.draft_version, annotation, sub_annotation_ids: ""
+         )
+  ) %>
 </span>

--- a/app/views/legislation/annotations/comments.js.erb
+++ b/app/views/legislation/annotations/comments.js.erb
@@ -14,11 +14,11 @@ if ($(".comment").length == 0) {
 
   $("#annotation-link a").attr("href", new_annotation_link)
 
-  var current_comment_text = $(".comments-count").text()
+  var current_comment_text = $("#annotation-link a").text()
   var current_comment_count = current_comment_text.match(/\d+/)[0]
   var new_comment_count = parseInt(current_comment_count) + parseInt(<%= @annotation.comments.roots.count %>)
   var new_comment_count_text = current_comment_text.replace(/(\d+)/, new_comment_count);
-  $(".comments-count").text(new_comment_count_text)
+  $("#annotation-link a").text(new_comment_count_text)
 }
 
 <%= render "comments_box_form", comment: @comment, annotation: @annotation %>

--- a/config/locales/en/general.yml
+++ b/config/locales/en/general.yml
@@ -475,6 +475,8 @@ en:
       see_proposed_actions: Check out recommended actions
       hide_proposed_actions: Hide recommended actions
       pending_title: Pending
+      execute: "Mark %{name} as done"
+      unexecute: "Unmark %{name} as done"
       show_description: Show description
       without_pending_actions: No recommended actions pending
       done_title: Done

--- a/config/locales/en/management.yml
+++ b/config/locales/en/management.yml
@@ -18,6 +18,7 @@ en:
           reseted: Password reseted successfully
           random: Generate random password
           save: Save password
+          show: Show password
           print: Print password
           print_help: You will be able to print the password when it is saved.
     account_info:

--- a/config/locales/es/general.yml
+++ b/config/locales/es/general.yml
@@ -475,6 +475,8 @@ es:
       see_proposed_actions: Ver todas las acciones recomendadas
       hide_proposed_actions: Ocultar acciones recomendadas
       pending_title: Pendientes
+      execute: "Marcar la acción %{name} como realizada"
+      unexecute: "Desmarcar la acción %{name} como realizada"
       show_description: Mostrar descripción
       without_pending_actions: No hay acciones recomendadas pendientes
       done_title: Realizadas

--- a/config/locales/es/management.yml
+++ b/config/locales/es/management.yml
@@ -18,6 +18,7 @@ es:
           reseted: Contraseña restablecida correctamente
           random: Generar contraseña aleatoria
           save: Guardar contraseña
+          show: Mostrar contraseña
           print: Imprimir contraseña
           print_help: Podrás imprimir la contraseña cuando se haya guardado.
     account_info:

--- a/spec/components/shared/banner_component_spec.rb
+++ b/spec/components/shared/banner_component_spec.rb
@@ -31,6 +31,14 @@ describe Shared::BannerComponent do
     expect(page).not_to have_content "Proposal banner"
   end
 
+  it "does not render an empty banner" do
+    banner = build(:banner, title: "", description: "")
+
+    render_inline Shared::BannerComponent.new(banner)
+
+    expect(page).not_to be_rendered
+  end
+
   context "several banners available in the same section" do
     before do
       create(:banner,

--- a/spec/models/legislation/process_spec.rb
+++ b/spec/models/legislation/process_spec.rb
@@ -154,6 +154,21 @@ describe Legislation::Process do
       expect(proposals_disabled).to be_valid
       expect(allegations_disabled).to be_valid
     end
+
+    it "is invalid if result publication is enabled but result_publication_date is not present" do
+      process = build(:legislation_process, result_publication_enabled: true, result_publication_date: "")
+
+      expect(process).not_to be_valid
+      expect(process.errors.messages[:result_publication_date]).to include("can't be blank")
+    end
+
+    it "is valid if result publication is enabled and result_publication_date is present" do
+      process = build(:legislation_process,
+                      result_publication_enabled: true,
+                      result_publication_date: Date.tomorrow)
+
+      expect(process).to be_valid
+    end
   end
 
   describe "date ranges validations" do

--- a/spec/system/comments/legislation_annotations_spec.rb
+++ b/spec/system/comments/legislation_annotations_spec.rb
@@ -39,9 +39,10 @@ describe "Commenting legislation annotations" do
         find(".icon-expand").click
       end
 
-      expect(page).to have_css(".comment", count: 2)
-      expect(page).to have_content("my annotation")
-      expect(page).to have_content("my other annotation")
+      expect(page).to have_content "Comments about"
+      expect(page).to have_css ".comment", count: 2
+      expect(page).to have_content "my annotation"
+      expect(page).to have_content "my other annotation"
     end
 
     scenario "Reply on a single annotation thread and display it in the merged annotation thread" do

--- a/spec/system/comments/legislation_annotations_spec.rb
+++ b/spec/system/comments/legislation_annotations_spec.rb
@@ -35,9 +35,7 @@ describe "Commenting legislation annotations" do
     end
 
     scenario "View comments of annotations in an included range" do
-      within("#annotation-link") do
-        find(".icon-expand").click
-      end
+      click_link "2 comment"
 
       expect(page).to have_content "Comments about"
       expect(page).to have_css ".comment", count: 2
@@ -71,20 +69,16 @@ describe "Commenting legislation annotations" do
         expect(page).to have_content "my other annotation"
       end
 
-      within("#annotation-link") do
-        find(".icon-expand").click
-      end
+      click_link "2 comment"
 
-      expect(page).to have_css(".comment", count: 3)
-      expect(page).to have_content("my annotation")
-      expect(page).to have_content("my other annotation")
-      expect(page).to have_content("replying in single annotation thread")
+      expect(page).to have_css ".comment", count: 3
+      expect(page).to have_content "my annotation"
+      expect(page).to have_content "my other annotation"
+      expect(page).to have_content "replying in single annotation thread"
     end
 
     scenario "Reply on a multiple annotation thread and display it in the single annotation thread" do
-      within("#annotation-link") do
-        find(".icon-expand").click
-      end
+      click_link "2 comment"
 
       within("#comment_#{comment2.id}") do
         click_link "Reply"

--- a/spec/system/dashboard/dashboard_spec.rb
+++ b/spec/system/dashboard/dashboard_spec.rb
@@ -100,14 +100,14 @@ describe "Proposal's dashboard" do
       expect(page).to have_content "Expand!"
     end
 
-    click_link "Mark Expand! as done"
+    click_button "Mark Expand! as done"
 
     within "#proposed_actions_done" do
       expect(page).to have_content "Expand!"
     end
 
-    expect(page).not_to have_link "Mark Expand! as done"
-    expect(page).to have_link "Unmark Expand! as done"
+    expect(page).not_to have_button "Mark Expand! as done"
+    expect(page).to have_button "Unmark Expand! as done"
   end
 
   scenario "Dashboard progress can unexecute proposed action" do
@@ -120,14 +120,14 @@ describe "Proposal's dashboard" do
       expect(page).to have_content "Reinforce!"
     end
 
-    click_link "Unmark Reinforce! as done"
+    click_button "Unmark Reinforce! as done"
 
     within "#proposed_actions_pending" do
       expect(page).to have_content "Reinforce!"
     end
 
-    expect(page).not_to have_link "Unmark Reinforce! as done"
-    expect(page).to have_link "Mark Reinforce! as done"
+    expect(page).not_to have_button "Unmark Reinforce! as done"
+    expect(page).to have_button "Mark Reinforce! as done"
   end
 
   scenario "Dashboard progress dont show proposed actions with published_proposal: true" do
@@ -464,7 +464,7 @@ describe "Proposal's dashboard" do
     action = create(:dashboard_action, :proposed_action, :active, title: "Make progress")
 
     visit recommended_actions_proposal_dashboard_path(proposal.to_param)
-    click_link "Mark Make progress as done"
+    click_button "Mark Make progress as done"
 
     within "#proposed_actions_done" do
       expect(page).to have_content(action.title)

--- a/spec/system/dashboard/dashboard_spec.rb
+++ b/spec/system/dashboard/dashboard_spec.rb
@@ -47,14 +47,6 @@ describe "Proposal's dashboard" do
     end
   end
 
-  scenario "Dashboard progress show proposed actions" do
-    action = create(:dashboard_action, :proposed_action, :active)
-
-    visit progress_proposal_dashboard_path(proposal)
-
-    expect(page).to have_content(action.title)
-  end
-
   scenario "Dashboard progress show proposed actions truncated description" do
     action = create(:dashboard_action, :proposed_action, :active, description: "One short action")
     action_long = create(:dashboard_action, :proposed_action, :active,
@@ -105,28 +97,14 @@ describe "Proposal's dashboard" do
     visit progress_proposal_dashboard_path(proposal)
 
     within "#proposed_actions_pending" do
-      expect(page).to have_content(action.title)
+      expect(page).to have_content action.title
     end
-  end
 
-  scenario "Dashboard progress display proposed_action done on his section" do
-    action = create(:dashboard_action, :proposed_action, :active)
-
-    visit progress_proposal_dashboard_path(proposal)
     find(:css, "#dashboard_action_#{action.id}_execute").click
 
     within "#proposed_actions_done" do
-      expect(page).to have_content(action.title)
+      expect(page).to have_content action.title
     end
-  end
-
-  scenario "Dashboard progress can execute proposed action" do
-    action = create(:dashboard_action, :proposed_action, :active)
-
-    visit progress_proposal_dashboard_path(proposal)
-    expect(page).to have_content(action.title)
-
-    find(:css, "#dashboard_action_#{action.id}_execute").click
     expect(page).not_to have_css "#dashboard_action_#{action.id}_execute"
   end
 

--- a/spec/system/dashboard/dashboard_spec.rb
+++ b/spec/system/dashboard/dashboard_spec.rb
@@ -92,31 +92,42 @@ describe "Proposal's dashboard" do
   end
 
   scenario "Dashboard progress display proposed_action pending on his section" do
-    action = create(:dashboard_action, :proposed_action, :active)
+    create(:dashboard_action, :proposed_action, :active, title: "Expand!")
 
     visit progress_proposal_dashboard_path(proposal)
 
     within "#proposed_actions_pending" do
-      expect(page).to have_content action.title
+      expect(page).to have_content "Expand!"
     end
 
-    find(:css, "#dashboard_action_#{action.id}_execute").click
+    click_link "Mark Expand! as done"
 
     within "#proposed_actions_done" do
-      expect(page).to have_content action.title
+      expect(page).to have_content "Expand!"
     end
-    expect(page).not_to have_css "#dashboard_action_#{action.id}_execute"
+
+    expect(page).not_to have_link "Mark Expand! as done"
+    expect(page).to have_link "Unmark Expand! as done"
   end
 
   scenario "Dashboard progress can unexecute proposed action" do
-    action = create(:dashboard_action, :proposed_action, :active)
+    action = create(:dashboard_action, :proposed_action, :active, title: "Reinforce!")
     create(:dashboard_executed_action, proposal: proposal, action: action)
 
     visit progress_proposal_dashboard_path(proposal)
-    expect(page).to have_content(action.title)
 
-    find(:css, "#dashboard_action_#{action.id}_unexecute").click
-    expect(page).to have_css "#dashboard_action_#{action.id}_execute"
+    within "#proposed_actions_done" do
+      expect(page).to have_content "Reinforce!"
+    end
+
+    click_link "Unmark Reinforce! as done"
+
+    within "#proposed_actions_pending" do
+      expect(page).to have_content "Reinforce!"
+    end
+
+    expect(page).not_to have_link "Unmark Reinforce! as done"
+    expect(page).to have_link "Mark Reinforce! as done"
   end
 
   scenario "Dashboard progress dont show proposed actions with published_proposal: true" do
@@ -450,10 +461,10 @@ describe "Proposal's dashboard" do
   end
 
   scenario "On recommended actions section display proposed_action done on his section" do
-    action = create(:dashboard_action, :proposed_action, :active)
+    action = create(:dashboard_action, :proposed_action, :active, title: "Make progress")
 
     visit recommended_actions_proposal_dashboard_path(proposal.to_param)
-    find(:css, "#dashboard_action_#{action.id}_execute").click
+    click_link "Mark Make progress as done"
 
     within "#proposed_actions_done" do
       expect(page).to have_content(action.title)

--- a/spec/system/legislation/summary_spec.rb
+++ b/spec/system/legislation/summary_spec.rb
@@ -22,6 +22,7 @@ describe "Legislation" do
   scenario "empty process" do
     process = create(:legislation_process, :empty,
                      result_publication_enabled: true,
+                     result_publication_date: 1.day.ago,
                      end_date: Date.current - 1.day)
 
     visit summary_legislation_process_path(process)

--- a/spec/system/management/account_spec.rb
+++ b/spec/system/management/account_spec.rb
@@ -59,6 +59,16 @@ describe "Account" do
 
     new_password = find_field("user_password").value
 
+    expect(page).to have_field "Password", type: :password
+
+    click_link "Show password"
+
+    expect(page).to have_field "Password", type: :text
+
+    click_link "Show password"
+
+    expect(page).to have_field "Password", type: :password
+
     click_button "Save password"
 
     expect(page).to have_content "Password reseted successfully"

--- a/spec/system/management/account_spec.rb
+++ b/spec/system/management/account_spec.rb
@@ -34,7 +34,7 @@ describe "Account" do
     login_as_manager
     click_link "Reset password manually"
 
-    find(:css, "input[id$='user_password']").set("new_password")
+    fill_in "Password", with: "new_password"
 
     click_button "Save password"
 
@@ -75,7 +75,7 @@ describe "Account" do
     login_as_manager
     click_link "Reset password manually"
 
-    find(:css, "input[id$='user_password']").set("another_new_password")
+    fill_in "Password", with: "another_new_password"
 
     click_button "Save password"
 

--- a/spec/system/management/account_spec.rb
+++ b/spec/system/management/account_spec.rb
@@ -60,14 +60,17 @@ describe "Account" do
     new_password = find_field("user_password").value
 
     expect(page).to have_field "Password", type: :password
+    expect(page).to have_css "button[aria-pressed=false]", exact_text: "Show password"
 
-    click_link "Show password"
+    click_button "Show password"
 
     expect(page).to have_field "Password", type: :text
+    expect(page).to have_css "button[aria-pressed=true]", exact_text: "Show password"
 
-    click_link "Show password"
+    click_button "Show password"
 
     expect(page).to have_field "Password", type: :password
+    expect(page).to have_css "button[aria-pressed=false]", exact_text: "Show password"
 
     click_button "Save password"
 

--- a/spec/system/management/account_spec.rb
+++ b/spec/system/management/account_spec.rb
@@ -27,7 +27,7 @@ describe "Account" do
     expect(email).to have_text "Change your password"
   end
 
-  scenario "Manager changes the password by hand (writen by them)" do
+  scenario "Manager manually writes the new password" do
     user = create(:user, :level_three)
     login_managed_user(user)
 
@@ -39,6 +39,8 @@ describe "Account" do
     click_button "Save password"
 
     expect(page).to have_content "Password reseted successfully"
+    expect(page).to have_link "Print password", href: "javascript:window.print();"
+    expect(page).to have_css "div.for-print-only", text: "new_password", visible: :hidden
 
     logout
 
@@ -66,22 +68,6 @@ describe "Account" do
     login_through_form_with(user.username, password: new_password)
 
     expect(page).to have_content "You have been signed in successfully."
-  end
-
-  scenario "The password is printed" do
-    user = create(:user, :level_three)
-    login_managed_user(user)
-
-    login_as_manager
-    click_link "Reset password manually"
-
-    fill_in "Password", with: "another_new_password"
-
-    click_button "Save password"
-
-    expect(page).to have_content "Password reseted successfully"
-    expect(page).to have_link "Print password", href: "javascript:window.print();"
-    expect(page).to have_css("div.for-print-only", text: "another_new_password", visible: :hidden)
   end
 
   describe "When a user has not been selected" do


### PR DESCRIPTION
## Objectives

* Make sure people using screen readers know what links are about
* Use buttons instead of links to show/hide passwords in the management area and to execute dashboard actions
* Use SVG icons instead of icon fonts for the icons to show/hide passwords and execute dashboard actions 