### PR TITLE
Newsletter recipients

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -88,6 +88,7 @@
 //= require markdown_editor
 //= require html_editor
 //= require cocoon
+//= require newsletter_recipient
 //= require options
 //= require questions
 //= require legislation_admin

--- a/app/assets/javascripts/newsletter_recipient.js
+++ b/app/assets/javascripts/newsletter_recipient.js
@@ -1,0 +1,12 @@
+document.addEventListener("DOMContentLoaded", function() {
+  "use strict";
+  var btn = document.getElementById("newsletter-recipient-btn");
+
+  btn.addEventListener("click", function() {
+    var currentState = JSON.parse(btn.getAttribute("aria-pressed"));
+    var yesText = btn.getAttribute("data-yes");
+    var noText = btn.getAttribute("data-no");
+
+    btn.textContent = currentState ? noText : yesText;
+  });
+});

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -9,6 +9,7 @@
 @import "participation";
 @import "milestones";
 @import "pages";
+@import "newsletter_recipient";
 @import "dashboard";
 @import "legislation";
 @import "legislation_process";

--- a/app/assets/stylesheets/newsletter_recipient.scss
+++ b/app/assets/stylesheets/newsletter_recipient.scss
@@ -1,0 +1,23 @@
+.sidebar-card {
+  color: #004a83;
+  font-size: 14px;
+  margin-bottom: 15px;
+  position: relative;
+  width: 100%;
+}
+
+.sidebar-card-title {
+  align-items: center;
+  color: #222;
+  display: flex;
+  font-weight: 500;
+  justify-content: space-between;
+  margin-bottom: 0 !important;
+  user-select: none;
+}
+
+.featured-settings-form {
+  [aria-pressed] {
+    @include switch;
+  }
+}

--- a/app/components/admin/menu_component.rb
+++ b/app/components/admin/menu_component.rb
@@ -62,7 +62,8 @@ class Admin::MenuComponent < ApplicationComponent
     end
 
     def profiles?
-      %w[administrators organizations officials moderators valuators managers users].include?(controller_name)
+      %w[administrators organizations officials moderators valuators managers users newsletter_recipients]
+        .include?(controller_name)
     end
 
     def settings?
@@ -398,7 +399,8 @@ class Admin::MenuComponent < ApplicationComponent
           valuators_link,
           managers_link,
           (sdg_managers_link if feature?(:sdg)),
-          users_link
+          users_link,
+          newsletter_recipients_link
         )
       end
     end
@@ -588,6 +590,13 @@ class Admin::MenuComponent < ApplicationComponent
         t("admin.menu.sdg_managers"),
         admin_sdg_managers_path,
         sdg_managers?
+      ]
+    end
+
+    def newsletter_recipients_link
+      [
+        t("admin.menu.newsletter_recipients"),
+        admin_newsletter_recipients_path
       ]
     end
 

--- a/app/components/newsletter_recipient/featured_settings_form_component.html.erb
+++ b/app/components/newsletter_recipient/featured_settings_form_component.html.erb
@@ -1,0 +1,4 @@
+<%= form_for(@user, as: :account, url: account_path, remote: true, authenticity_token: true, html: { class: "featured-settings-form" }) do |f| %>
+  <%= f.hidden_field feature.to_sym, value: (enabled? ? "" : "active") %>
+  <%= f.button text, options %>
+<% end %>

--- a/app/components/newsletter_recipient/featured_settings_form_component.rb
+++ b/app/components/newsletter_recipient/featured_settings_form_component.rb
@@ -1,0 +1,29 @@
+class NewsletterRecipient::FeaturedSettingsFormComponent < ApplicationComponent
+  attr_reader :feature, :user, :value
+
+  def initialize(feature, user)
+    @feature = feature
+    @user = user
+    @value = user.try(feature)
+  end
+
+  def enabled?
+    value
+  end
+
+  private
+
+    def text
+      value ? t("shared.yes") : t("shared.no")
+    end
+
+    def options
+      {
+        "aria-pressed": !!value,
+        id: "newsletter-recipient-btn",
+        name: "Newsletter recipient",
+        "data-yes": t("shared.yes"),
+        "data-no": t("shared.no")
+      }
+    end
+end

--- a/app/components/newsletter_recipient/register_component.html.erb
+++ b/app/components/newsletter_recipient/register_component.html.erb
@@ -1,0 +1,36 @@
+<div class="sidebar-card js-sidebar-card -collapsed-on-mobile">
+  <div class="sidebar-card-title js-sidebar-card-title">
+    <div class="d-flex sidebar-card-title-inner">
+      <h2 class="sidebar-card-title-text title">
+        <%= t("welcome.feed.newsletters_receptions.opt_in_title") %>
+      </h2>
+    </div>
+    <div class="icon-chevron-down sidebar-collapse-icon"></div>
+  </div>
+  <div class="sidebar-card--content">
+    <div class="sidebar-card--section">
+      <div id="newsletter-subscription-form">
+        <p><%= t("welcome.feed.newsletters_receptions.opt_in_sub_title") %></p>
+        <%= form_for newsletter_recipient,
+                     url: newsletter_recipients_path,
+                     html: {
+                       class: "new_newsletter_recipient",
+                       id: "new_newsletter_recipient",
+                       accept_charset: "UTF-8"
+                     },
+                     remote: true,
+                     method: :post do |f| %>
+
+          <%= f.text_field :email,
+                           label: t("attributes.email"),
+                           placeholder: t("attributes.email") %>
+
+          <%= f.submit t("welcome.feed.newsletters_receptions.submit_btn"),
+                       class: "button",
+                       name: "commit",
+                       data: { disable_with: t("welcome.feed.newsletters_receptions.submit_btn") } %>
+        <% end %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/components/newsletter_recipient/register_component.rb
+++ b/app/components/newsletter_recipient/register_component.rb
@@ -1,0 +1,7 @@
+class NewsletterRecipient::RegisterComponent < ApplicationComponent
+  attr_reader :newsletter_recipient
+
+  def initialize
+    @newsletter_recipient = NewsletterRecipient.new
+  end
+end

--- a/app/components/widget/feeds/feed_component.html.erb
+++ b/app/components/widget/feeds/feed_component.html.erb
@@ -1,4 +1,14 @@
 <section id="feed_<%= kind %>" class="widget-feed feed-<%= kind %>">
+  <% if kind == "debates" %>
+    <% if current_user %>
+      <header>
+        <h2 class="title"><%= t("welcome.feed.newsletters_receptions.opt_in_title") %></h2>
+      </header>
+      <%= render NewsletterRecipient::FeaturedSettingsFormComponent.new("newsletter", current_user) %>
+    <% else %>
+      <%= render NewsletterRecipient::RegisterComponent.new %>
+    <% end %>
+  <% end %>
   <header>
     <h2 class="title"><%= t("welcome.feed.most_active.#{kind}") %></h2>
   </header>

--- a/app/components/widget/feeds/feed_component.rb
+++ b/app/components/widget/feeds/feed_component.rb
@@ -1,9 +1,10 @@
 class Widget::Feeds::FeedComponent < ApplicationComponent
-  attr_reader :feed
+  attr_reader :feed, :current_user
   delegate :kind, to: :feed
 
-  def initialize(feed)
+  def initialize(feed, current_user = nil)
     @feed = feed
+    @current_user = current_user
   end
 
   def see_all_path

--- a/app/components/widget/feeds/participation_component.html.erb
+++ b/app/components/widget/feeds/participation_component.html.erb
@@ -1,7 +1,7 @@
 <div class="margin-bottom feeds-list feeds-participation">
   <% feeds.each do |feed| %>
     <% if feed_proposals?(feed) || feed_debates?(feed) %>
-      <%= render Widget::Feeds::FeedComponent.new(feed) %>
+      <%= render Widget::Feeds::FeedComponent.new(feed, current_user) %>
     <% end %>
   <% end %>
 </div>

--- a/app/components/widget/feeds/participation_component.rb
+++ b/app/components/widget/feeds/participation_component.rb
@@ -1,8 +1,9 @@
 class Widget::Feeds::ParticipationComponent < ApplicationComponent
-  attr_reader :feeds
+  attr_reader :feeds, :current_user
 
-  def initialize(feeds)
+  def initialize(feeds, current_user = nil)
     @feeds = feeds
+    @current_user = current_user
   end
 
   private

--- a/app/controllers/account_controller.rb
+++ b/app/controllers/account_controller.rb
@@ -7,11 +7,15 @@ class AccountController < ApplicationController
   end
 
   def update
-    if @account.update(account_params)
-      redirect_to account_path, notice: t("flash.actions.save_changes.notice")
-    else
-      @account.errors.delete(:organization)
-      render :show
+    respond_to do |format|
+      if @account.update(account_params)
+        format.html { redirect_to account_path, notice: t("flash.actions.save_changes.notice") }
+        format.js
+      else
+        @account.errors.delete(:organization)
+        format.html { render :show }
+      end
+      format.js
     end
   end
 

--- a/app/controllers/admin/newsletter_recipients_controller.rb
+++ b/app/controllers/admin/newsletter_recipients_controller.rb
@@ -1,0 +1,23 @@
+class Admin::NewsletterRecipientsController < Admin::BaseController
+  load_and_authorize_resource
+
+  has_filters %w[active inactive], only: :index
+
+  def index
+    @newsletter_recipients = @current_filter ? filtered_data : NewsletterRecipient.all
+    @newsletter_recipients = @newsletter_recipients.by_email(params[:search]) if params[:search]
+    @newsletter_recipients = @newsletter_recipients.page(params[:page])
+    respond_to do |format|
+      format.html
+      format.js
+    end
+  end
+
+  private
+
+    def filtered_data
+      return @newsletter_recipients.active if @current_filter&.downcase == "active"
+
+      @newsletter_recipients.inactive
+    end
+end

--- a/app/controllers/newsletter_recipients_controller.rb
+++ b/app/controllers/newsletter_recipients_controller.rb
@@ -1,0 +1,46 @@
+class NewsletterRecipientsController < ApplicationController
+  skip_authorization_check
+  before_action :find_record, only: %i[edit destroy]
+
+  def new
+    @newsletter_recipient = NewsletterRecipient.new
+  end
+
+  def create
+    @newsletter_recipient = NewsletterRecipient.new(permited_params)
+    if @newsletter_recipient.save
+      Mailer.newsletter_recipients_invitation(@newsletter_recipient).deliver_later
+      redirect_to root_path, notice: t("welcome.feed.newsletters_receptions.subscribed")
+    else
+      redirect_to root_path, alert: @newsletter_recipient.errors.messages.values.join()
+    end
+  end
+
+  def edit
+    unless @record
+      return redirect_to root_path, error: t("welcome.feed.newsletters_receptions.confirmation_failed")
+    end
+
+    @record.update!(confirmed_at: Time.zone.now) unless @record.confirmed_at
+    redirect_to root_path, notice: t("welcome.feed.newsletters_receptions.confirmation_success")
+  end
+
+  def destroy
+    unless @record
+      return redirect_to root_path, error: t("welcome.feed.newsletters_receptions.stop_subscription_failed")
+    end
+
+    @record.destroy!
+    redirect_to root_path, notice: t("welcome.feed.newsletters_receptions.stop_subscription_success")
+  end
+
+  private
+
+    def find_record
+      @record = NewsletterRecipient.find_by(token: params[:token])
+    end
+
+    def permited_params
+      params.require(:newsletter_recipient).permit(:email)
+    end
+end

--- a/app/controllers/users/confirmations_controller.rb
+++ b/app/controllers/users/confirmations_controller.rb
@@ -48,6 +48,7 @@ class Users::ConfirmationsController < Devise::ConfirmationsController
     if resource.encrypted_password.blank?
       respond_with_navigational(resource) { render :show }
     elsif resource.errors.empty?
+      adopt_newsletter_recipient
       set_official_position if resource.has_official_email?
 
       if resource.confirm
@@ -77,6 +78,14 @@ class Users::ConfirmationsController < Devise::ConfirmationsController
     end
 
   private
+
+    def adopt_newsletter_recipient
+      newsletter_recipient = NewsletterRecipient.find_by(email: resource.email)
+      return unless newsletter_recipient
+
+      resource.newsletter = newsletter_recipient.active
+      newsletter_recipient.destroy!
+    end
 
     def set_official_position
       resource.add_official_position!(Setting["official_level_1_name"], 1)

--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -8,6 +8,7 @@ class WelcomeController < ApplicationController
   layout "devise", only: :welcome
 
   def index
+    @current_user = warden.authenticate(scope: :user)
     @header = Widget::Card.header.first
     @feeds = Widget::Feed.active
     @cards = Widget::Card.body

--- a/app/lib/user_segments.rb
+++ b/app/lib/user_segments.rb
@@ -1,6 +1,7 @@
 class UserSegments
   def self.segments
     %w[all_users
+       all_users_plus_newsletter_recipients
        administrators
        all_proposal_authors
        proposal_authors
@@ -71,7 +72,15 @@ class UserSegments
     end
   end
 
+  def self.all_users_plus_newsletter_recipients
+    user_emails = all_users.newsletter.pluck(:email).compact
+    newsletter_recipients_emails = NewsletterRecipient.active.pluck(:email)
+    user_emails + newsletter_recipients_emails
+  end
+
   def self.user_segment_emails(segment)
+    return all_users_plus_newsletter_recipients if "all_users_plus_newsletter_recipients" == segment
+
     recipients(segment).newsletter.order(:created_at).pluck(:email).compact
   end
 

--- a/app/mailers/mailer.rb
+++ b/app/mailers/mailer.rb
@@ -81,6 +81,15 @@ class Mailer < ApplicationMailer
     end
   end
 
+  def newsletter_recipients_invitation(newsletter_recipient)
+    @newsletter_recipient = newsletter_recipient
+    @email_to = @newsletter_recipient.email
+
+    I18n.with_locale(Setting.default_locale) do
+      mail(to: @email_to, subject: t("mailers.user_invite.subject", org_name: Setting["org_name"]))
+    end
+  end
+
   def budget_investment_created(investment)
     @investment = investment
     @email_to = @investment.author.email

--- a/app/models/abilities/administrator.rb
+++ b/app/models/abilities/administrator.rb
@@ -59,6 +59,7 @@ module Abilities
       can [:search, :create, :index, :destroy], ::Manager
       can [:create, :read, :destroy], ::SDG::Manager
       can [:search, :index], ::User
+      can [:search, :index], ::NewsletterRecipient
 
       can :manage, Dashboard::Action
 

--- a/app/models/newsletter_recipient.rb
+++ b/app/models/newsletter_recipient.rb
@@ -1,0 +1,22 @@
+class NewsletterRecipient < ApplicationRecord
+  attribute :token, default: -> { SecureRandom.hex(16) }
+  attribute :active, default: -> { !Setting["feature.gdpr.require_consent_for_notifications"] }
+
+  scope :by_email, ->(search_email) { where("email ILIKE ?", "%#{search_email.strip}%") }
+  scope :active, -> { where(active: true).where.not(confirmed_at: nil) }
+  scope :inactive, -> { where.not(active: true) }
+
+  validates :email, presence: true, uniqueness: true, format: { with: URI::MailTo::EMAIL_REGEXP }
+
+  validate :user_check
+
+  def user_check
+    return unless User.where.not(confirmed_at: nil).find_by(email: email)
+
+    errors.add(:email, I18n.t("errors.messages.taken"))
+  end
+
+  def editable_by?(user)
+    user.confirmed? && user.email == email
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -445,6 +445,12 @@ class User < ApplicationRecord
     username.to_s.parameterize
   end
 
+  def newsletter_recipient
+    return nil unless email
+
+    NewsletterRecipient.find_by(email: email)
+  end
+
   private
 
     def clean_document_number

--- a/app/views/account/update.js.erb
+++ b/app/views/account/update.js.erb
@@ -1,0 +1,4 @@
+var $button = $(".featured-settings-form button");
+var isPressed = $button.attr("aria-pressed") === "true";
+
+$button.attr("aria-pressed", !isPressed);

--- a/app/views/admin/newsletter_recipients/_newsletter_recipients.html.erb
+++ b/app/views/admin/newsletter_recipients/_newsletter_recipients.html.erb
@@ -1,0 +1,36 @@
+<%= render "shared/filter_subnav", i18n_namespace: "admin.newsletter_recipients.index" %>
+
+<% if @newsletter_recipients.any? %>
+  <h3><%= page_entries_info @newsletter_recipients %></h3>
+
+  <table>
+    <thead>
+      <tr>
+        <th scope="col"><%= t("admin.newsletter_recipients.columns.email") %></th>
+        <th scope="col"><%= t("admin.newsletter_recipients.columns.active") %></th>
+        <th scope="col"><%= t("admin.newsletter_recipients.columns.confirmation") %></th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @newsletter_recipients.each do |newsletter_recipient| %>
+        <tr>
+          <td><%= newsletter_recipient.email %></td>
+          <td><%= newsletter_recipient.active %></td>
+          <td>
+            <% if newsletter_recipient.confirmed_at? %>
+              <%= t("admin.newsletter_recipients.email.non_confirmed") %>
+            <% else %>
+              <%= t("admin.newsletter_recipients.email.confirmed") %>
+            <% end %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+
+  <%= paginate @newsletter_recipients %>
+<% else %>
+  <div class="callout primary">
+    <%= t("admin.newsletter_recipients.index.no_records") %>
+  </div>
+<% end %>

--- a/app/views/admin/newsletter_recipients/index.html.erb
+++ b/app/views/admin/newsletter_recipients/index.html.erb
@@ -1,0 +1,10 @@
+<h2><%= t("admin.newsletter_recipients.index.title") %></h2>
+
+<%= render Admin::SearchComponent.new(
+  label: t("admin.newsletter_recipients.search.placeholder"),
+  remote: true
+) %>
+
+<div id="newsletter_recipients">
+  <%= render "newsletter_recipients" %>
+</div>

--- a/app/views/admin/newsletter_recipients/index.js.erb
+++ b/app/views/admin/newsletter_recipients/index.js.erb
@@ -1,0 +1,1 @@
+$("#newsletter_recipients").html("<%= j render "newsletter_recipients" %>");

--- a/app/views/admin/newsletter_recipients/update.js.erb
+++ b/app/views/admin/newsletter_recipients/update.js.erb
@@ -1,0 +1,7 @@
+var form = $("<%= j render Admin::Settings::FeaturedSettingsFormComponent.new(
+  @setting,
+  tab: params[:tab],
+  describedby: params[:setting][:describedby]
+) %>");
+
+$("#" + form.attr("id")).html(form.html()).find("[type='submit']").focus();

--- a/app/views/mailer/newsletter_recipients_invitation.html.erb
+++ b/app/views/mailer/newsletter_recipients_invitation.html.erb
@@ -1,0 +1,15 @@
+<td style="<%= css_for_mailer_content %>">
+
+  <h1 style="<%= css_for_mailer_heading %>">
+    <%= t("mailers.newsletter_recipient_confirmation.subject") %>
+  </h1>
+
+  <p style="<%= css_for_mailer_text %>">
+    <%= t("mailers.newsletter_recipient_confirmation.confirm") %>
+  </p>
+
+  <p style="<%= css_for_mailer_text %>">
+    <%= link_to t("mailers.newsletter_recipient_confirmation.subject"),
+                edit_newsletter_recipient_url(@newsletter_recipient, token: @newsletter_recipient.token), style: css_for_mailer_link %>
+  </p>
+</td>

--- a/app/views/welcome/_feeds.html.erb
+++ b/app/views/welcome/_feeds.html.erb
@@ -1,1 +1,1 @@
-<%= render Widget::Feeds::ParticipationComponent.new(@feeds) %>
+<%= render Widget::Feeds::ParticipationComponent.new(@feeds, @current_user) %>

--- a/app/views/welcome/featured_settings_form_component.html.erb
+++ b/app/views/welcome/featured_settings_form_component.html.erb
@@ -1,0 +1,3 @@
+<%= form_for([:account], remote: true, authenticity_token: true, html: { class: "featured-settings-form" }) do |f| %>
+  <%= f.button text, options %>
+<% end %>

--- a/config/locales/de-DE/general.yml
+++ b/config/locales/de-DE/general.yml
@@ -826,6 +826,15 @@ de:
         other: "Sie können nur Investitionsprojekte in %{count} Bezirken unterstützen. Sie haben bereits Projekte in %{supported_headings} unterstützt."
   welcome:
     feed:
+      newsletters_receptions:
+        subscribed: "Du hast dich erfolgreich angemeldet!"
+        confirmation_failed: "Bestätigung fehlgeschlagen."
+        confirmation_success: "E-Mail wurde erfolgreich bestätigt."
+        stop_subscription_failed: "Abmeldung fehlgeschlagen!"
+        stop_subscription_success: "Du hast dich erfolgreich abgemeldet."
+        opt_in_title: Newsletter
+        opt_in_sub_title: Nicht registriert? Jetzt abonnieren
+        submit_btn: Anmelden
       most_active:
         debates: "Aktivste Debatten"
         proposals: "Aktivste Vorschläge"

--- a/config/locales/de-DE/mailers.yml
+++ b/config/locales/de-DE/mailers.yml
@@ -2,6 +2,9 @@ de:
   mailers:
     title: "Open Government"
     no_reply: "Diese Nachricht wurde von einer E-Mail-Adresse gesendet, die keine Antworten akzeptiert."
+    newsletter_recipient_confirmation:
+      confirm: "Bitte klicke auf den folgenden Link, um deine E-Mail-Adresse zu bestätigen:"
+      subject: "Bestätigung deiner Newsletter-Anmeldung"
     already_confirmed:
       info: "Wir haben eine Anfrage erhalten, Ihnen Anweisungen zur Bestätigung Ihres Kontos zu senden. Ihr Konto ist jedoch bereits bestätigt, sodass Sie dies nicht erneut tun müssen."
       new_password: "Wenn Sie Ihr Passwort vergessen haben, können Sie es unter dem folgenden Link zurücksetzen:"

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -749,6 +749,7 @@ en:
       administrators: Administrators
       managers: Managers
       sdg_managers: SDG Managers
+      newsletter_recipients: Newsletter recipients
       moderators: Moderators
       messaging_users: Messages to users
       newsletters: Newsletters
@@ -828,6 +829,7 @@ en:
         title: "Moderators: User search"
     segment_recipient:
       all_users: All users
+      all_users_plus_newsletter_recipients: All users + newsletter recipients
       administrators: Administrators
       all_proposal_authors: Proposal authors (including archived and withdrawn)
       proposal_authors: Proposal authors
@@ -1552,6 +1554,19 @@ en:
         title: Proposal topics
         topic: Topic
         help: "When a user creates a proposal, the following topics are suggested as default tags."
+    newsletter_recipients:
+      columns:
+        active: Active
+        email: Email
+        confirmation: Confirmation Status
+      email:
+        non_confirmed: Confirmed
+        confirmed: Not confirmed
+      index:
+        title: Newsletter recipients
+        no_records: There are no records.
+      search:
+        placeholder: Search records by email only
     users:
       columns:
         id: ID

--- a/config/locales/en/general.yml
+++ b/config/locales/en/general.yml
@@ -1,4 +1,6 @@
 en:
+  attributes:
+    email: E-Mail
   account:
     show:
       last_sign_in: "Last login: %{last_sign_in_at} from IP %{last_sign_in_ip}"
@@ -848,6 +850,15 @@ en:
         other: "You can only support investment projects in %{count} districts. You have already supported investments in %{supported_headings}."
   welcome:
     feed:
+      newsletters_receptions:
+        subscribed: You have successfully subscribed!
+        confirmation_failed: Confirmation failed.
+        confirmation_success: Email is successfully confirmed.
+        stop_subscription_failed: Unsubscribtion failed!
+        stop_subscription_success: You have successfully unsubscribed.
+        opt_in_title: Newsletter
+        opt_in_sub_title: Not registered yet? Subscribe for newsletter now
+        submit_btn: Register
       most_active:
         debates: "Most active debates"
         proposals: "Most active proposals"

--- a/config/locales/en/mailers.yml
+++ b/config/locales/en/mailers.yml
@@ -2,6 +2,9 @@ en:
   mailers:
     title: "Open Government"
     no_reply: "This message was sent from an email address that does not accept replies."
+    newsletter_recipient_confirmation:
+      confirm: "Please click with the following link to confirm your Email address:"
+      subject: Confirmation your newsletter subscription
     already_confirmed:
       info: "We've received a request to send you instructions to confirm your account. However, your account is already confirmed, so there's no need to do so again."
       new_password: "If you've forgotten your password, you can reset it at the following link:"

--- a/config/locales/es/general.yml
+++ b/config/locales/es/general.yml
@@ -1,4 +1,6 @@
 es:
+  attributes:
+    email: E-Mail
   account:
     show:
       last_sign_in: "Último acceso efectuado: %{last_sign_in_at} desde la IP %{last_sign_in_ip}"
@@ -848,6 +850,15 @@ es:
         other: "Sólo puedes apoyar proyectos de gasto de %{count} distritos. Ya has apoyado en %{supported_headings}."
   welcome:
     feed:
+      newsletters_receptions:
+        subscribed: "¡Te has suscrito con éxito!"
+        confirmation_failed: "La confirmación ha fallado."
+        confirmation_success: "El correo electrónico se ha confirmado correctamente."
+        stop_subscription_failed: "¡La cancelación de la suscripción ha fallado!"
+        stop_subscription_success: "Te has dado de baja con éxito."
+        opt_in_title: Boletín
+        opt_in_sub_title: ¿No estás registrado? Suscríbete ahora
+        submit_btn: Registrarse
       most_active:
         debates: "Debates más activos"
         proposals: "Propuestas más activas"

--- a/config/locales/es/mailers.yml
+++ b/config/locales/es/mailers.yml
@@ -2,6 +2,9 @@ es:
   mailers:
     title: "Gobierno abierto"
     no_reply: "Este mensaje se ha enviado desde una dirección de correo electrónico que no admite respuestas."
+    newsletter_recipient_confirmation:
+      confirm: "Por favor, haz clic en el siguiente enlace para confirmar tu dirección de correo electrónico:"
+      subject: "Confirmación de tu suscripción al boletín"
     already_confirmed:
       info: "Hemos recibido una solicitud para enviarte instrucciones para confirmar tu cuenta. Sin embargo, tu cuenta ya está confirmada, por lo que no es necesario volver a hacerlo."
       new_password: "Si has olvidado tu contraseña, puedes restablecerla en el siguiente enlace:"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -40,6 +40,7 @@ Rails.application.routes.draw do
     get "/consul.json", to: "installation#details"
     get "robots.txt", to: "robots#index"
 
+    resources :newsletter_recipients, only: %i[create new edit destroy], param: :token
     resources :images, only: [:destroy]
     resources :documents, only: [:destroy]
     resources :follows, only: [:create, :destroy]

--- a/config/routes/admin.rb
+++ b/config/routes/admin.rb
@@ -165,6 +165,7 @@ namespace :admin do
     end
 
     resources :users, only: [:index, :show]
+    resources :newsletter_recipients, only: [:index, :show]
 
     scope module: :poll do
       resources :polls do

--- a/db/migrate/20251015181413_create_newsletter_recipients.rb
+++ b/db/migrate/20251015181413_create_newsletter_recipients.rb
@@ -1,0 +1,19 @@
+class CreateNewsletterRecipients < ActiveRecord::Migration[7.1]
+  def change
+    create_table :newsletter_recipients do |t|
+      t.string :email, null: false
+      t.string :token, null: false
+      t.timestamp :confirmed_at
+      t.boolean :active
+
+      t.timestamps
+    end
+
+    add_index :newsletter_recipients, :email, unique: true
+    add_index :newsletter_recipients, :token, unique: true
+    add_index :newsletter_recipients, :active
+    add_index :newsletter_recipients, :confirmed_at,
+              where: "active = true AND confirmed_at IS NOT NULL",
+              name: :index_newsletter_recipients_on_active_confirmed
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_10_09_085528) do
+ActiveRecord::Schema[7.1].define(version: 2025_10_15_181413) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
   enable_extension "plpgsql"
@@ -976,6 +976,19 @@ ActiveRecord::Schema[7.1].define(version: 2025_10_09_085528) do
   create_table "moderators", id: :serial, force: :cascade do |t|
     t.integer "user_id"
     t.index ["user_id"], name: "index_moderators_on_user_id"
+  end
+
+  create_table "newsletter_recipients", force: :cascade do |t|
+    t.string "email", null: false
+    t.string "token", null: false
+    t.datetime "confirmed_at", precision: nil
+    t.boolean "active"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["active"], name: "index_newsletter_recipients_on_active"
+    t.index ["confirmed_at"], name: "index_newsletter_recipients_on_active_confirmed", where: "((active = true) AND (confirmed_at IS NOT NULL))"
+    t.index ["email"], name: "index_newsletter_recipients_on_email", unique: true
+    t.index ["token"], name: "index_newsletter_recipients_on_token", unique: true
   end
 
   create_table "newsletters", id: :serial, force: :cascade do |t|

--- a/spec/controllers/admin/newsletter_recipients_controller_spec.rb
+++ b/spec/controllers/admin/newsletter_recipients_controller_spec.rb
@@ -1,0 +1,48 @@
+require "rails_helper"
+
+describe Admin::NewsletterRecipientsController, type: :request do
+  before do
+    admin = create(:administrator, user: create(:user, email: "admin@consul.dev"))
+    sign_in(admin.user)
+  end
+
+  describe "GET #index" do
+    let!(:active_recipient) { create(:newsletter_recipient, :with_confirmed) }
+    let!(:inactive_recipient_1) { create(:newsletter_recipient, active: true, confirmed_at: nil) }
+    let!(:inactive_recipient_2) { create(:newsletter_recipient, active: false, confirmed_at: Time.zone.now) }
+
+    it "renders all recipients when no filter is provided" do
+      get admin_newsletter_recipients_path
+
+      expect(response).to be_successful
+      expect(response.body).to include(active_recipient.email)
+      expect(response.body).not_to include(inactive_recipient_1.email)
+      expect(response.body).not_to include(inactive_recipient_2.email)
+    end
+
+    it "filters by active" do
+      get admin_newsletter_recipients_path, params: { filter: "active" }
+
+      expect(response).to be_successful
+      expect(response.body).to include(active_recipient.email)
+      expect(response.body).not_to include(inactive_recipient_1.email)
+      expect(response.body).not_to include(inactive_recipient_2.email)
+    end
+
+    it "filters by inactive" do
+      get admin_newsletter_recipients_path, params: { filter: "inactive" }
+
+      expect(response).to be_successful
+      expect(response.body).not_to include(active_recipient.email)
+      expect(response.body).not_to include(inactive_recipient_1.email)
+      expect(response.body).to include(inactive_recipient_2.email)
+    end
+
+    it "responds with JS format" do
+      get admin_newsletter_recipients_path, xhr: true
+
+      expect(response).to be_successful
+      expect(response.media_type).to eq("text/javascript")
+    end
+  end
+end

--- a/spec/controllers/newsletter_recipients_controller_spec.rb
+++ b/spec/controllers/newsletter_recipients_controller_spec.rb
@@ -1,0 +1,64 @@
+require "rails_helper"
+
+describe NewsletterRecipientsController do
+  describe "POST #create" do
+    let(:valid_params) { { newsletter_recipient: { email: "user@example.com" }} }
+    let(:invalid_params) { { newsletter_recipient: { email: "" }} }
+
+    it "creates a new newsletter recipient with valid params" do
+      expect do
+        post :create, xhr: true, params: valid_params
+      end.to change(NewsletterRecipient, :count).by(1)
+
+      expect(response).to redirect_to(root_path)
+      expect(flash[:notice]).to eq("You have successfully subscribed!")
+    end
+
+    it "does not create newsletter recipient with invalid params" do
+      expect do
+        post :create, xhr: true, params: invalid_params
+      end.not_to change(NewsletterRecipient, :count)
+
+      expect(response).to redirect_to(root_path)
+      expect(flash[:alert]).to be_present
+    end
+  end
+
+  describe "GET #edit" do
+    let!(:recipient) { create(:newsletter_recipient, confirmed_at: nil) }
+
+    it "confirms email if token is valid" do
+      get :edit, params: { token: recipient.token }
+
+      expect(response).to redirect_to(root_path)
+      expect(flash[:notice]).to eq("Email is successfully confirmed.")
+      expect(recipient.reload.confirmed_at).to be_present
+    end
+
+    it "redirects with error if token is invalid" do
+      get :edit, params: { token: "wrong-token" }
+
+      expect(response).to redirect_to(root_path)
+    end
+  end
+
+  describe "DELETE #destroy" do
+    let!(:recipient) { create(:newsletter_recipient) }
+
+    it "destroys recipient if token is valid" do
+      expect do
+        delete :destroy, params: { token: recipient.token }
+      end.to change(NewsletterRecipient, :count).by(-1)
+
+      expect(response).to redirect_to(root_path)
+    end
+
+    it "redirects token is invalid" do
+      expect do
+        delete :destroy, params: { token: "wrong-token" }
+      end.not_to change(NewsletterRecipient, :count)
+
+      expect(response).to redirect_to(root_path)
+    end
+  end
+end

--- a/spec/controllers/users/confirmations_controller_spec.rb
+++ b/spec/controllers/users/confirmations_controller_spec.rb
@@ -25,5 +25,19 @@ describe Users::ConfirmationsController do
 
       expect(response).to redirect_to(new_user_session_path)
     end
+
+    context "with newsletter_recipient" do
+      let(:tokens) { Devise.token_generator.generate(User, :confirmation_token) }
+      let(:user) { create(:user, confirmation_token: tokens[1], confirmed_at: nil, newsletter: false) }
+
+      it "adopts newsletter_recipient to user" do
+        create(:newsletter_recipient, :with_confirmed, email: user.email, active: true)
+
+        get :show, params: { user: user, confirmation_token: tokens[1] }
+
+        expect(response).to have_http_status(302)
+        expect(user.reload.newsletter).to be_truthy
+      end
+    end
   end
 end

--- a/spec/factories/newsletter_recipients.rb
+++ b/spec/factories/newsletter_recipients.rb
@@ -1,0 +1,11 @@
+FactoryBot.define do
+  factory :newsletter_recipient do
+    email { Faker::Internet.email }
+    token { Faker::Internet.device_token }
+
+    trait :with_confirmed do
+      active { true }
+      confirmed_at { Time.zone.now }
+    end
+  end
+end

--- a/spec/system/admin/emails/newsletters_spec.rb
+++ b/spec/system/admin/emails/newsletters_spec.rb
@@ -58,19 +58,24 @@ describe "Admin newsletter emails", :admin do
   end
 
   scenario "Create" do
+    segment_recipient = I18n.t("admin.segment_recipient.#{UserSegments.segments.sample}")
     visit admin_newsletters_path
     click_link "New newsletter"
 
     expect(page).to have_link "Go back", href: admin_newsletters_path
 
+    within("#newsletter_segment_recipient") do
+      expect(page).to have_css("option", text: "All users + newsletter recipients")
+    end
+
     fill_in_newsletter_form(subject: "This is a subject",
-                            segment_recipient: "Proposal authors",
+                            segment_recipient: segment_recipient,
                             body: "This is a body")
     click_button "Create Newsletter"
 
     expect(page).to have_content "Newsletter created successfully"
     expect(page).to have_content "This is a subject"
-    expect(page).to have_content "Proposal authors"
+    expect(page).to have_content segment_recipient
     expect(page).to have_content "no-reply@consul.dev"
     expect(page).to have_content "This is a body"
   end

--- a/spec/system/home_spec.rb
+++ b/spec/system/home_spec.rb
@@ -8,6 +8,32 @@ describe "Home" do
       expect(page).to have_content "CONSUL"
     end
 
+    scenario "Creates a newsletter recipient" do
+      visit root_path
+
+      expect(page).to have_content "Newsletter"
+      expect(page).to have_content "Not registered yet? Subscribe for newsletter now"
+      fill_in "E-Mail", with: "test@test.test"
+      click_button "Register"
+      expect(page).to have_content "You have successfully subscribed!"
+    end
+
+    scenario "Newsletter recipient is already present" do
+      record = [
+        build(:user, email: "test@test.test"),
+        build(:newsletter_recipient, email: "test@test.test")
+      ].sample
+      record.save
+
+      visit root_path
+
+      expect(page).to have_content "Newsletter"
+      expect(page).to have_content "Not registered yet? Subscribe for newsletter now"
+      fill_in "E-Mail", with: "test@test.test"
+      click_button "Register"
+      expect(page).to have_content "has already been taken"
+    end
+
     scenario "Not display recommended section" do
       create(:debate)
 
@@ -49,6 +75,18 @@ describe "Home" do
 
         expect(page).to have_content debate.title
         expect(page).to have_content debate.description
+      end
+
+      scenario "Displays newsletter subscription" do
+        visit root_path
+
+        within(".feeds-participation") do
+          button = find_button("Newsletter recipient")
+          expect(button).to have_text("Yes")
+          button.click
+
+          expect(button).to have_text("No")
+        end
       end
 
       scenario "Display all recommended debates link" do


### PR DESCRIPTION
## Objectives
feat(newsletter): add newsletter sign-up form for homepage and account integration

Why:
Many visitors want to receive updates without creating an account. Until now, only logged-in users could subscribe to newsletters, which limited outreach and engagement.

Adding a public sign-up form increases accessibility and allows non-registered users to stay informed about platform updates.

The change also improves GDPR compliance by introducing a clear, explicit opt-in mechanism with double confirmation. This ensures that no newsletter is sent without verified consent.

Finally, placing the sign-up option on the homepage enhances visibility, making it easier for both new and existing users to manage their subscriptions and stay connected with the platform.
