### PR TITLE
Replace link with button in ballot investment component

### DIFF
--- a/app/assets/stylesheets/budgets/ballot/investment.scss
+++ b/app/assets/stylesheets/budgets/ballot/investment.scss
@@ -33,6 +33,7 @@
     position: absolute;
     right: $close-icon-margin;
     top: $close-icon-margin;
+    cursor: pointer;
   }
 
   &:hover {

--- a/app/assets/stylesheets/budgets/ballot/investment.scss
+++ b/app/assets/stylesheets/budgets/ballot/investment.scss
@@ -29,11 +29,11 @@
 
   .remove-budget-investment {
     @include has-fa-icon(times, solid);
+    cursor: pointer;
     font-size: $close-icon-size;
     position: absolute;
     right: $close-icon-margin;
     top: $close-icon-margin;
-    cursor: pointer;
   }
 
   &:hover {

--- a/app/components/budgets/ballot/investment_component.html.erb
+++ b/app/components/budgets/ballot/investment_component.html.erb
@@ -4,10 +4,10 @@
 
   <% if budget.balloting? %>
     <%= button_to delete_path,
-                title: t("budgets.ballots.show.remove"),
-                class: "remove-budget-investment",
-                method: :delete,
-                remote: true do %>
+                  title: t("budgets.ballots.show.remove"),
+                  class: "remove-budget-investment",
+                  method: :delete,
+                  remote: true do %>
       <span class="show-for-sr"><%= t("budgets.ballots.show.remove") %></span>
     <% end %>
   <% end %>

--- a/app/components/budgets/ballot/investment_component.html.erb
+++ b/app/components/budgets/ballot/investment_component.html.erb
@@ -3,7 +3,7 @@
   <%= investment_price %>
 
   <% if budget.balloting? %>
-    <%= link_to delete_path,
+    <%= button_to delete_path,
                 title: t("budgets.ballots.show.remove"),
                 class: "remove-budget-investment",
                 method: :delete,

--- a/spec/system/budgets/ballots_spec.rb
+++ b/spec/system/budgets/ballots_spec.rb
@@ -379,7 +379,7 @@ describe "Ballots" do
     expect(page).to have_content("You have voted one investment")
 
     within("#budget_investment_#{investment.id}") do
-      click_link "Remove vote"
+      click_button "Remove vote"
     end
 
     expect(page).to have_current_path(budget_ballot_path(budget))
@@ -406,7 +406,7 @@ describe "Ballots" do
     end
 
     within("#sidebar #budget_investment_#{investment1.id}_sidebar") do
-      click_link "Remove vote"
+      click_button "Remove vote"
     end
 
     expect(page).to have_css("#total_amount", text: "€20,000")
@@ -436,7 +436,7 @@ describe "Ballots" do
       expect(page).to have_content("You have voted one investment")
 
       within(".ballot-list li", text: "Sully monument") do
-        click_link "Remove vote"
+        click_button "Remove vote"
       end
 
       expect(page).to have_content("You have voted 0 investments")
@@ -623,7 +623,7 @@ describe "Ballots" do
       end
 
       within("#budget_investment_#{bi1.id}_sidebar") do
-        click_link "Remove vote"
+        click_button "Remove vote"
       end
 
       expect(page).not_to have_css "#budget_investment_#{bi1.id}_sidebar"


### PR DESCRIPTION
## References

Contributes to #5461 (first item ie first TODO)
## Objectives

Replacing `link_to` with `button_to` elements to improve Accessibility.
The first of many changes. This one is a bit of a try. Next ones should be addressed in other PRs. 

## Visual Changes

There should be none. I only had to explicitly use a cursor pointer in the css to get the same ux than with the link.

## Notes

> Mention rake tasks or actions to be done when deploying this changes to a server (if any).
> Explain any caveats, or important things to notice like deprecations (if any).
