### PR TITLE
Fix PDF poster generated in dashboard

### DIFF
--- a/app/assets/stylesheets/dashboard.scss
+++ b/app/assets/stylesheets/dashboard.scss
@@ -545,6 +545,10 @@
     }
   }
 
+  .proposal-code {
+    text-align: center;
+  }
+
   .poster-content {
     margin: 0 auto;
     max-width: 90%;

--- a/app/views/dashboard/poster/index.html.erb
+++ b/app/views/dashboard/poster/index.html.erb
@@ -13,7 +13,7 @@
           <%= sanitize(t("dashboard.poster.index.intro_text", org: Setting["org_name"])) %>
         </p>
 
-        <p class="text-center">
+        <p class="proposal-code">
           <strong><%= t("dashboard.poster.index.proposal_code", code: proposal.code) %></strong>
         </p>
         <div class="proposal-image">

--- a/app/views/dashboard/poster/index.pdf.erb
+++ b/app/views/dashboard/poster/index.pdf.erb
@@ -18,7 +18,7 @@
     <p class="intro">
       <%= sanitize(t("dashboard.poster.index.intro_text", org: Setting["org_name"])) %>
     </p>
-    <p class="text-center proposal-code">
+    <p class="proposal-code">
       <strong><%= t("dashboard.poster.index.proposal_code", code: proposal.code) %></strong>
     </p>
     <div class="proposal-image">
@@ -29,7 +29,7 @@
       <% end %>
     </div>
     <div class="poster-content">
-      <h2 class="text-center"><strong><%= t("dashboard.poster.index.support") %></strong></h2>
+      <h2><strong><%= t("dashboard.poster.index.support") %></strong></h2>
       <%= wicked_pdf_image_tag "quote_before_blue.png", alt: "" %>
       <h3><strong><%= proposal.title %></strong></h3>
       <%= wicked_pdf_image_tag "quote_after_blue.png", alt: "" %>


### PR DESCRIPTION
## Objectives
The proposal code text rendered correctly in the browser preview, but when generating the final PDF, it was left-aligned and hidden behind an image.

This PR fixes that issue by:
- Adding specific styles to center the text in the generated PDF.

## Visual Changes
Before
- Image showing the text hidden behind the image
<img width="786" alt="Image showing the text hidden behind the image" src="https://github.com/user-attachments/assets/e2ae1f65-58c5-4549-b3c3-61aed2bd59c9" />

After
- Image showing the centered and readable text 
<img width="788" alt="Image showing the centered and readable text" src="https://github.com/user-attachments/assets/507a959c-f4f8-4092-af35-1bc648f2db04" />