### PR TITLE
Add setting for instance repository URL in footer

### DIFF
--- a/app/components/admin/settings/configuration_tab_component.rb
+++ b/app/components/admin/settings/configuration_tab_component.rb
@@ -21,6 +21,7 @@ class Admin::Settings::ConfigurationTabComponent < ApplicationComponent
       twitter_hashtag
       youtube_handle
       org_name
+      instance_repository_url
       meta_title
       meta_description
       meta_keywords

--- a/app/components/layout/footer_component.html.erb
+++ b/app/components/layout/footer_component.html.erb
@@ -10,6 +10,11 @@
                        open_source: open_source_link,
                        consul: repository_link),
                      attributes: allowed_link_attributes) %>
+        <% if instance_repository_link.present? %>
+          <%= sanitize(t("layouts.footer.description_with_instance_repository",
+                         instance_repository: instance_repository_link),
+                       attributes: allowed_link_attributes) %>
+        <% end %>
       </p>
     </div>
 

--- a/app/components/layout/footer_component.rb
+++ b/app/components/layout/footer_component.rb
@@ -19,6 +19,13 @@ class Layout::FooterComponent < ApplicationComponent
       external_link_to(t("layouts.footer.consul"), t("layouts.footer.consul_url"))
     end
 
+    def instance_repository_link
+      url = Setting["instance_repository_url"].to_s.strip
+      return if url.blank?
+
+      external_link_to(t("layouts.footer.instance_repository_text"), url)
+    end
+
     def external_link_to(text, url)
       link_to(text, url, rel: "nofollow external")
     end

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -150,6 +150,7 @@ class Setting < ApplicationRecord
         "twitter_hashtag": nil,
         "youtube_handle": nil,
         "org_name": default_org_name,
+        "instance_repository_url": nil,
         "meta_title": nil,
         "meta_description": nil,
         "meta_keywords": nil,

--- a/config/locales/en/general.yml
+++ b/config/locales/en/general.yml
@@ -200,6 +200,8 @@ en:
       copyright: CONSUL DEMOCRACY, %{year}
       cookies_consent_management: Manage cookies
       description: This portal uses the %{consul} which is %{open_source}.
+      description_with_instance_repository: The code for this instance is available at %{instance_repository}.
+      instance_repository_text: this repository
       open_source: open-source software
       open_source_url: http://www.gnu.org/licenses/agpl-3.0.html
       participation_text: Decide how to shape the city you want to live in.

--- a/config/locales/en/settings.yml
+++ b/config/locales/en/settings.yml
@@ -42,6 +42,8 @@ en:
     instagram_handle_description: "If filled in it will appear in the footer"
     org_name: "Site name"
     org_name_description: "This name will appear on mailers subject, help pages..."
+    instance_repository_url: "Instance repository URL"
+    instance_repository_url_description: "Link to the source code repository of this Consul Democracy instance (e.g. your fork on GitHub). It will appear in the footer."
     related_content_score_threshold: "Related content score threshold"
     related_content_score_threshold_description: "According to the rating of votes in a related content, hides content that users mark as unrelated"
     hot_score_period_in_days: "Period (days) used by the filter 'most active'"

--- a/config/locales/es/general.yml
+++ b/config/locales/es/general.yml
@@ -200,6 +200,8 @@ es:
       cookies_consent_management: Configuración de cookies
       copyright: CONSUL DEMOCRACY, %{year}
       description: Este portal usa la %{consul} que es %{open_source}.
+      description_with_instance_repository: El código para esta instancia está disponible en %{instance_repository}.
+      instance_repository_text: este repositorio
       open_source: software de código abierto
       open_source_url: http://www.gnu.org/licenses/agpl-3.0.html
       participation_text: Decide cómo debe ser la ciudad que quieres.

--- a/config/locales/es/settings.yml
+++ b/config/locales/es/settings.yml
@@ -42,6 +42,8 @@ es:
     instagram_handle_description: "Si está rellenado aparecerá en el pie de página"
     org_name: "Nombre del sitio"
     org_name_description: "Este nombre aparecerá en el asunto de emails, páginas de ayuda..."
+    instance_repository_url: "URL del repositorio de la instancia"
+    instance_repository_url_description: "Enlace al repositorio de código fuente de esta instancia de Consul Democracy (p. ej., tu fork en GitHub). Se mostrará en el pie de página."
     related_content_score_threshold: "Umbral de puntuación de contenido relacionado"
     related_content_score_threshold_description: "Según la puntuación de votos en un contenido relacionado, oculta el contenido que los usuarios marquen como no relacionado"
     hot_score_period_in_days: "Periodo (días) usado para el filtro 'Más Activos'"

--- a/spec/components/layout/footer_component_spec.rb
+++ b/spec/components/layout/footer_component_spec.rb
@@ -3,12 +3,14 @@ require "rails_helper"
 describe Layout::FooterComponent do
   describe "description links" do
     it "generates links that open in the same tab" do
+      Setting["instance_repository_url"] = "https://example.com/my-fork/consuldemocracy"
+
       render_inline Layout::FooterComponent.new
 
       page.find(".info") do |info|
-        expect(info).to have_css "a", count: 2
-        expect(info).to have_css "a[rel~=nofollow]", count: 2
-        expect(info).to have_css "a[rel~=external]", count: 2
+        expect(info).to have_css "a", count: 3
+        expect(info).to have_css "a[rel~=nofollow]", count: 3
+        expect(info).to have_css "a[rel~=external]", count: 3
         expect(info).not_to have_css "a[target]"
       end
     end
@@ -38,6 +40,32 @@ describe Layout::FooterComponent do
       render_inline Layout::FooterComponent.new
 
       expect(page).not_to have_content "Manage cookies"
+    end
+  end
+
+  describe "instance repository link" do
+    context "when instance_repository_url is present" do
+      before { Setting["instance_repository_url"] = "https://example.com/my-fork/consuldemocracy" }
+
+      it "renders the description with a link to the repository" do
+        render_inline Layout::FooterComponent.new
+
+        page.find(".info") do
+          expect(page).to have_link "this repository", href: "https://example.com/my-fork/consuldemocracy"
+        end
+      end
+    end
+
+    context "when instance_repository_url is blank" do
+      before { Setting["instance_repository_url"] = "" }
+
+      it "does not render the instance repository sentence" do
+        render_inline Layout::FooterComponent.new
+
+        page.find(".info") do
+          expect(page).not_to have_link "this repository"
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
## Objectives

Introduce a new setting "instance_repository_url" to allow configuring a custom link to the source code repository of the current Consul Democracy instance.

The link text is rendered in the footer when the setting is present. This helps users find the relevant repository more easily.

## Visual Changes

<img width="1924" height="582" alt="Allow configuring a custom link to the source code repository in settings admin section" src="https://github.com/user-attachments/assets/909ecbc8-4c5b-4bbb-90be-7310c9398759" />

<img width="1634" height="399" alt="Link text is rendered in the footer" src="https://github.com/user-attachments/assets/b212221a-a94d-46c6-a704-67b0676e4f3b" />

## Release Notes

⚠️ In this PR we add new Setting. Remember add this note in the release text:

⚙️ After deploying the new version, execute the release tasks:
bin/rake consul:execute_release_tasks RAILS_ENV=production

This PR is part of a larger development to ensure that all Consul installations, both existing and new ones, display a link to their repository in the footer.

In the future, we plan to add a complementary PR to encourage as many institutions as possible to fill in this information.