### PR TITLE
Fix missing Spanish translation

### DIFF
--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -1507,7 +1507,7 @@ es:
         level_3_user: Usuarios de nivel 3 verificados
         proposal_created: Propuestas Ciudadanas creadas
         title: Gráficos
-        visit: Visitas
+        visits: Visitas
       budgets:
         no_data_before_balloting_phase: "No hay datos que mostrar hasta que la fase de votación no esté abierta."
         title: "Presupuestos participativos - Estadisticas de participación"


### PR DESCRIPTION
## References

* We forgot to make this change in commit d25f2e7259c from pull request #5503, when we renamed the internationalization key in English but not in Spanish

## Objectives

* Display "Visitas" instead of "Visits" in the visits stats chart when accessing the page in Spanish