### PR TITLE
Add option to require confirmation for external links

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -105,6 +105,7 @@
 //= require i18n
 //= require globalize
 //= require settings
+//= require external_links
 //= require cookies
 //= require cookies_consent
 //= require columns_selector
@@ -156,6 +157,7 @@ var initialize_modules = function() {
   App.Polls.initialize();
   App.TableSortable.initialize();
   App.InvestmentReportAlert.initialize();
+  App.ExternalLinks.initialize();
   App.Managers.initialize();
   App.Globalize.initialize();
   App.Settings.initialize();

--- a/app/assets/javascripts/external_links.js
+++ b/app/assets/javascripts/external_links.js
@@ -1,0 +1,19 @@
+(function() {
+  "use strict";
+
+  App.ExternalLinks = {
+    initialize: function() {
+      $("body").on("click", "a[href]", function(event) {
+        var message, url, link_is_external, link_is_visitable;
+
+        message = document.documentElement.dataset.warningForExternalLinks;
+
+        url = new URL(event.target.closest("a[href]").href);
+        link_is_visitable = url.protocol === "http:" || url.protocol === "https:";
+        link_is_external = link_is_visitable && url.origin !== window.location.origin;
+
+        return !link_is_external || !message || confirm(message);
+      });
+    }
+  };
+}).call(this);

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -681,49 +681,6 @@ body > header,
 // 03. Footer
 // ----------
 
-footer {
-  .logo {
-    color: inherit;
-  }
-
-  .logo a {
-    font-family: "Lato" !important;
-    text-decoration: none;
-
-    &:hover {
-      text-decoration: underline;
-    }
-  }
-
-  p {
-    font-size: $small-font-size;
-
-    &.info a {
-      text-decoration: underline;
-    }
-  }
-
-  a,
-  a:active,
-  a:focus {
-    color: inherit;
-    text-decoration: underline;
-
-    &:hover {
-      color: $text-medium;
-    }
-  }
-
-  .footer-sections {
-    padding-left: 0;
-  }
-
-  .title {
-    font-weight: bold;
-    text-decoration: none;
-  }
-}
-
 .footer {
   @include background-with-text-contrast($footer, footer);
   clear: both;
@@ -733,34 +690,6 @@ footer {
 
   .public & {
     @include full-width-background;
-  }
-}
-
-.subfooter {
-  border-top: 1px solid $text-light;
-  font-size: $small-font-size;
-  padding-top: calc($line-height / 2);
-
-  .legal {
-    display: inline-block;
-    margin-#{$global-left}: 0;
-
-    &::before {
-      content: "|";
-    }
-
-    li {
-      display: inline-block;
-
-      &::after {
-        content: "|";
-        margin-left: 4px;
-      }
-
-      &:last-child::after {
-        content: none;
-      }
-    }
   }
 }
 

--- a/app/assets/stylesheets/layout/footer.scss
+++ b/app/assets/stylesheets/layout/footer.scss
@@ -29,6 +29,15 @@ footer {
     &:hover {
       color: $text-medium;
     }
+
+    &[rel~=external] {
+      @include has-fa-icon(external-link-alt, solid, after);
+
+      &::after {
+        font-size: 0.8em;
+        margin-#{$global-left}: 0.2em;
+      }
+    }
   }
 
   .footer-sections {

--- a/app/assets/stylesheets/layout/footer.scss
+++ b/app/assets/stylesheets/layout/footer.scss
@@ -1,0 +1,48 @@
+footer {
+  .logo {
+    color: inherit;
+  }
+
+  .logo a {
+    font-family: "Lato" !important;
+    text-decoration: none;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+
+  p {
+    font-size: $small-font-size;
+
+    &.info a {
+      text-decoration: underline;
+    }
+  }
+
+  a,
+  a:active,
+  a:focus {
+    color: inherit;
+    text-decoration: underline;
+
+    &:hover {
+      color: $text-medium;
+    }
+  }
+
+  .footer-sections {
+    padding-left: 0;
+  }
+
+  .title {
+    font-weight: bold;
+    text-decoration: none;
+  }
+
+  .subfooter {
+    border-top: 1px solid $text-light;
+    font-size: $small-font-size;
+    padding-top: calc($line-height / 2);
+  }
+}

--- a/app/assets/stylesheets/layout/legal.scss
+++ b/app/assets/stylesheets/layout/legal.scss
@@ -1,0 +1,21 @@
+.subfooter .legal {
+  display: inline-block;
+  margin-#{$global-left}: 0;
+
+  &::before {
+    content: "|";
+  }
+
+  li {
+    display: inline-block;
+
+    &::after {
+      content: "|";
+      margin-left: 4px;
+    }
+
+    &:last-child::after {
+      content: none;
+    }
+  }
+}

--- a/app/components/admin/settings/features_tab_component.rb
+++ b/app/components/admin/settings/features_tab_component.rb
@@ -27,6 +27,7 @@ class Admin::Settings::FeaturesTabComponent < ApplicationComponent
       feature.machine_learning
       feature.remove_investments_supports
       feature.gdpr.require_consent_for_notifications
+      feature.gdpr.warning_for_external_links
       feature.dashboard.notification_emails
     ]
   end

--- a/app/components/layout/common_html_attributes_component.rb
+++ b/app/components/layout/common_html_attributes_component.rb
@@ -4,7 +4,7 @@ class Layout::CommonHtmlAttributesComponent < ApplicationComponent
   private
 
     def attributes
-      tag.attributes(dir: dir, lang: lang, class: html_class)
+      tag.attributes(dir: dir, lang: lang, class: html_class, data: data)
     end
 
     def dir
@@ -17,5 +17,13 @@ class Layout::CommonHtmlAttributesComponent < ApplicationComponent
 
     def html_class
       "tenant-#{Tenant.current_schema}" if Rails.application.config.multitenancy
+    end
+
+    def data
+      { warning_for_external_links: warning_for_external_links_text }
+    end
+
+    def warning_for_external_links_text
+      t("shared.warning_for_external_links") if feature?("gdpr.warning_for_external_links")
     end
 end

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -91,6 +91,7 @@ class Setting < ApplicationRecord
         "feature.remove_investments_supports": true,
         "feature.cookies_consent": false,
         "feature.gdpr.require_consent_for_notifications": false,
+        "feature.gdpr.warning_for_external_links": false,
         "homepage.widgets.feeds.debates": true,
         "homepage.widgets.feeds.processes": true,
         "homepage.widgets.feeds.proposals": true,

--- a/config/locales/en/general.yml
+++ b/config/locales/en/general.yml
@@ -655,6 +655,7 @@ en:
     show:
       back: "Go back to my content"
   shared:
+    warning_for_external_links: "By confirming, you agree to leave the website."
     actions:
       label: "%{action} %{name}"
     edit: "Edit"

--- a/config/locales/en/settings.yml
+++ b/config/locales/en/settings.yml
@@ -143,6 +143,8 @@ en:
       gdpr:
         require_consent_for_notifications: Explicit consent for notifications
         require_consent_for_notifications_description: Require explicit user consent in order to send them newsletters and similar information as required by the General Data Protection Regulation (GDPR).
+        warning_for_external_links: "Warning for external links"
+        warning_for_external_links_description: "Enable a pop-up that requires users to confirm before going to an external website."
     remote_census:
       general:
         endpoint: "Endpoint"

--- a/config/locales/es/general.yml
+++ b/config/locales/es/general.yml
@@ -655,6 +655,7 @@ es:
     show:
       back: "Volver a mi contenido"
   shared:
+    warning_for_external_links: "Al confirmar, aceptas salir del sitio web."
     actions:
       label: "%{action} %{name}"
     edit: "Editar"

--- a/config/locales/es/settings.yml
+++ b/config/locales/es/settings.yml
@@ -143,6 +143,8 @@ es:
       gdpr:
         require_consent_for_notifications: Consentimiento explícito para notificaciones
         require_consent_for_notifications_description: Requerir que los usuarios tengan que dar consentimiento explícito para enviarles boletines e información similar tal y como describe Reglamento General de Protección de Datos (RGPD).
+        warning_for_external_links: "Aviso en enlaces externos"
+        warning_for_external_links_description: "Activa un aviso que solicita confirmación del usuario antes ir a un sitio web externo."
     remote_census:
       general:
         endpoint: "Endpoint"

--- a/spec/system/external_links_spec.rb
+++ b/spec/system/external_links_spec.rb
@@ -1,0 +1,51 @@
+require "rails_helper"
+
+describe "Warning for external links" do
+  context "when the feature is enabled" do
+    before { Setting["feature.gdpr.warning_for_external_links"] = true }
+
+    scenario "warns before leaving to an external website" do
+      visit root_path
+
+      accept_confirm("By confirming, you agree to leave the website.") do
+        click_link "open-source software"
+      end
+
+      expect(page).to have_current_path "http://www.gnu.org/licenses/agpl-3.0.html"
+    end
+
+    scenario "cancels navigation when the user dismisses the confirm dialog" do
+      visit root_path
+
+      dismiss_confirm do
+        click_link "open-source software"
+      end
+
+      expect(page).to have_current_path root_path
+    end
+
+    scenario "does not warn when using the CKEditor link button", :admin do
+      visit new_admin_site_customization_page_path
+      fill_in_ckeditor "Content", with: "Filling in to make sure CKEditor is loaded"
+
+      find(".cke_button__link").click
+
+      expect(page).to have_css ".cke_dialog"
+
+      find(".cke_dialog_close_button").click
+
+      expect(page).not_to have_css ".cke_dialog"
+      expect(page).to have_current_path new_admin_site_customization_page_path
+    end
+  end
+
+  scenario "does not warn when the feature is disabled" do
+    Setting["feature.gdpr.warning_for_external_links"] = nil
+
+    visit root_path
+
+    click_link "open-source software"
+
+    expect(page).to have_current_path "http://www.gnu.org/licenses/agpl-3.0.html"
+  end
+end

--- a/spec/system/notifications_spec.rb
+++ b/spec/system/notifications_spec.rb
@@ -160,7 +160,7 @@ describe "Notifications" do
 
       first("#notification_#{notification.id} a").click
 
-      expect(page).to have_current_path "https://www.external.link.dev/", url: true
+      expect(page).to have_current_path "https://www.external.link.dev/"
     end
 
     scenario "With internal link" do


### PR DESCRIPTION
## Objectives

- Added a warning banner when users click external links
- Informs users they are leaving our site and data handling is under third-party responsibility
- Implemented to align with GDPR transparency and information duties
  (Art. 5(1)(a), Art. 12–14, Recital 39)

## Visual Changes


https://github.com/user-attachments/assets/44d106d4-2706-4cf0-915e-271b22048b63


<img width="1182" height="501" alt="Screenshot 2025-09-25 at 20 38 55" src="https://github.com/user-attachments/assets/53b1d62e-7cdc-40ff-b70a-7881243ae166" />


