### PR TITLE
Avoid side-effects when removing username message

### DIFF
--- a/app/assets/javascripts/registration_form.js
+++ b/app/assets/javascripts/registration_form.js
@@ -5,12 +5,16 @@
       var clearUsernameMessage, showUsernameMessage, usernameInput, validateUsername;
       usernameInput = $("form#new_user[action=\"/users\"] input#user_username");
       clearUsernameMessage = function() {
-        $("small").remove();
+        $("form#new_user .username-message").remove();
       };
       showUsernameMessage = function(response) {
         var klass;
         klass = response.available ? "no-error" : "error";
-        usernameInput.after($("<small class=\"" + klass + "\" style=\"margin-top: -16px;\">" + response.message + "</small>"));
+        usernameInput.after($(
+          "<small class=\"username-message " + klass + "\" style=\"margin-top: -16px;\">" +
+            response.message +
+            "</small>"
+        ));
       };
       validateUsername = function(username) {
         var request;


### PR DESCRIPTION
## Background

In the registration form, after changing the username, we were removing the message about whether a username was available. However, we were also removing every `<small>` tag on the page. This affected the demo branch, where we add a `<small>` tag on every page.

## Objectives

* Make sure we don't remove other elements when removing the "username (un)available message"