### PR TITLE
Verification links with expiration time

### DIFF
--- a/app/controllers/users/confirmations_controller.rb
+++ b/app/controllers/users/confirmations_controller.rb
@@ -37,32 +37,14 @@ class Users::ConfirmationsController < Devise::ConfirmationsController
 
   # GET /resource/confirmation?confirmation_token=abcdef
   def show
-    # In the default implementation, this already confirms the resource:
-    # self.resource = self.resource = resource_class.confirm_by_token(params[:confirmation_token])
     self.resource = resource_class.find_by!(confirmation_token: params[:confirmation_token])
 
-    yield resource if block_given?
-
-    # New condition added to if: when no password was given, display the "show" view
-    # (which uses "update" above)
-    if resource.encrypted_password.blank?
-      respond_with_navigational(resource) { render :show }
-    elsif resource.errors.empty?
-      set_official_position if resource.has_official_email?
-
-      if resource.confirm
-        set_flash_message(:notice, :confirmed) if is_flashing_format?
-
-        respond_with_navigational(resource) do
-          redirect_to after_confirmation_path_for(resource_name, resource)
-        end
-      else
-        respond_with_navigational(resource.errors, status: :unprocessable_entity) do
-          render :new, status: :unprocessable_entity
-        end
-      end
+    if resource.encrypted_password.present?
+      super
     else
-      respond_with_navigational(resource.errors, status: :unprocessable_entity) { render :new }
+      yield resource if block_given?
+
+      respond_with_navigational(resource) { render :show }
     end
   end
 

--- a/app/controllers/users/confirmations_controller.rb
+++ b/app/controllers/users/confirmations_controller.rb
@@ -17,6 +17,10 @@ class Users::ConfirmationsController < Devise::ConfirmationsController
   def update
     self.resource = resource_class.find_by!(confirmation_token: params[:confirmation_token])
 
+    if confirmation_period_expired?
+      return redirect_to user_confirmation_path(confirmation_token: params[:confirmation_token])
+    end
+
     if resource.encrypted_password.blank?
       resource.assign_attributes(resource_params)
 
@@ -39,7 +43,7 @@ class Users::ConfirmationsController < Devise::ConfirmationsController
   def show
     self.resource = resource_class.find_by!(confirmation_token: params[:confirmation_token])
 
-    if resource.encrypted_password.present?
+    if confirmation_period_expired? || resource.encrypted_password.present?
       super
     else
       yield resource if block_given?
@@ -62,5 +66,9 @@ class Users::ConfirmationsController < Devise::ConfirmationsController
 
     def set_official_position
       resource.add_official_position!(Setting["official_level_1_name"], 1)
+    end
+
+    def confirmation_period_expired?
+      resource.send(:confirmation_period_expired?)
     end
 end

--- a/app/controllers/users/confirmations_controller.rb
+++ b/app/controllers/users/confirmations_controller.rb
@@ -15,7 +15,7 @@ class Users::ConfirmationsController < Devise::ConfirmationsController
   # new action, PATCH does not exist in the default Devise::ConfirmationsController
   # PATCH /resource/confirmation
   def update
-    self.resource = resource_class.find_by(confirmation_token: params[:confirmation_token])
+    self.resource = resource_class.find_by!(confirmation_token: params[:confirmation_token])
 
     if resource.encrypted_password.blank?
       resource.assign_attributes(resource_params)

--- a/app/controllers/users/confirmations_controller.rb
+++ b/app/controllers/users/confirmations_controller.rb
@@ -28,7 +28,7 @@ class Users::ConfirmationsController < Devise::ConfirmationsController
         resource.save!
         set_official_position if resource.has_official_email?
         resource.confirm
-        set_flash_message(:notice, :confirmed) if is_flashing_format?
+        set_flash_message!(:notice, :confirmed)
         sign_in_and_redirect(resource_name, resource)
       else
         render :show

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -146,7 +146,7 @@ Devise.setup do |config|
   # their account can't be confirmed with the token any more.
   # Default is nil, meaning there is no restriction on how long a user can take
   # before confirming their account.
-  # config.confirm_within = 3.days
+  config.confirm_within = 3.days
 
   # If true, requires any email changes to be confirmed (exactly the same way as
   # initial account confirmation) to be applied. Requires additional unconfirmed_email

--- a/spec/controllers/users/confirmations_controller_spec.rb
+++ b/spec/controllers/users/confirmations_controller_spec.rb
@@ -40,5 +40,54 @@ describe Users::ConfirmationsController do
         patch :update, params: { confirmation_token: "non_existent" }
       end.to raise_error ActiveRecord::RecordNotFound
     end
+
+    it "confirms a passwordless management user when the token is still valid" do
+      request.env["devise.mapping"] = Devise.mappings[:user]
+      allow(User).to receive(:confirm_within).and_return(nil)
+
+      user = create(:user,
+                    confirmed_at: nil,
+                    encrypted_password: "",
+                    confirmation_token: "plain-token",
+                    confirmation_sent_at: Time.current)
+
+      travel_to(4.days.from_now) do
+        patch :update, params: {
+          confirmation_token: "plain-token",
+          user: {
+            password: "12345678",
+            password_confirmation: "12345678"
+          }
+        }
+
+        expect(user.reload).to be_confirmed
+        expect(user.encrypted_password).not_to be_empty
+      end
+    end
+
+    it "does not persist the password when the token has expired" do
+      request.env["devise.mapping"] = Devise.mappings[:user]
+      allow(User).to receive(:confirm_within).and_return(3.days)
+
+      user = create(:user,
+                    confirmed_at: nil,
+                    encrypted_password: "",
+                    confirmation_token: "plain-token",
+                    confirmation_sent_at: Time.current)
+
+      travel_to(4.days.from_now) do
+        patch :update, params: {
+          confirmation_token: "plain-token",
+          user: {
+            password: "12345678",
+            password_confirmation: "12345678"
+          }
+        }
+
+        expect(response).to redirect_to(user_confirmation_path(confirmation_token: "plain-token"))
+        expect(user.reload).not_to be_confirmed
+        expect(user.encrypted_password).to be_empty
+      end
+    end
   end
 end

--- a/spec/controllers/users/confirmations_controller_spec.rb
+++ b/spec/controllers/users/confirmations_controller_spec.rb
@@ -7,7 +7,9 @@ describe Users::ConfirmationsController do
 
   describe "GET show" do
     it "returns a 404 code with a wrong token" do
-      expect { get :show, params: { token: "non_existent" } }.to raise_error ActiveRecord::RecordNotFound
+      expect do
+        get :show, params: { confirmation_token: "non_existent" }
+      end.to raise_error ActiveRecord::RecordNotFound
     end
 
     context "existent and used token" do
@@ -29,6 +31,14 @@ describe Users::ConfirmationsController do
       get :show, params: { user: user, confirmation_token: "token1" }
 
       expect(response).to redirect_to(new_user_session_path)
+    end
+  end
+
+  describe "PATCH update" do
+    it "returns a 404 code with a wrong token" do
+      expect do
+        patch :update, params: { confirmation_token: "non_existent" }
+      end.to raise_error ActiveRecord::RecordNotFound
     end
   end
 end

--- a/spec/controllers/users/confirmations_controller_spec.rb
+++ b/spec/controllers/users/confirmations_controller_spec.rb
@@ -10,12 +10,17 @@ describe Users::ConfirmationsController do
       expect { get :show, params: { token: "non_existent" } }.to raise_error ActiveRecord::RecordNotFound
     end
 
-    it "returns a 422 code with a existent and used token" do
-      user = create(:user, confirmation_token: "token1")
+    context "existent and used token" do
+      render_views
 
-      get :show, params: { user: user, confirmation_token: "token1" }
+      it "renders the page with an error message" do
+        user = create(:user, confirmation_token: "token1")
 
-      expect(response).to have_http_status(:unprocessable_entity)
+        get :show, params: { user: user, confirmation_token: "token1" }
+
+        expect(response).to be_successful
+        expect(response.body).to include "You have already been verified"
+      end
     end
 
     it "redirect to sign_in page with a existent and not used token" do

--- a/spec/system/management/users_spec.rb
+++ b/spec/system/management/users_spec.rb
@@ -44,6 +44,22 @@ describe "Users" do
     expect(page).to have_content "Account verified"
   end
 
+  scenario "Confirmation link does not accept a password once it has expired" do
+    create(:user,
+           confirmed_at: nil,
+           encrypted_password: "",
+           confirmation_token: "plain-token",
+           confirmation_sent_at: Time.current)
+
+    travel_to(4.days.from_now) do
+      visit user_confirmation_path(confirmation_token: "plain-token")
+
+      expect(page).to have_content "Re-send confirmation instructions"
+      expect(page).to have_content "You need to be verified within 3 days"
+      expect(page).not_to have_field "New access password"
+    end
+  end
+
   scenario "Create a level 3 user without email from scratch" do
     stub_secrets(security: { password_complexity: true })
     login_as_manager


### PR DESCRIPTION
**Here's a quick summary of some points to check**
Added expiry for email verification links (valid for 72 hours only)

## References

According [doc](https://github.com/heartcombo/devise/blob/cf93de390a29654620fdf7ac07b4794eb95171d0/lib/devise/models/recoverable.rb#L90C16-L90C19) currently token is used in invalid way. 

## Objectives

- Added expiry for email verification links (valid for 72 hours only)
- Aligns with GDPR principles of data minimization (Art. 5(1)(c))
  and storage limitation (Art. 5(1)(e))
- Improves overall account security (Art. 32 GDPR)

