### PR TITLE
Use old Chrome in CI tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,6 +48,14 @@ jobs:
         run: npm clean-install
       - name: Install ImageMagick
         run: sudo apt-get install imagemagick
+      - name: Remove image-bundled Chrome
+        run: sudo apt-get purge google-chrome-stable
+      - name: Setup Chrome/Chromium 128
+        uses: browser-actions/setup-chrome@v1
+        with:
+          chrome-version: 128
+          install-chromedriver: true
+          install-dependencies: true
       - name: Copy secrets and database files
         run: for i in config/*.example; do cp "$i" "${i/.example}"; done
       - name: Setup database


### PR DESCRIPTION
## References

Our tests are failing fairly consistently on CI. We believe that this started when the most recent Github Actions ubuntu-latest image was released[1]. Though, we don't 100% understand why. There's some speculation[2] that the root of the issue has something to do with Chrome/Chromedriver version 134 (which is the version bundled with that new ubuntu-latest).

[1]: https://github.com/actions/runner-images PR#11761
[2]: https://github.com/teamcapybara/capybara Issue#2800

We've largely copied what the signon team did to get their CI back up-and-running[3].

[3]: https://github.com/alphagov/signon PR#3663

## Objectives

In this commit we remove the version of Chrome that the actions/runner-images image bundles for us, so that Selenium doesn't try to use it and install an old version of Chrome and Chromedriver.
