### PR TITLE
Replace link with button in various components part i

### DIFF
--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -1154,6 +1154,10 @@ form {
       line-height: rem-calc(120);
       vertical-align: top;
     }
+
+    button {
+      @include link;
+    }
   }
 }
 

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -1811,8 +1811,11 @@ table {
   color: $delete;
 }
 
-.dropdown-pane a {
-  color: $text-medium;
+.dropdown-pane {
+  a,
+  button {
+    color: $text-medium;
+  }
 }
 
 // 17. Activity

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -821,6 +821,16 @@ footer {
 
 .auth-page {
 
+  .cancel-button {
+    cursor: pointer;
+
+    &:hover,
+    &:active,
+    &:focus {
+      text-decoration: underline;
+    }
+  }
+
   .footer {
     margin-top: 0;
   }

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -2134,7 +2134,7 @@ table {
     text-align: center;
   }
 
-  a {
+  button {
     font-weight: bold;
     margin-right: $line-height;
     text-decoration: none;
@@ -2152,6 +2152,14 @@ table {
     &::before {
       margin-right: $font-icon-margin;
     }
+
+    &:hover {
+      cursor: pointer;
+    }
+  }
+
+  form {
+    display: inline;
   }
 }
 

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -1190,9 +1190,17 @@ form {
   @include breakpoint(medium) {
 
     .mark-notification {
+      @include anchor-color;
+      cursor: pointer;
       position: absolute;
       right: 12px;
       top: 12px;
+
+      &:hover,
+      &:active,
+      &:focus {
+        @include anchor-color-hover;
+      }
     }
   }
 

--- a/app/assets/stylesheets/layout/account_menu.scss
+++ b/app/assets/stylesheets/layout/account_menu.scss
@@ -32,14 +32,20 @@
       width: auto;
     }
 
-    a {
+    a,
+    button {
       color: inherit;
+      cursor: pointer;
       line-height: inherit;
       padding-left: 0;
 
       @include breakpoint(medium) {
         font-size: $small-font-size;
         padding: rem-calc(8) rem-calc(16);
+      }
+
+      &:hover {
+        text-decoration: underline;
       }
     }
 

--- a/app/components/devise/omniauth_form_component.html.erb
+++ b/app/components/devise/omniauth_form_component.html.erb
@@ -8,10 +8,9 @@
   <div class="oauth-logins small-12">
     <% oauth_logins.each do |login| %>
       <div class="oauth-login">
-        <%= link_to t("omniauth.#{login}.name"), send("user_#{login}_omniauth_authorize_path"),
-                    title: t("omniauth.#{login}.#{action}"),
-                    class: "button-#{login.to_s.delete_suffix("_oauth2")} button expanded",
-                    method: :post %>
+        <%= button_to t("omniauth.#{login}.name"), send("user_#{login}_omniauth_authorize_path"),
+                      title: t("omniauth.#{login}.#{action}"),
+                      class: "button-#{login.to_s.delete_suffix("_oauth2")} button expanded" %>
       </div>
     <% end %>
   </div>

--- a/app/components/layout/login_items_component.html.erb
+++ b/app/components/layout/login_items_component.html.erb
@@ -18,8 +18,8 @@
                                    t("layouts.header.my_account_link") %>
   </li>
   <li>
-    <%= link_to t("devise_views.menu.login_items.logout"),
-                destroy_user_session_path, rel: "nofollow", method: :delete %>
+    <%= button_to t("devise_views.menu.login_items.logout"),
+                  destroy_user_session_path, rel: "nofollow", method: :delete %>
   </li>
 <% else %>
   <li>

--- a/app/views/budgets/investments/_author_actions.html.erb
+++ b/app/views/budgets/investments/_author_actions.html.erb
@@ -7,9 +7,9 @@
                   edit_budget_investment_path(investment.budget, investment),
                   method: :get, class: "button hollow expanded" %>
     <% else %>
-      <%= link_to image_path(investment.image),
-                  method: :delete,
-                  class: "button hollow alert expanded" do %>
+      <%= button_to image_path(investment.image),
+                    method: :delete,
+                    class: "button hollow alert expanded" do %>
         <span class="icon-image"></span>
         <%= t("images.remove_image") %>
       <% end %>

--- a/app/views/dashboard/mailing/_mailing_options.html.erb
+++ b/app/views/dashboard/mailing/_mailing_options.html.erb
@@ -5,8 +5,7 @@
                 class: "button expanded" %>
   <% end %>
 
-  <%= link_to t("dashboard.mailing.mailing_options.send", address: current_user.email),
-              proposal_dashboard_mailing_index_path(proposal),
-              method: :post,
-              class: "button expanded" %>
+  <%= button_to t("dashboard.mailing.mailing_options.send", address: current_user.email),
+                proposal_dashboard_mailing_index_path(proposal),
+                class: "button expanded" %>
 </div>

--- a/app/views/dashboard/show.html.erb
+++ b/app/views/dashboard/show.html.erb
@@ -13,8 +13,9 @@
 <% end %>
 
 <% if can?(:publish, proposal) %>
-  <%= link_to t("dashboard.index.publish"),
-              publish_proposal_dashboard_path(proposal),
-              class: "button success",
-              method: :patch %>
+  <%= button_to t("dashboard.index.publish"),
+                publish_proposal_dashboard_path(proposal),
+                class: "button success",
+                form_class: "button_to inline",
+                method: :patch %>
 <% end %>

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -11,10 +11,4 @@
     <%= link_to t("devise_views.shared.links.new_unlock"), new_unlock_path(resource_name) %><br>
   <% end -%>
 
-  <%- if devise_mapping.omniauthable? && devise_mapping.name == "user" %>
-    <%- resource_class.omniauth_providers.each do |provider| %>
-      <%= link_to t("devise_views.shared.links.signin_with_provider", provider: provider.to_s.titleize), omniauth_authorize_path(resource_name, provider), method: :post %><br>
-    <% end -%>
-  <% end -%>
-
 </div>

--- a/app/views/follows/_follow_button.html.erb
+++ b/app/views/follows/_follow_button.html.erb
@@ -1,19 +1,19 @@
 <div class="js-follow">
   <span class="followable-content">
     <% if follow.followable.followed_by?(current_user) %>
-      <%= link_to t("shared.following"),
-                  follow_path(follow),
-                  method: :delete, remote: true,
-                  title: unfollow_text(follow.followable),
-                  class: "button expanded" %>
+      <%= button_to t("shared.following"),
+                    follow_path(follow),
+                    method: :delete, remote: true,
+                    title: unfollow_text(follow.followable),
+                    class: "button expanded" %>
 
     <% else %>
-      <%= link_to follow_text(follow.followable),
-                  follows_path(followable_id: follow.followable.id,
-                               followable_type: follow.followable.class.name),
-                  method: :post, remote: true,
-                  title: follow_text(follow.followable),
-                  class: "button hollow expanded" %>
+      <%= button_to follow_text(follow.followable),
+                    follows_path(followable_id: follow.followable.id,
+                                 followable_type: follow.followable.class.name),
+                    remote: true,
+                    title: follow_text(follow.followable),
+                    class: "button hollow expanded" %>
     <% end %>
   </span>
 </div>

--- a/app/views/management/_account_info.html.erb
+++ b/app/views/management/_account_info.html.erb
@@ -1,9 +1,9 @@
 <% if managed_user.document_number.present? %>
   <section class="account-info">
-    <%= link_to(t("management.account_info.change_user"),
-                logout_management_users_path,
-                method: :delete,
-                class: "float-right btchange-user button hollow") %>
+    <%= button_to(t("management.account_info.change_user"),
+                  logout_management_users_path,
+                  method: :delete,
+                  class: "float-right btchange-user button hollow") %>
 
     <% if managed_user.level_two_or_three_verified? %>
       <p>

--- a/app/views/notifications/_notification.html.erb
+++ b/app/views/notifications/_notification.html.erb
@@ -15,16 +15,16 @@
   <% end %>
 
   <% if notification.unread? %>
-    <%= link_to t("notifications.notification.mark_as_read"),
-                mark_as_read_notification_path(notification),
-                method: :put,
-                remote: true,
-                class: "mark-notification small" %>
+    <%= button_to t("notifications.notification.mark_as_read"),
+                  mark_as_read_notification_path(notification),
+                  method: :put,
+                  remote: true,
+                  class: "mark-notification small" %>
   <% else %>
-    <%= link_to t("notifications.notification.mark_as_unread"),
-                mark_as_unread_notification_path(notification),
-                method: :put,
-                remote: true,
-                class: "mark-notification small" %>
+    <%= button_to t("notifications.notification.mark_as_unread"),
+                  mark_as_unread_notification_path(notification),
+                  method: :put,
+                  remote: true,
+                  class: "mark-notification small" %>
   <% end %>
 </li>

--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -5,10 +5,10 @@
       <%= t("notifications.index.title") %>
     </h1>
 
-    <%= link_to t("notifications.index.mark_all_as_read"),
-                mark_all_as_read_notifications_path,
-                method: :put,
-                class: "button hollow float-right-medium" %>
+    <%= button_to t("notifications.index.mark_all_as_read"),
+                  mark_all_as_read_notifications_path,
+                  method: :put,
+                  class: "button hollow float-right-medium" %>
 
     <ul class="menu simple clear">
       <li class="is-active">

--- a/app/views/proposals/created.html.erb
+++ b/app/views/proposals/created.html.erb
@@ -13,9 +13,9 @@
       <% end %>
 
       <% if can?(:publish, @proposal) %>
-        <%= link_to t("proposals.created.publish"),
-                    publish_proposal_path(@proposal),
-                    method: :patch, class: "button" %>
+        <%= button_to t("proposals.created.publish"),
+                      publish_proposal_path(@proposal),
+                      method: :patch, class: "button", form_class: "inline" %>
       <% end %>
     </div>
   </div>

--- a/app/views/relationable/_score.html.erb
+++ b/app/views/relationable/_score.html.erb
@@ -1,15 +1,15 @@
 <small><%= t("related_content.is_related") %></small>
 
-<span class="relate-content-score">
-  <%= link_to t("related_content.score_positive"),
-              score_positive_related_content_path(related),
-              method: :put,
-              remote: true,
-              class: "score-positive" %>
+<div class="relate-content-score">
+  <%= button_to t("related_content.score_positive"),
+                score_positive_related_content_path(related),
+                method: :put,
+                remote: true,
+                class: "score-positive" %>
 
-  <%= link_to t("related_content.score_negative"),
-              score_negative_related_content_path(related),
-              method: :put,
-              remote: true,
-              class: "score-negative" %>
-</span>
+  <%= button_to t("related_content.score_negative"),
+                score_negative_related_content_path(related),
+                method: :put,
+                remote: true,
+                class: "score-negative" %>
+</div>

--- a/app/views/shared/_flag_actions.html.erb
+++ b/app/views/shared/_flag_actions.html.erb
@@ -8,7 +8,8 @@
       <span class="icon-flag flag-disable"></span>
     </button>
     <span class="dropdown-pane" id="flag-drop-<%= dom_id(flaggable) %>" data-dropdown data-auto-focus="true">
-      <%= link_to t("shared.flag"), polymorphic_path(flaggable, action: :flag), method: :put, remote: true %>
+      <%= button_to t("shared.flag"), polymorphic_path(flaggable, action: :flag),
+                    method: :put, remote: true %>
     </span>
   <% end %>
 
@@ -21,7 +22,8 @@
       <span class="icon-flag flag-active"></span>
     </button>
     <span class="dropdown-pane" id="unflag-drop-<%= dom_id(flaggable) %>" data-dropdown data-auto-focus="true">
-      <%= link_to t("shared.unflag"), polymorphic_path(flaggable, action: :unflag), method: :put, remote: true %>
+      <%= button_to t("shared.unflag"), polymorphic_path(flaggable, action: :unflag),
+                    method: :put, remote: true %>
     </span>
   <% end %>
 </span>

--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -32,10 +32,10 @@
                     edit_community_topic_path(@community.id, @topic),
                     class: "button hollow expanded" %>
 
-        <%= link_to t("community.show.topic.destroy"),
-                    community_topic_path(@community.id, @topic),
-                    method: :delete,
-                    class: "button hollow expanded alert" %>
+        <%= button_to t("community.show.topic.destroy"),
+                      community_topic_path(@community.id, @topic),
+                      method: :delete,
+                      class: "button hollow expanded alert" %>
       </aside>
     <% end %>
   </div>

--- a/app/views/users/registrations/finish_signup.html.erb
+++ b/app/views/users/registrations/finish_signup.html.erb
@@ -20,7 +20,7 @@
   <% end %>
 
   <%= f.submit t("devise_views.users.registrations.new.submit"), class: "button expanded" %>
-  <div class="text-center">
-    <%= link_to t("devise_views.users.registrations.new.cancel"), destroy_user_session_path, class: "delete", method: :delete %>
-  </div>
 <% end %>
+<div class="text-center">
+  <%= button_to t("devise_views.users.registrations.new.cancel"), destroy_user_session_path, class: "delete cancel-button", method: :delete %>
+</div>

--- a/app/views/verification/letter/new.html.erb
+++ b/app/views/verification/letter/new.html.erb
@@ -42,7 +42,7 @@
           <%= t("verification.letter.new.office") %>
         </li>
         <li>
-          <%= link_to t("verification.letter.new.send_letter"), letter_path, method: :post %>
+          <%= button_to t("verification.letter.new.send_letter"), letter_path %>
         </li>
       </ul>
     </div>

--- a/config/locales/en/devise_views.yml
+++ b/config/locales/en/devise_views.yml
@@ -69,7 +69,6 @@ en:
         new_confirmation: Haven't received instructions to activate your account?
         new_password: Forgotten your password?
         new_unlock: Haven't received unlocking instructions?
-        signin_with_provider: Sign in with %{provider}
         signup: Don't have an account? %{signup_link}
         signup_link: Sign up
     unlocks:

--- a/config/locales/es/devise_views.yml
+++ b/config/locales/es/devise_views.yml
@@ -69,7 +69,6 @@ es:
         new_confirmation: '¿No has recibido instrucciones para confirmar tu cuenta?'
         new_password: '¿Olvidaste tu contraseña?'
         new_unlock: '¿No has recibido instrucciones para desbloquear?'
-        signin_with_provider: Entrar con %{provider}
         signup: '¿No tienes una cuenta? %{signup_link}'
         signup_link: Regístrate
     unlocks:

--- a/spec/components/devise/omniauth_form_component_spec.rb
+++ b/spec/components/devise/omniauth_form_component_spec.rb
@@ -22,8 +22,8 @@ describe Devise::OmniauthFormComponent do
 
       render_inline component
 
-      expect(page).to have_link "Twitter"
-      expect(page).to have_link count: 1
+      expect(page).to have_button "Twitter"
+      expect(page).to have_button count: 1
     end
 
     it "renders the facebook link when the feature is enabled" do
@@ -31,8 +31,8 @@ describe Devise::OmniauthFormComponent do
 
       render_inline component
 
-      expect(page).to have_link "Facebook"
-      expect(page).to have_link count: 1
+      expect(page).to have_button "Facebook"
+      expect(page).to have_button count: 1
     end
 
     it "renders the google link when the feature is enabled" do
@@ -40,8 +40,8 @@ describe Devise::OmniauthFormComponent do
 
       render_inline component
 
-      expect(page).to have_link "Google"
-      expect(page).to have_link count: 1
+      expect(page).to have_button "Google"
+      expect(page).to have_button count: 1
     end
 
     it "renders the wordpress link when the feature is enabled" do
@@ -49,8 +49,8 @@ describe Devise::OmniauthFormComponent do
 
       render_inline component
 
-      expect(page).to have_link "Wordpress"
-      expect(page).to have_link count: 1
+      expect(page).to have_button "Wordpress"
+      expect(page).to have_button count: 1
     end
   end
 end

--- a/spec/components/layout/admin_header_component_spec.rb
+++ b/spec/components/layout/admin_header_component_spec.rb
@@ -18,7 +18,7 @@ describe Layout::AdminHeaderComponent do
       expect(page).to have_link "You don't have new notifications"
       expect(page).to have_link "My content"
       expect(page).to have_link "My account"
-      expect(page).to have_link "Sign out"
+      expect(page).to have_button "Sign out"
       expect(page).to have_css "[data-toggle]"
     end
 

--- a/spec/shared/system/flaggable.rb
+++ b/spec/shared/system/flaggable.rb
@@ -27,18 +27,18 @@ shared_examples "flaggable" do |factory_name, admin: false|
 
     within "##{dom_id(flaggable)} .flag-content" do
       click_button "Flag as inappropriate"
-      click_link "Flag as inappropriate"
+      within("form") { click_button "Flag as inappropriate" }
 
       expect(page).to have_button "Unflag"
-      expect(page).to have_link "Unflag", visible: :hidden
-      expect(page).not_to have_link "Flag as inappropriate", visible: :all
+      expect(page).to have_button "Unflag", visible: :hidden
+      expect(page).not_to have_button "Flag as inappropriate", visible: :all
     end
 
     refresh
 
     within "##{dom_id(flaggable)} .flag-content" do
-      expect(page).to have_link "Unflag", visible: :hidden
-      expect(page).not_to have_link "Flag as inappropriate", visible: :all
+      expect(page).to have_button "Unflag", visible: :hidden
+      expect(page).not_to have_button "Flag as inappropriate", visible: :all
     end
   end
 
@@ -52,18 +52,18 @@ shared_examples "flaggable" do |factory_name, admin: false|
       expect(page).to have_button "Unflag"
 
       click_button "Unflag"
-      click_link "Unflag"
+      within("form") { click_button "Unflag" }
 
       expect(page).not_to have_button "Unflag"
-      expect(page).to have_link "Flag as inappropriate", visible: :hidden
-      expect(page).not_to have_link "Unflag", visible: :all
+      expect(page).to have_button "Flag as inappropriate", visible: :hidden
+      expect(page).not_to have_button "Unflag", visible: :all
     end
 
     visit path
 
     within "##{dom_id(flaggable)} .flag-content" do
-      expect(page).to have_link "Flag as inappropriate", visible: :hidden
-      expect(page).not_to have_link "Unflag", visible: :all
+      expect(page).to have_button "Flag as inappropriate", visible: :hidden
+      expect(page).not_to have_button "Unflag", visible: :all
     end
   end
 
@@ -73,12 +73,12 @@ shared_examples "flaggable" do |factory_name, admin: false|
 
     within "##{dom_id(flaggable)} .flag-content" do
       click_button "Flag as inappropriate"
-      click_link "Flag as inappropriate"
+      within("form") { click_button "Flag as inappropriate" }
 
       expect(page).to have_button "Unflag"
 
       click_button "Unflag"
-      click_link "Unflag"
+      within("form") { click_button "Unflag" }
 
       expect(page).not_to have_button "Unflag"
     end
@@ -86,8 +86,8 @@ shared_examples "flaggable" do |factory_name, admin: false|
     visit path
 
     within "##{dom_id(flaggable)} .flag-content" do
-      expect(page).to have_link "Flag as inappropriate", visible: :hidden
-      expect(page).not_to have_link "Unflag", visible: :all
+      expect(page).to have_button "Flag as inappropriate", visible: :hidden
+      expect(page).not_to have_button "Unflag", visible: :all
     end
   end
 
@@ -99,7 +99,7 @@ shared_examples "flaggable" do |factory_name, admin: false|
 
     within "##{dom_id(flaggable)} > .comment-body .flag-content" do
       click_button "Flag as inappropriate"
-      click_link "Flag as inappropriate"
+      within("form") { click_button "Flag as inappropriate" }
 
       expect(page).to have_button "Unflag"
     end

--- a/spec/shared/system/followable.rb
+++ b/spec/shared/system/followable.rb
@@ -17,7 +17,7 @@ shared_examples "followable" do |followable_class_name, followable_path, followa
       visit send(followable_path, arguments)
 
       within "##{dom_id(followable)}" do
-        expect(page).not_to have_link("Follow")
+        expect(page).not_to have_button("Follow")
       end
     end
 
@@ -28,7 +28,7 @@ shared_examples "followable" do |followable_class_name, followable_path, followa
       visit send(followable_path, arguments)
 
       within "##{dom_id(followable)}" do
-        expect(page).to have_link("Follow #{followable.model_name.human.downcase}")
+        expect(page).to have_button("Follow #{followable.model_name.human.downcase}")
       end
     end
 
@@ -37,7 +37,7 @@ shared_examples "followable" do |followable_class_name, followable_path, followa
       login_as(user)
 
       visit send(followable_path, arguments)
-      expect(page).to have_link("Follow #{followable.model_name.human.downcase}")
+      expect(page).to have_button("Follow #{followable.model_name.human.downcase}")
     end
 
     scenario "Should display unfollow after user clicks on follow button" do
@@ -46,10 +46,10 @@ shared_examples "followable" do |followable_class_name, followable_path, followa
 
       visit send(followable_path, arguments)
       within "##{dom_id(followable)}" do
-        click_link("Follow #{followable.model_name.human.downcase}")
+        click_button("Follow #{followable.model_name.human.downcase}")
 
-        expect(page).not_to have_link("Follow")
-        expect(page).to have_link("Following")
+        expect(page).not_to have_button("Follow")
+        expect(page).to have_button("Following")
       end
     end
 
@@ -59,7 +59,7 @@ shared_examples "followable" do |followable_class_name, followable_path, followa
 
       visit send(followable_path, arguments)
       within "##{dom_id(followable)}" do
-        click_link("Follow #{followable.model_name.human.downcase}")
+        click_button("Follow #{followable.model_name.human.downcase}")
       end
 
       expect(page).to have_content "We will notify you of changes as they occur"
@@ -71,7 +71,7 @@ shared_examples "followable" do |followable_class_name, followable_path, followa
 
       visit send(followable_path, arguments)
 
-      expect(page).to have_link("Following")
+      expect(page).to have_button("Following")
     end
 
     scenario "Updates follow button & show destroy notice after unfollow button is clicked" do
@@ -80,10 +80,10 @@ shared_examples "followable" do |followable_class_name, followable_path, followa
 
       visit send(followable_path, arguments)
       within "##{dom_id(followable)}" do
-        click_link("Unfollow #{followable.model_name.human.downcase}")
+        click_button("Unfollow #{followable.model_name.human.downcase}")
 
-        expect(page).not_to have_link("Unfollow")
-        expect(page).to have_link("Follow #{followable.model_name.human.downcase}")
+        expect(page).not_to have_button("Unfollow")
+        expect(page).to have_button("Follow #{followable.model_name.human.downcase}")
       end
     end
 
@@ -93,7 +93,7 @@ shared_examples "followable" do |followable_class_name, followable_path, followa
 
       visit send(followable_path, arguments)
       within "##{dom_id(followable)}" do
-        click_link("Unfollow #{followable.model_name.human.downcase}")
+        click_button("Unfollow #{followable.model_name.human.downcase}")
       end
 
       expect(page).to have_content "You will no longer receive notifications"

--- a/spec/shared/system/relationable.rb
+++ b/spec/shared/system/relationable.rb
@@ -146,10 +146,10 @@ shared_examples "relationable" do |relationable_model_name|
     visit polymorphic_path(relationable)
 
     within("#related-content-list") do
-      click_link "Yes"
+      click_button "Yes"
 
-      expect(page).not_to have_link "Yes"
-      expect(page).not_to have_link "No"
+      expect(page).not_to have_button "Yes"
+      expect(page).not_to have_button "No"
     end
   end
 
@@ -163,10 +163,10 @@ shared_examples "relationable" do |relationable_model_name|
     visit polymorphic_path(relationable)
 
     within("#related-content-list") do
-      click_link "No"
+      click_button "No"
 
-      expect(page).not_to have_link "Yes"
-      expect(page).not_to have_link "No"
+      expect(page).not_to have_button "Yes"
+      expect(page).not_to have_button "No"
     end
   end
 

--- a/spec/system/budgets/investments_spec.rb
+++ b/spec/system/budgets/investments_spec.rb
@@ -1715,7 +1715,7 @@ describe "Budget Investments" do
         within("aside") do
           expect(page).not_to have_content "Author"
           expect(page).not_to have_link "Edit"
-          expect(page).not_to have_link "Remove image"
+          expect(page).not_to have_button "Remove image"
         end
       end
 
@@ -1728,7 +1728,7 @@ describe "Budget Investments" do
         within("aside") do
           expect(page).to have_content "AUTHOR"
           expect(page).to have_link "Edit"
-          expect(page).not_to have_link "Remove image"
+          expect(page).not_to have_button "Remove image"
         end
       end
 
@@ -1742,7 +1742,7 @@ describe "Budget Investments" do
         within("aside") do
           expect(page).to have_content "AUTHOR"
           expect(page).not_to have_link "Edit"
-          expect(page).to have_link "Remove image"
+          expect(page).to have_button "Remove image"
         end
       end
     end

--- a/spec/system/dashboard/dashboard_spec.rb
+++ b/spec/system/dashboard/dashboard_spec.rb
@@ -10,17 +10,17 @@ describe "Proposal's dashboard" do
     expect(page).to have_link("Edit my proposal")
     expect(page).to have_link("Edit proposal")
     expect(page).to have_link("Withdraw proposal")
-    expect(page).to have_link("Publish proposal")
+    expect(page).to have_button("Publish proposal")
     expect(page).to have_link("Polls")
     expect(page).to have_link("E-mail")
     expect(page).to have_link("Poster")
   end
 
-  scenario "Publish link dissapears after proposal's publication" do
+  scenario "Publish button dissapears after proposal's publication" do
     visit proposal_dashboard_path(proposal)
-    click_link "Publish proposal"
+    click_button "Publish proposal"
 
-    expect(page).not_to have_link("Publish proposal")
+    expect(page).not_to have_button("Publish proposal")
   end
 
   scenario "Dashboard progress shows current goal" do

--- a/spec/system/dashboard/mailing_spec.rb
+++ b/spec/system/dashboard/mailing_spec.rb
@@ -13,11 +13,11 @@ describe "Mailing" do
   end
 
   scenario "Has a link to send the mail" do
-    expect(page).to have_link("Send to #{proposal.author.email}")
+    expect(page).to have_button("Send to #{proposal.author.email}")
   end
 
   scenario "User receives feedback after the email is sent" do
-    click_link "Send to #{proposal.author.email}"
+    click_button "Send to #{proposal.author.email}"
     expect(page).to have_content("The email has been sent")
   end
 
@@ -31,6 +31,6 @@ describe "Mailing" do
     click_link "Preview"
 
     expect(page).not_to have_link("Preview")
-    expect(page).to have_link("Send to #{proposal.author.email}")
+    expect(page).to have_button("Send to #{proposal.author.email}")
   end
 end

--- a/spec/system/management/managed_users_spec.rb
+++ b/spec/system/management/managed_users_spec.rb
@@ -149,7 +149,7 @@ describe "Managed User" do
       expect(page).to have_content "Identified as"
       expect(page).to have_content user.username.to_s
 
-      click_link "Change user"
+      click_button "Change user"
     end
 
     expect(page).to have_content "User session signed out successfully."

--- a/spec/system/moderation/users_spec.rb
+++ b/spec/system/moderation/users_spec.rb
@@ -39,7 +39,7 @@ describe "Moderate users" do
     expect(page).to have_css "h1", exact_text: debate3.title
     expect(page).not_to have_content(comment3.body)
 
-    click_link "Sign out"
+    click_button "Sign out"
 
     expect(page).to have_content "You have been signed out successfully"
 

--- a/spec/system/multitenancy_spec.rb
+++ b/spec/system/multitenancy_spec.rb
@@ -53,7 +53,7 @@ describe "Multitenancy", :seed_tenants do
 
       expect(page).to have_content "Proposal created successfully."
 
-      click_link "No, I want to publish the proposal"
+      click_button "No, I want to publish the proposal"
 
       expect(page).to have_content "You've created a proposal!"
 

--- a/spec/system/notifications_spec.rb
+++ b/spec/system/notifications_spec.rb
@@ -74,7 +74,7 @@ describe "Notifications" do
     click_notifications_icon
 
     expect(page).to have_css(".notification", count: 2)
-    click_link "Mark all as read"
+    click_button "Mark all as read"
 
     expect(page).to have_css(".notification", count: 0)
   end

--- a/spec/system/notifications_spec.rb
+++ b/spec/system/notifications_spec.rb
@@ -59,7 +59,7 @@ describe "Notifications" do
     click_notifications_icon
 
     within("#notification_#{notification1.id}") do
-      click_link "Mark as read"
+      click_button "Mark as read"
     end
 
     expect(page).to have_css(".notification", count: 1)
@@ -89,7 +89,7 @@ describe "Notifications" do
 
     expect(page).to have_css(".notification", count: 1)
     within("#notification_#{notification1.id}") do
-      click_link "Mark as unread"
+      click_button "Mark as unread"
     end
 
     expect(page).to have_css(".notification", count: 0)

--- a/spec/system/polls/polls_spec.rb
+++ b/spec/system/polls/polls_spec.rb
@@ -294,7 +294,7 @@ describe "Polls" do
       expect(page).to have_content "Vote introduced!"
 
       within("#notice") { click_button "Close" }
-      click_link "Sign out"
+      click_button "Sign out"
 
       expect(page).to have_content "You must sign in or register to continue."
 

--- a/spec/system/proposals_spec.rb
+++ b/spec/system/proposals_spec.rb
@@ -356,7 +356,7 @@ describe "Proposals" do
     expect(page).to have_content "Help refugees"
     expect(page).not_to have_content "You can also see more information about improving your campaign"
 
-    click_link "No, I want to publish the proposal"
+    click_button "No, I want to publish the proposal"
 
     expect(page).to have_content "Improve your campaign and get more support"
     click_link "Not now, go to my proposal"
@@ -424,7 +424,7 @@ describe "Proposals" do
     click_button "Create proposal"
 
     expect(page).to have_content "Proposal created successfully."
-    click_link "No, I want to publish the proposal"
+    click_button "No, I want to publish the proposal"
     click_link "Not now, go to my proposal"
 
     click_link "Dashboard"
@@ -450,7 +450,7 @@ describe "Proposals" do
 
     click_button "Create proposal"
     expect(page).to have_content "Proposal created successfully."
-    click_link "No, I want to publish the proposal"
+    click_button "No, I want to publish the proposal"
     click_link "Not now, go to my proposal"
 
     expect(page).to have_css "h1", exact_text: "Help refugees"
@@ -481,7 +481,7 @@ describe "Proposals" do
     click_button "Create proposal"
 
     expect(page).to have_content "Proposal created successfully."
-    click_link "No, I want to publish the proposal"
+    click_button "No, I want to publish the proposal"
     click_link "Not now, go to my proposal"
 
     expect(page).to have_content "Testing an attack"
@@ -504,7 +504,7 @@ describe "Proposals" do
     click_button "Create proposal"
 
     expect(page).to have_content "Proposal created successfully."
-    click_link "No, I want to publish the proposal"
+    click_button "No, I want to publish the proposal"
     click_link "Not now, go to my proposal"
 
     expect(page).to have_content "Testing auto link"
@@ -528,7 +528,7 @@ describe "Proposals" do
     click_button "Create proposal"
 
     expect(page).to have_content "Proposal created successfully."
-    click_link "No, I want to publish the proposal"
+    click_button "No, I want to publish the proposal"
     click_link "Not now, go to my proposal"
 
     expect(page).to have_content "Testing auto link"
@@ -568,7 +568,7 @@ describe "Proposals" do
       click_button "Create proposal"
 
       expect(page).to have_content "Proposal created successfully."
-      click_link "No, I want to publish the proposal"
+      click_button "No, I want to publish the proposal"
       click_link "Not now, go to my proposal"
 
       within "#geozone" do
@@ -613,7 +613,7 @@ describe "Proposals" do
       click_button "Create proposal"
 
       expect(page).to have_content "Proposal created successfully."
-      click_link "No, I want to publish the proposal"
+      click_button "No, I want to publish the proposal"
       click_link "Not now, go to my proposal"
 
       within "#geozone" do

--- a/spec/system/sessions_spec.rb
+++ b/spec/system/sessions_spec.rb
@@ -16,7 +16,7 @@ describe "Sessions" do
 
     within("#notice") { click_button "Close" }
 
-    click_link "Sign out"
+    click_button "Sign out"
 
     expect(page).to have_content("You have been signed out successfully")
     expect(page).to have_current_path(debate_path(debate))
@@ -63,7 +63,7 @@ describe "Sessions" do
 
     expect(page).to have_content(/errors prevented the verification of your residence/)
 
-    click_link "Sign out"
+    click_button "Sign out"
 
     expect(page).to have_content "You must sign in or register to continue."
     expect(page).to have_current_path new_user_session_path

--- a/spec/system/tags/proposals_spec.rb
+++ b/spec/system/tags/proposals_spec.rb
@@ -74,7 +74,7 @@ describe "Tags" do
     click_button "Create proposal"
 
     expect(page).to have_content "Proposal created successfully."
-    click_link "No, I want to publish the proposal"
+    click_button "No, I want to publish the proposal"
     click_link "Not now, go to my proposal"
 
     expect(page).to have_content "Economía"
@@ -99,7 +99,7 @@ describe "Tags" do
     click_button "Create proposal"
 
     expect(page).to have_content "Proposal created successfully."
-    click_link "No, I want to publish the proposal"
+    click_button "No, I want to publish the proposal"
     click_link "Not now, go to my proposal"
 
     expect(page).to have_css "h1", exact_text: "Help refugees"
@@ -144,7 +144,7 @@ describe "Tags" do
     click_button "Create proposal"
 
     expect(page).to have_content "Proposal created successfully."
-    click_link "No, I want to publish the proposal"
+    click_button "No, I want to publish the proposal"
     click_link "Not now, go to my proposal"
 
     expect(page).to have_content "user_id1"

--- a/spec/system/topics_spec.rb
+++ b/spec/system/topics_spec.rb
@@ -131,7 +131,7 @@ describe "Topics" do
       login_as(user)
       visit community_topic_path(topic.community, topic)
 
-      click_link "Delete topic"
+      click_button "Delete topic"
 
       expect(page).to have_content "Topic deleted successfully."
       expect(page).not_to have_content topic.title

--- a/spec/system/users_auth_spec.rb
+++ b/spec/system/users_auth_spec.rb
@@ -211,7 +211,7 @@ describe "Users" do
         click_button "Sign up with Twitter"
 
         expect(page).to have_current_path(finish_signup_path)
-        click_link "Cancel login"
+        click_button "Cancel login"
 
         expect(page).to have_content "You have been signed out successfully"
 

--- a/spec/system/users_auth_spec.rb
+++ b/spec/system/users_auth_spec.rb
@@ -130,7 +130,7 @@ describe "Users" do
         visit "/"
         click_link "Register"
 
-        click_link "Sign up with Twitter"
+        click_button "Sign up with Twitter"
 
         expect_to_be_signed_in
 
@@ -149,7 +149,7 @@ describe "Users" do
         visit "/"
         click_link "Register"
 
-        click_link "Sign up with Twitter"
+        click_button "Sign up with Twitter"
 
         expect(page).to have_current_path(new_user_session_path)
         expect(page).to have_content "To continue, please click on the confirmation " \
@@ -160,7 +160,7 @@ describe "Users" do
 
         visit "/"
         click_link "Sign in"
-        click_link "Sign in with Twitter"
+        click_button "Sign in with Twitter"
         expect_to_be_signed_in
 
         within("#notice") { click_button "Close" }
@@ -177,7 +177,7 @@ describe "Users" do
 
         visit "/"
         click_link "Register"
-        click_link "Sign up with Twitter"
+        click_button "Sign up with Twitter"
 
         expect(page).to have_current_path(finish_signup_path)
         fill_in "Email", with: "manueladelascarmenas@example.com"
@@ -191,7 +191,7 @@ describe "Users" do
 
         visit "/"
         click_link "Sign in"
-        click_link "Sign in with Twitter"
+        click_button "Sign in with Twitter"
         expect_to_be_signed_in
 
         within("#notice") { click_button "Close" }
@@ -208,7 +208,7 @@ describe "Users" do
 
         visit "/"
         click_link "Register"
-        click_link "Sign up with Twitter"
+        click_button "Sign up with Twitter"
 
         expect(page).to have_current_path(finish_signup_path)
         click_link "Cancel login"
@@ -228,7 +228,7 @@ describe "Users" do
 
         visit "/"
         click_link "Sign in"
-        click_link "Sign in with Twitter"
+        click_button "Sign in with Twitter"
 
         expect_to_be_signed_in
 
@@ -247,7 +247,7 @@ describe "Users" do
 
         visit "/"
         click_link "Register"
-        click_link "Sign up with Twitter"
+        click_button "Sign up with Twitter"
 
         expect(page).to have_current_path(finish_signup_path)
 
@@ -275,7 +275,7 @@ describe "Users" do
 
         visit "/"
         click_link "Register"
-        click_link "Sign up with Twitter"
+        click_button "Sign up with Twitter"
 
         expect(page).to have_current_path(finish_signup_path)
         expect(page).to have_field "Username", with: "manuela"
@@ -296,7 +296,7 @@ describe "Users" do
 
         visit "/"
         click_link "Sign in"
-        click_link "Sign in with Twitter"
+        click_button "Sign in with Twitter"
 
         within("#notice") { click_button "Close" }
         click_link "My account"
@@ -312,7 +312,7 @@ describe "Users" do
 
         visit "/"
         click_link "Register"
-        click_link "Sign up with Twitter"
+        click_button "Sign up with Twitter"
 
         expect(page).to have_current_path(finish_signup_path)
 
@@ -332,7 +332,7 @@ describe "Users" do
 
         visit "/"
         click_link "Sign in"
-        click_link "Sign in with Twitter"
+        click_button "Sign in with Twitter"
         expect_to_be_signed_in
 
         within("#notice") { click_button "Close" }
@@ -350,7 +350,7 @@ describe "Users" do
 
         visit "/"
         click_link "Register"
-        click_link "Sign up with Twitter"
+        click_button "Sign up with Twitter"
 
         expect(page).to have_current_path(finish_signup_path)
 
@@ -366,7 +366,7 @@ describe "Users" do
 
         visit "/"
         click_link "Sign in"
-        click_link "Sign in with Twitter"
+        click_button "Sign in with Twitter"
         expect_to_be_signed_in
 
         within("#notice") { click_button "Close" }
@@ -398,7 +398,7 @@ describe "Users" do
         create(:user, username: "manuela", email: "manuelacarmena@example.com")
 
         visit new_user_session_path
-        click_link "Sign in with Google"
+        click_button "Sign in with Google"
 
         expect_to_be_signed_in
       end
@@ -423,7 +423,7 @@ describe "Users" do
         visit "/"
         click_link "Register"
 
-        click_link "Sign up with Wordpress"
+        click_button "Sign up with Wordpress"
 
         expect(page).to have_current_path(new_user_session_path)
         expect(page).to have_content "To continue, please click on the confirmation " \
@@ -434,7 +434,7 @@ describe "Users" do
 
         visit "/"
         click_link "Sign in"
-        click_link "Sign in with Wordpress"
+        click_button "Sign in with Wordpress"
         expect_to_be_signed_in
 
         within("#notice") { click_button "Close" }
@@ -452,7 +452,7 @@ describe "Users" do
 
         visit "/"
         click_link "Register"
-        click_link "Sign up with Wordpress"
+        click_button "Sign up with Wordpress"
 
         expect(page).to have_current_path(finish_signup_path)
 
@@ -475,7 +475,7 @@ describe "Users" do
 
         visit "/"
         click_link "Sign in"
-        click_link "Sign in with Wordpress"
+        click_button "Sign in with Wordpress"
 
         expect_to_be_signed_in
 

--- a/spec/system/users_auth_spec.rb
+++ b/spec/system/users_auth_spec.rb
@@ -85,7 +85,7 @@ describe "Users" do
         expect(page).to have_link "My content", href: user_path(u1)
 
         within("#notice") { click_button "Close" }
-        click_link "Sign out"
+        click_button "Sign out"
 
         expect(page).to have_content "You have been signed out successfully."
 
@@ -495,7 +495,7 @@ describe "Users" do
     login_as(user)
 
     visit "/"
-    click_link "Sign out"
+    click_button "Sign out"
 
     expect(page).to have_content "You have been signed out successfully."
   end

--- a/spec/system/verification/letter_spec.rb
+++ b/spec/system/verification/letter_spec.rb
@@ -8,7 +8,7 @@ describe "Verify Letter" do
     login_as(user)
     visit new_letter_path
 
-    click_link "Send me a letter with the code"
+    click_button "Send me a letter with the code"
 
     expect(page).to have_content "Thank you for requesting your maximum security code " \
                                  "(only required for the final votes). In a few days " \

--- a/spec/system/verification/level_three_verification_spec.rb
+++ b/spec/system/verification/level_three_verification_spec.rb
@@ -76,7 +76,7 @@ describe "Level three verification" do
     verify_residence
     confirm_phone(code: "1234")
 
-    click_link "Send me a letter with the code"
+    click_button "Send me a letter with the code"
 
     expect(page).to have_content "Thank you for requesting your maximum security code " \
                                  "(only required for the final votes). In a few days " \


### PR DESCRIPTION
## References

Contributes to #5461 

## Objectives

Replacing `link_to` with `button_to` elements to improve Accessibility.
Follow-up of #5927 
Three files here (and 3 commits)

## Visual Changes

There should be none. 
I  had to modify css in case there were a difference in styling, so that buttons are styled like links.
