### PR TITLE
Run apt update to install ImageMagick in CI workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Install node packages
         run: npm clean-install
       - name: Install ImageMagick
-        run: sudo apt-get install imagemagick
+        run: sudo apt-get update && sudo apt-get install imagemagick
       - name: Remove image-bundled Chrome
         run: sudo apt-get purge google-chrome-stable
       - name: Setup Chrome/Chromium 128


### PR DESCRIPTION
## References

* This issue has caused our test suite to fail without running any tests; for example, our [test run 8887](https://github.com/consuldemocracy/consuldemocracy/actions/runs/14146912382).

## Background

We've been getting an error in our CI because some the Ubuntu 24.04 image in GitHub Actions doesn't have an updated package database:

```
E: Failed to fetch mirror+file:
   pool/main/g/ghostscript/libgs-common_10.02.1%7edfsg1-0ubuntu7.4_all.deb
   404  Not Found
E: Failed to fetch mirror+file:
   pool/main/g/ghostscript/libgs10-common_10.02.1%7edfsg1-0ubuntu7.4_all.deb
   404  Not Found
E: Failed to fetch mirror+file:
   pool/main/g/ghostscript/libgs10_10.02.1%7edfsg1-0ubuntu7.4_amd64.deb
   404  Not Found
E: Failed to fetch mirror+file:
   pool/main/g/ghostscript/ghostscript_10.02.1%7edfsg1-0ubuntu7.4_amd64.deb
   404  Not Found
E: Unable to fetch some archives, maybe run apt-get update
   or try with --fix-missing?
```

## Objectives

* Make sure ImageMagick can be installed when running the tests in GitHub Actions