### PR TITLE
Check for valid segments before returning recipients

### DIFF
--- a/app/lib/user_segments.rb
+++ b/app/lib/user_segments.rb
@@ -64,7 +64,7 @@ class UserSegments
   def self.recipients(segment)
     if geozones[segment.to_s]
       all_users.where(geozone: geozones[segment.to_s])
-    else
+    elsif valid_segment?(segment)
       send(segment)
     end
   end

--- a/app/lib/user_segments.rb
+++ b/app/lib/user_segments.rb
@@ -66,6 +66,8 @@ class UserSegments
       all_users.where(geozone: geozones[segment.to_s])
     elsif valid_segment?(segment)
       send(segment)
+    else
+      User.none
     end
   end
 

--- a/app/models/admin_notification.rb
+++ b/app/models/admin_notification.rb
@@ -13,7 +13,7 @@ class AdminNotification < ApplicationRecord
   before_validation :complete_link_url
 
   def list_of_recipients
-    UserSegments.recipients(segment_recipient) if valid_segment_recipient?
+    UserSegments.recipients(segment_recipient)
   end
 
   def valid_segment_recipient?

--- a/app/models/admin_notification.rb
+++ b/app/models/admin_notification.rb
@@ -25,7 +25,7 @@ class AdminNotification < ApplicationRecord
   end
 
   def list_of_recipients_count
-    list_of_recipients&.count || 0
+    list_of_recipients.count
   end
 
   def deliver

--- a/app/models/newsletter.rb
+++ b/app/models/newsletter.rb
@@ -11,7 +11,7 @@ class Newsletter < ApplicationRecord
   include ActsAsParanoidAliases
 
   def list_of_recipient_emails
-    UserSegments.user_segment_emails(segment_recipient) if valid_segment_recipient?
+    UserSegments.user_segment_emails(segment_recipient)
   end
 
   def valid_segment_recipient?

--- a/spec/controllers/admin/emails_download_controller_spec.rb
+++ b/spec/controllers/admin/emails_download_controller_spec.rb
@@ -15,5 +15,12 @@ describe Admin::EmailsDownloadController do
       expect(response).to be_successful
       expect(response.body).to eq "admin@consul.dev,user@consul.dev"
     end
+
+    it "sends an empty file with an invalid users_segment" do
+      get :generate_csv, params: { users_segment: "invalid_segment" }
+
+      expect(response).to be_successful
+      expect(response.body).to be_empty
+    end
   end
 end

--- a/spec/controllers/admin/emails_download_controller_spec.rb
+++ b/spec/controllers/admin/emails_download_controller_spec.rb
@@ -1,0 +1,19 @@
+require "rails_helper"
+
+describe Admin::EmailsDownloadController do
+  before do
+    admin = create(:administrator, user: create(:user, email: "admin@consul.dev"))
+    sign_in(admin.user)
+  end
+
+  describe "GET generate_csv" do
+    it "sends a list of emails in a comma-separated format" do
+      create(:user, email: "user@consul.dev")
+
+      get :generate_csv, params: { users_segment: "all_users" }
+
+      expect(response).to be_successful
+      expect(response.body).to eq "admin@consul.dev,user@consul.dev"
+    end
+  end
+end

--- a/spec/lib/user_segments_spec.rb
+++ b/spec/lib/user_segments_spec.rb
@@ -307,7 +307,7 @@ describe UserSegments do
 
       recipients = UserSegments.recipients(:invalid_segment)
 
-      expect(recipients).to be nil
+      expect(recipients).to eq []
     end
 
     it "does not return any recipients when given a method name as a segment" do
@@ -315,7 +315,7 @@ describe UserSegments do
 
       recipients = UserSegments.recipients(:ancestors)
 
-      expect(recipients).to be nil
+      expect(recipients).to eq []
     end
   end
 
@@ -326,6 +326,14 @@ describe UserSegments do
 
       emails = UserSegments.user_segment_emails(:all_users)
       expect(emails).to eq ["first@email.com", "last@email.com"]
+    end
+
+    it "returns an empty list when given an invalid segment" do
+      create(:user, email: "first@email.com")
+
+      emails = UserSegments.user_segment_emails(:invalid_segment)
+
+      expect(emails).to eq []
     end
   end
 

--- a/spec/lib/user_segments_spec.rb
+++ b/spec/lib/user_segments_spec.rb
@@ -301,6 +301,24 @@ describe UserSegments do
     end
   end
 
+  describe ".recipients" do
+    it "does not return any recipients when given an invalid segment" do
+      create(:user, email: "first@email.com")
+
+      recipients = UserSegments.recipients(:invalid_segment)
+
+      expect(recipients).to be nil
+    end
+
+    it "does not return any recipients when given a method name as a segment" do
+      create(:user, email: "first@email.com")
+
+      recipients = UserSegments.recipients(:ancestors)
+
+      expect(recipients).to be nil
+    end
+  end
+
   describe ".user_segment_emails" do
     it "returns list of emails sorted by user creation date" do
       create(:user, email: "first@email.com", created_at: 1.day.ago)


### PR DESCRIPTION
## Objectives

* Remove a warning by CodeQL about a possible code injection in user segments recipients
* Simplify the code checking for valid recipients

## Notes

The chances of this warning being a real security risk were minimal because only administrators could run this code and they were only able to invoke class methods of the `UserSegments` class.