### PR TITLE
Reduce the number of fields with placeholders

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -29,6 +29,7 @@
 @import "management/**/*";
 @import "milestones/**/*";
 @import "moderation/**/*";
+@import "officing/**/*";
 @import "polls/**/*";
 @import "proposals/**/*";
 @import "relationable/**/*";

--- a/app/assets/stylesheets/officing/results/form.scss
+++ b/app/assets/stylesheets/officing/results/form.scss
@@ -1,0 +1,5 @@
+.officing-results-form {
+  legend {
+    @include header-font-size(h3);
+  }
+}

--- a/app/components/attachable/fields_component.html.erb
+++ b/app/components/attachable/fields_component.html.erb
@@ -4,7 +4,7 @@
   <%= f.hidden_field :cached_attachment %>
 
   <div class="small-12 column title">
-    <%= f.text_field :title, placeholder: t("#{plural_name}.form.title_placeholder") %>
+    <%= f.text_field :title %>
   </div>
 
   <% if attachable.attachment.attached? && attachable.attachment.image? %>

--- a/app/components/officing/results/form_component.html.erb
+++ b/app/components/officing/results/form_component.html.erb
@@ -1,4 +1,4 @@
-<%= form_tag(officing_poll_results_path(poll), { id: "officer_assignment_form" }) do %>
+<%= form_tag(officing_poll_results_path(poll), { id: "officer_assignment_form", class: "officing-results-form" }) do %>
   <div class="row">
     <div class="small-12 medium-6 column">
       <%= label_tag :officer_assignment_id, t("officing.results.new.booth") %>
@@ -9,17 +9,15 @@
   </div>
 
   <% poll.questions.each do |question| %>
-    <div class="row">
-      <div class="small-12 column">
-        <h3><%= question.title %></h3>
-      </div>
+    <fieldset class="row">
+      <legend class="column"><%= question.title %></legend>
       <% question.question_options.each_with_index do |option, i| %>
         <div class="small-12 medium-6 large-3 column end">
           <%= label_tag "questions_#{question.id}_#{i}", option.title %>
           <%= text_field_tag "questions[#{question.id}][#{i}]", answer_result_value(question.id, i), placeholder: "0" %>
         </div>
       <% end %>
-    </div>
+    </fieldset>
     <hr>
   <% end %>
 

--- a/app/components/officing/results/form_component.html.erb
+++ b/app/components/officing/results/form_component.html.erb
@@ -14,7 +14,7 @@
       <% question.question_options.each_with_index do |option, i| %>
         <div class="small-12 medium-6 large-3 column end">
           <%= label_tag "questions_#{question.id}_#{i}", option.title %>
-          <%= text_field_tag "questions[#{question.id}][#{i}]", answer_result_value(question.id, i), placeholder: "0" %>
+          <%= number_field_tag "questions[#{question.id}][#{i}]", answer_result_value(question.id, i), min: 0 %>
         </div>
       <% end %>
     </fieldset>
@@ -24,17 +24,17 @@
   <div class="row">
     <div class="small-12 medium-6 large-3 column">
       <%= label_tag :whites, t("officing.results.new.ballots_white") %>
-      <%= text_field_tag :whites, params[:whites].presence, placeholder: "0" %>
+      <%= number_field_tag :whites, params[:whites].to_i, min: 0 %>
     </div>
 
     <div class="small-12 medium-6 large-3 column end">
       <%= label_tag :nulls, t("officing.results.new.ballots_null") %>
-      <%= text_field_tag :nulls, params[:nulls].presence, placeholder: "0" %>
+      <%= number_field_tag :nulls, params[:nulls].to_i, min: 0 %>
     </div>
 
     <div class="small-12 medium-6 large-3 column end">
       <%= label_tag :total, t("officing.results.new.ballots_total") %>
-      <%= text_field_tag :total, params[:total].presence, placeholder: "0" %>
+      <%= number_field_tag :total, params[:total].to_i, min: 0 %>
     </div>
   </div>
   <hr>

--- a/app/components/officing/results/form_component.html.erb
+++ b/app/components/officing/results/form_component.html.erb
@@ -15,7 +15,7 @@
       </div>
       <% question.question_options.each_with_index do |option, i| %>
         <div class="small-12 medium-6 large-3 column end">
-          <label><%= option.title %></label>
+          <%= label_tag "questions_#{question.id}_#{i}", option.title %>
           <%= text_field_tag "questions[#{question.id}][#{i}]", answer_result_value(question.id, i), placeholder: "0" %>
         </div>
       <% end %>
@@ -25,17 +25,17 @@
 
   <div class="row">
     <div class="small-12 medium-6 large-3 column">
-      <h3><%= t("officing.results.new.ballots_white") %></h3>
+      <%= label_tag :whites, t("officing.results.new.ballots_white") %>
       <%= text_field_tag :whites, params[:whites].presence, placeholder: "0" %>
     </div>
 
     <div class="small-12 medium-6 large-3 column end">
-      <h3><%= t("officing.results.new.ballots_null") %></h3>
+      <%= label_tag :nulls, t("officing.results.new.ballots_null") %>
       <%= text_field_tag :nulls, params[:nulls].presence, placeholder: "0" %>
     </div>
 
     <div class="small-12 medium-6 large-3 column end">
-      <h3><%= t("officing.results.new.ballots_total") %></h3>
+      <%= label_tag :total, t("officing.results.new.ballots_total") %>
       <%= text_field_tag :total, params[:total].presence, placeholder: "0" %>
     </div>
   </div>

--- a/app/components/officing/results/form_component.html.erb
+++ b/app/components/officing/results/form_component.html.erb
@@ -1,0 +1,49 @@
+<%= form_tag(officing_poll_results_path(poll), { id: "officer_assignment_form" }) do %>
+  <div class="row">
+    <div class="small-12 medium-6 column">
+      <%= label_tag :officer_assignment_id, t("officing.results.new.booth") %>
+      <%= select_tag :officer_assignment_id,
+                     booths_for_officer_select_options(officer_assignments),
+                     { prompt: t("officing.results.new.select_booth") } %>
+    </div>
+  </div>
+
+  <% poll.questions.each do |question| %>
+    <div class="row">
+      <div class="small-12 column">
+        <h3><%= question.title %></h3>
+      </div>
+      <% question.question_options.each_with_index do |option, i| %>
+        <div class="small-12 medium-6 large-3 column end">
+          <label><%= option.title %></label>
+          <%= text_field_tag "questions[#{question.id}][#{i}]", answer_result_value(question.id, i), placeholder: "0" %>
+        </div>
+      <% end %>
+    </div>
+    <hr>
+  <% end %>
+
+  <div class="row">
+    <div class="small-12 medium-6 large-3 column">
+      <h3><%= t("officing.results.new.ballots_white") %></h3>
+      <%= text_field_tag :whites, params[:whites].presence, placeholder: "0" %>
+    </div>
+
+    <div class="small-12 medium-6 large-3 column end">
+      <h3><%= t("officing.results.new.ballots_null") %></h3>
+      <%= text_field_tag :nulls, params[:nulls].presence, placeholder: "0" %>
+    </div>
+
+    <div class="small-12 medium-6 large-3 column end">
+      <h3><%= t("officing.results.new.ballots_total") %></h3>
+      <%= text_field_tag :total, params[:total].presence, placeholder: "0" %>
+    </div>
+  </div>
+  <hr>
+
+  <div class="row">
+    <div class="small-12 medium-6 large-3 column">
+      <%= submit_tag t("officing.results.new.submit"), class: "button expanded" %>
+    </div>
+  </div>
+<% end %>

--- a/app/components/officing/results/form_component.rb
+++ b/app/components/officing/results/form_component.rb
@@ -10,10 +10,6 @@ class Officing::Results::FormComponent < ApplicationComponent
   private
 
     def answer_result_value(question_id, option_index)
-      return nil if params.blank?
-      return nil if params[:questions].blank?
-      return nil if params[:questions][question_id.to_s].blank?
-
-      params[:questions][question_id.to_s][option_index.to_s]
+      params.dig(:questions, question_id.to_s, option_index.to_s).to_i
     end
 end

--- a/app/components/officing/results/form_component.rb
+++ b/app/components/officing/results/form_component.rb
@@ -1,0 +1,19 @@
+class Officing::Results::FormComponent < ApplicationComponent
+  attr_reader :poll, :officer_assignments
+  use_helpers :booths_for_officer_select_options
+
+  def initialize(poll, officer_assignments)
+    @poll = poll
+    @officer_assignments = officer_assignments
+  end
+
+  private
+
+    def answer_result_value(question_id, option_index)
+      return nil if params.blank?
+      return nil if params[:questions].blank?
+      return nil if params[:questions][question_id.to_s].blank?
+
+      params[:questions][question_id.to_s][option_index.to_s]
+    end
+end

--- a/app/helpers/officing_helper.rb
+++ b/app/helpers/officing_helper.rb
@@ -6,12 +6,4 @@ module OfficingHelper
     options.sort_by! { |x| x[0] }
     options_for_select(options, params[:oa])
   end
-
-  def answer_result_value(question_id, option_index)
-    return nil if params.blank?
-    return nil if params[:questions].blank?
-    return nil if params[:questions][question_id.to_s].blank?
-
-    params[:questions][question_id.to_s][option_index.to_s]
-  end
 end

--- a/app/views/admin/legislation/questions/_form.html.erb
+++ b/app/views/admin/legislation/questions/_form.html.erb
@@ -17,24 +17,26 @@
   </div>
 
   <div class="row">
-    <div class="small-12 medium-9 column">
-      <%= f.label :question_options, t("admin.legislation.questions.form.question_options") %>
-    </div>
+    <fieldset>
+      <legend class="small-12 medium-9 column">
+        <%= t("admin.legislation.questions.form.question_options") %>
+      </legend>
 
-    <div id="nested_question_options">
-      <%= f.fields_for :question_options do |ff| %>
-        <%= render "question_option_fields", f: ff %>
-      <% end %>
+      <div id="nested_question_options">
+        <%= f.fields_for :question_options do |ff| %>
+          <%= render "question_option_fields", f: ff %>
+        <% end %>
 
-      <div class="js-add-fields-container">
-        <div class="small-12 medium-9 column">
-          <%= link_to_add_association t("admin.legislation.questions.form.add_option"),
-                                      f,
-                                      :question_options,
-                                      class: "button hollow" %>
+        <div class="js-add-fields-container">
+          <div class="small-12 medium-9 column">
+            <%= link_to_add_association t("admin.legislation.questions.form.add_option"),
+                                        f,
+                                        :question_options,
+                                        class: "button hollow" %>
+          </div>
         </div>
       </div>
-    </div>
+    </fieldset>
 
     <div class="small-12 medium-6 large-3 clear column end margin-top">
       <%= f.submit(class: "button success expanded", value: t("admin.legislation.questions.#{admin_submit_action(@question)}.submit_button")) %>

--- a/app/views/admin/legislation/questions/_question_option_fields.html.erb
+++ b/app/views/admin/legislation/questions/_question_option_fields.html.erb
@@ -3,8 +3,7 @@
     <div class="small-12 medium-9 column">
       <%= f.translatable_fields do |translations_form| %>
         <%= translations_form.text_field :value,
-                                         placeholder: t("admin.legislation.questions.form.value_placeholder"),
-                                         label: false %>
+                                         label: t("admin.legislation.questions.form.value_placeholder") %>
       <% end %>
     </div>
 

--- a/app/views/officing/results/new.html.erb
+++ b/app/views/officing/results/new.html.erb
@@ -1,56 +1,6 @@
 <% if @officer_assignments.any? %>
   <h2><%= t("officing.results.new.title", poll: @poll.name) %></h2>
-
-  <%= form_tag(officing_poll_results_path(@poll), { id: "officer_assignment_form" }) do %>
-    <div class="row">
-      <div class="small-12 medium-6 column">
-        <%= label_tag :officer_assignment_id, t("officing.results.new.booth") %>
-        <%= select_tag :officer_assignment_id,
-                       booths_for_officer_select_options(@officer_assignments),
-                       { prompt: t("officing.results.new.select_booth") } %>
-      </div>
-    </div>
-
-    <% @poll.questions.each do |question| %>
-      <div class="row">
-        <div class="small-12 column">
-          <h3><%= question.title %></h3>
-        </div>
-        <% question.question_options.each_with_index do |option, i| %>
-          <div class="small-12 medium-6 large-3 column end">
-            <label><%= option.title %></label>
-            <%= text_field_tag "questions[#{question.id}][#{i}]", answer_result_value(question.id, i), placeholder: "0" %>
-          </div>
-        <% end %>
-      </div>
-      <hr>
-    <% end %>
-
-    <div class="row">
-      <div class="small-12 medium-6 large-3 column">
-        <h3><%= t("officing.results.new.ballots_white") %></h3>
-        <%= text_field_tag :whites, params[:whites].presence, placeholder: "0" %>
-      </div>
-
-      <div class="small-12 medium-6 large-3 column end">
-        <h3><%= t("officing.results.new.ballots_null") %></h3>
-        <%= text_field_tag :nulls, params[:nulls].presence, placeholder: "0" %>
-      </div>
-
-      <div class="small-12 medium-6 large-3 column end">
-        <h3><%= t("officing.results.new.ballots_total") %></h3>
-        <%= text_field_tag :total, params[:total].presence, placeholder: "0" %>
-      </div>
-    </div>
-    <hr>
-
-    <div class="row">
-      <div class="small-12 medium-6 large-3 column">
-        <%= submit_tag t("officing.results.new.submit"), class: "button expanded" %>
-      </div>
-    </div>
-  <% end %>
-
+  <%= render Officing::Results::FormComponent.new(@poll, @officer_assignments) %>
 <% else %>
   <h2><%= @poll.name %></h2>
   <div class="callout alert">

--- a/app/views/proposals/retire_form.html.erb
+++ b/app/views/proposals/retire_form.html.erb
@@ -28,7 +28,7 @@
             <%= translations_form.text_area :retired_explanation,
                                             rows: 4,
                                             maxlength: 500,
-                                            placeholder: t("proposals.retire_form.retired_explanation_placeholder") %>
+                                            hint: t("proposals.retire_form.retired_explanation_placeholder") %>
           </div>
         <% end %>
       </div>

--- a/config/locales/en/documents.yml
+++ b/config/locales/en/documents.yml
@@ -5,7 +5,6 @@ en:
     additional: Additional documentation
     form:
       title: Documents
-      title_placeholder: Add a descriptive title for the document
       delete_button: Remove document
       cancel_button: Cancel
       note: "You can upload up to a maximum of %{max_documents_allowed} documents of following content types: %{accepted_content_types}, up to %{max_file_size} MB per file."

--- a/config/locales/en/images.yml
+++ b/config/locales/en/images.yml
@@ -3,7 +3,6 @@ en:
     remove_image: Remove image
     form:
       title: Descriptive image
-      title_placeholder: Add a descriptive title for the image
       delete_button: Remove image
       note: "You can upload one image of following content types: %{accepted_content_types}, up to %{max_file_size} MB."
       add_new_image: Add image

--- a/config/locales/es/documents.yml
+++ b/config/locales/es/documents.yml
@@ -5,7 +5,6 @@ es:
     additional: Documentación adicional
     form:
       title: Documentos
-      title_placeholder: Añade un título descriptivo para el documento
       delete_button: Eliminar documento
       cancel_button: Cancelar
       note: "Puedes subir hasta un máximo de %{max_documents_allowed} documentos en los formatos: %{accepted_content_types}, y de hasta %{max_file_size} MB por archivo."

--- a/config/locales/es/images.yml
+++ b/config/locales/es/images.yml
@@ -3,7 +3,6 @@ es:
     remove_image: Eliminar imagen
     form:
       title: Imagen descriptiva
-      title_placeholder: Añade un título descriptivo para la imagen
       delete_button: Eliminar imagen
       note: "Puedes subir una imagen en los formatos: %{accepted_content_types}, y de hasta %{max_file_size} MB por archivo."
       add_new_image: Añadir imagen

--- a/spec/components/officing/results/form_component_spec.rb
+++ b/spec/components/officing/results/form_component_spec.rb
@@ -1,0 +1,19 @@
+require "rails_helper"
+
+describe Officing::Results::FormComponent do
+  let(:poll) { create(:poll, ends_at: 1.day.ago) }
+  before { create(:poll_question, :yes_no, poll: poll, title: "Agreed?") }
+
+  it "uses number fields with 0 as a default value" do
+    render_inline Officing::Results::FormComponent.new(poll, Poll::OfficerAssignment.none)
+
+    page.find(:fieldset, "Agreed?") do |fieldset|
+      expect(fieldset).to have_field "Yes", with: 0, type: :number
+      expect(fieldset).to have_field "No", with: 0, type: :number
+    end
+
+    expect(page).to have_field "Totally blank ballots", with: 0, type: :number
+    expect(page).to have_field "Invalid ballots", with: 0, type: :number
+    expect(page).to have_field "Valid ballots", with: 0, type: :number
+  end
+end

--- a/spec/system/admin/legislation/questions_spec.rb
+++ b/spec/system/admin/legislation/questions_spec.rb
@@ -107,7 +107,7 @@ describe "Admin legislation questions", :admin do
       create(:legislation_question_option, question: question, value: "Original")
 
       visit edit_question_url
-      find("#nested_question_options input").set("Changed")
+      fill_in "Add a closed answer", with: "Changed"
       click_button "Save changes"
 
       expect(page).to have_content "Question updated successfully"
@@ -154,11 +154,11 @@ describe "Admin legislation questions", :admin do
 
         click_link "Add option"
 
-        find("#nested_question_options input").set("Option 1")
+        fill_in "Add a closed answer", with: "Option 1"
 
         select "Español", from: "Current language"
 
-        find("#nested_question_options input").set("Opción 1")
+        fill_in "Add a closed answer", with: "Opción 1"
 
         click_button "Save changes"
 
@@ -180,11 +180,11 @@ describe "Admin legislation questions", :admin do
 
         click_link "Add option"
 
-        find("#nested_question_options input").set("Opción 1")
+        fill_in "Add a closed answer", with: "Opción 1"
 
         select "English", from: "Current language"
 
-        find("#nested_question_options input").set("Option 1")
+        fill_in "Add a closed answer", with: "Option 1"
 
         click_button "Save changes"
 

--- a/spec/system/officing/results_spec.rb
+++ b/spec/system/officing/results_spec.rb
@@ -59,11 +59,15 @@ describe "Officing Results", :with_frozen_time do
 
     select booth.name, from: "Booth"
 
-    fill_in "Yes", with: "100"
-    fill_in "No", with: "200"
+    within_fieldset question_1.title do
+      fill_in "Yes", with: "100"
+      fill_in "No", with: "200"
+    end
 
-    fill_in "Today", with: "333"
-    fill_in "Tomorrow", with: "444"
+    within_fieldset question_2.title do
+      fill_in "Today", with: "333"
+      fill_in "Tomorrow", with: "444"
+    end
 
     fill_in "Totally blank ballots", with: "66"
     fill_in "Invalid ballots", with: "77"
@@ -102,8 +106,11 @@ describe "Officing Results", :with_frozen_time do
     booth_name = partial_result.booth_assignment.booth.name
     select booth_name, from: "Booth"
 
-    fill_in "Yes", with: "5555"
-    fill_in "No", with: "200"
+    within_fieldset question_1.title do
+      fill_in "Yes", with: "5555"
+      fill_in "No", with: "200"
+    end
+
     fill_in "Totally blank ballots", with: "6"
     fill_in "Invalid ballots", with: "7"
     fill_in "Valid ballots", with: "8"

--- a/spec/system/officing/results_spec.rb
+++ b/spec/system/officing/results_spec.rb
@@ -59,15 +59,15 @@ describe "Officing Results", :with_frozen_time do
 
     select booth.name, from: "Booth"
 
-    fill_in "questions[#{question_1.id}][0]", with: "100"
-    fill_in "questions[#{question_1.id}][1]", with: "200"
+    fill_in "Yes", with: "100"
+    fill_in "No", with: "200"
 
-    fill_in "questions[#{question_2.id}][0]", with: "333"
-    fill_in "questions[#{question_2.id}][1]", with: "444"
+    fill_in "Today", with: "333"
+    fill_in "Tomorrow", with: "444"
 
-    fill_in "whites", with: "66"
-    fill_in "nulls",  with: "77"
-    fill_in "total",  with: "88"
+    fill_in "Totally blank ballots", with: "66"
+    fill_in "Invalid ballots", with: "77"
+    fill_in "Valid ballots", with: "88"
 
     click_button "Save"
 
@@ -102,11 +102,11 @@ describe "Officing Results", :with_frozen_time do
     booth_name = partial_result.booth_assignment.booth.name
     select booth_name, from: "Booth"
 
-    fill_in "questions[#{question_1.id}][0]", with: "5555"
-    fill_in "questions[#{question_1.id}][1]", with: "200"
-    fill_in "whites", with: "6"
-    fill_in "nulls",  with: "7"
-    fill_in "total",  with: "8"
+    fill_in "Yes", with: "5555"
+    fill_in "No", with: "200"
+    fill_in "Totally blank ballots", with: "6"
+    fill_in "Invalid ballots", with: "7"
+    fill_in "Valid ballots", with: "8"
 
     click_button "Save"
 


### PR DESCRIPTION
## References

* Continues pull request #5509
* We started reducing the amount of placeholdes in the application in pull request #4557

## Objectives

* Use labels or hints instead of placeholders where possible
* Remove redundant placeholders
* Make the form to enter officing results easier to use

## Visual Changes

### Before

Attachment fields with redundant placeholders:

<img width="1385" alt="The title field in attachments contains a placeholder asking to add a title" src="https://github.com/user-attachments/assets/3a57e6ff-2b0a-4802-aa31-00c6d97cf602" />

Form to introduce officing results:

![Fields have headings instead of labels and text fields show 0 as a placeholder](https://github.com/user-attachments/assets/21974bb3-549f-4204-bcf8-edb481f9cc51)

### After

Attachment fields without redundant placeholders:

<img width="1418" alt="The title field in attachments doesn't have a placeholder" src="https://github.com/user-attachments/assets/3fad647e-e38d-46fe-baaa-5126f32c371f" />

Form to introduce officing results:

![Fields have labels and text fields are actually number fields with 0 as a default value](https://github.com/user-attachments/assets/91defa5b-2bc4-4b51-bfe0-c432a83e43f3)

## Notes

This pull request doesn't remove every placeholder in the application; only the ones which were relatively easy. We should definitely get rid of the remaining 13 at some point :relieved:. Most of them fall on two basic usecases: tag lists and search forms, which would require non-trivial changes in the user interface.