### PR TITLE
Use pronto.yml to configure pronto-stylelint

### DIFF
--- a/.pronto.yml
+++ b/.pronto.yml
@@ -2,3 +2,5 @@ rubocop:
   suggestions: true
   severities:
     refactor: info
+stylelint:
+  stylelint_executable: "npx stylelint"

--- a/.pronto_stylelint.yml
+++ b/.pronto_stylelint.yml
@@ -1,1 +1,0 @@
-stylelint_executable: "npx stylelint"


### PR DESCRIPTION
## References

* Continues pull request #5872
* Pronto-stylelint changed the way to configure stylelint in version 0.11.0 (see pull request kevinjalbert/pronto-stylelint#15)

## Objectives

* Make sure Pronto keeps working with the latest version of pronto-stylelint