### PR TITLE
Introduce Sensemaker Integration 3/5: Adds core business logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,5 @@ tmp/
 # Test results
 /spec/examples.txt
 /coverage/
+
+/vendor/sensemaking-tools/

--- a/app/components/admin/settings/llm_configuration_tab_component.html.erb
+++ b/app/components/admin/settings/llm_configuration_tab_component.html.erb
@@ -5,4 +5,5 @@
   <%= render Admin::Settings::RowComponent.new("llm.model", type: :dropdown, tab: tab, options: model_options, disabled: model_disabled?) %>
   <%= render Admin::Settings::RowComponent.new("llm.use_llm_for_translations", type: :feature, tab: tab, disabled: feature_disabled?) %>
   <%= render Admin::Settings::RowComponent.new("llm.use_ai_image_suggestions", type: :feature, tab: tab, disabled: image_suggestions_disabled?) %>
+  <%= render Admin::Settings::RowComponent.new("llm.use_sensemaker", type: :feature, tab: tab, disabled: sensemaker_disabled?) %>
 <% end %>

--- a/app/components/admin/settings/llm_configuration_tab_component.rb
+++ b/app/components/admin/settings/llm_configuration_tab_component.rb
@@ -42,4 +42,8 @@ class Admin::Settings::LlmConfigurationTabComponent < ApplicationComponent
   def image_suggestions_disabled?
     !::Llm::Config.configured? || Tenant.current_secrets.pexels_access_key.blank?
   end
+
+  def sensemaker_disabled?
+    !::Llm::Config.configured? || Tenant.current_secrets.sensemaker_data_folder.blank?
+  end
 end

--- a/app/lib/conversation.rb
+++ b/app/lib/conversation.rb
@@ -1,0 +1,341 @@
+# frozen_string_literal: true
+
+class Conversation
+  CommentLikeItem = Data.define(:id, :body, :cached_votes_up, :cached_votes_down, :cached_votes_total,
+                                :user_id)
+
+  attr_reader :target
+
+  def initialize(analysable_type, analysable_id = nil)
+    @analysable_type = analysable_type
+    @analysable_id = analysable_id
+
+    if @analysable_id.present?
+      @target = analysable_type.constantize.find(analysable_id)
+    else
+      @target = analysable_type.constantize
+    end
+  end
+
+  def context_i18n_scope
+    "conversation.context"
+  end
+
+  def comments
+    if @target.is_a?(Legislation::QuestionOption)
+      user_ids = @target.answers.pluck(:user_id)
+      if user_ids.any?
+        @target.question.comments.includes(:user).where(hidden_at: nil, user_id: user_ids)
+      else
+        Comment.none
+      end
+    elsif @target.is_a?(Budget) || @target.is_a?(Budget::Group)
+      investments = @target.investments.includes(:author).where(hidden_at: nil)
+      investments.map do |investment|
+        CommentLikeItem.new(
+          id: investment.id,
+          body: "#{investment.title}\n\n#{self.class.sanitize_html(investment.description)}",
+          cached_votes_up: 1 + investment.cached_votes_up,
+          cached_votes_down: 0,
+          cached_votes_total: 1 + investment.cached_votes_up,
+          user_id: investment.author_id
+        )
+      end
+    elsif @analysable_type == "Proposal" && @analysable_id.nil?
+      proposals = Proposal.includes(:author).where(hidden_at: nil)
+      proposals.map do |proposal|
+        CommentLikeItem.new(
+          id: proposal.id,
+          body: "#{proposal.title}\n\n#{self.class.sanitize_html(proposal.description)}",
+          cached_votes_up: 1 + proposal.cached_votes_up,
+          cached_votes_down: 0,
+          cached_votes_total: 1 + proposal.cached_votes_up,
+          user_id: proposal.author_id
+        )
+      end
+    elsif @target.is_a?(Poll) && @target.questions.any?(&:open?)
+      all_answers = @target.answers
+                           .includes(:author, :option, question: [:question_options, :votation_type])
+                           .group_by(&:author_id)
+      return [] if all_answers.empty?
+
+      all_answers.map do |user_id, user_answers|
+        answer_parts = []
+
+        @target.questions.each_with_index do |question, index|
+          question_answers = user_answers.select { |answer| answer.question_id == question.id }
+          next if question_answers.empty?
+
+          question_number = index + 1
+          formatted_answer = format_user_answer_for_question(question, question_answers)
+          answer_parts << "Q#{question_number}: #{formatted_answer}"
+        end
+
+        next if answer_parts.empty?
+
+        CommentLikeItem.new(
+          id: "combined_answers_#{user_id}",
+          body: answer_parts.join(" | "),
+          cached_votes_up: 1,
+          cached_votes_down: 0,
+          cached_votes_total: 1,
+          user_id: user_id
+        )
+      end.compact
+    elsif @target.is_a?(Poll::Question)
+      question = Poll::Question
+                 .includes(:question_options, :votation_type, answers: :author, partial_results: :option)
+                 .find(@target.id)
+
+      unless question.open?
+        question_type = question.multiple? ? "multiple choice" : "single choice"
+        raise ArgumentError,
+              "Conversation is only supported for open-ended Poll::Question. " \
+              "This question is #{question_type}."
+      end
+
+      question.answers.includes(:author).map do |answer|
+        CommentLikeItem.new(
+          id: "a_#{answer.id}",
+          body: answer.answer.to_s,
+          cached_votes_up: 1,
+          cached_votes_down: 0,
+          cached_votes_total: 1,
+          user_id: answer.author_id
+        )
+      end
+    else
+      @target.comments.includes(:user).where(hidden_at: nil)
+    end
+  end
+
+  def compile_context
+    scope = context_i18n_scope
+    if @target.is_a?(Legislation::QuestionOption)
+      question_context = self.class.compile_context_for_target(@target.question,
+                                                               i18n_scope: scope,
+                                                               comments_count: comments.size)
+      filter_note = I18n.t("#{scope}.question_option.filter_note", option_value: @target.value)
+      "#{question_context}\n\n#{filter_note}"
+    elsif @target.is_a?(Poll::Question)
+      poll_context = self.class.compile_context_for_target(@target.poll,
+                                                           i18n_scope: scope,
+                                                           comments_count: comments.size)
+      poll_note = I18n.t("#{scope}.poll_question.filter_note", question_title: @target.title)
+      "#{poll_context}\n\n#{poll_note}"
+    elsif @analysable_type == "Proposal" && @analysable_id.nil?
+      I18n.t("#{scope}.proposals.all")
+    else
+      self.class.compile_context_for_target(@target, i18n_scope: scope, comments_count: comments.size)
+    end
+  end
+
+  def target_label(format: :short)
+    if @target.is_a?(Poll::Question)
+      case format
+      when :full
+        "Poll::Question #{@target.id}: #{@target.title}"
+      else
+        @target.title
+      end
+    elsif @target.is_a?(Class)
+      case format
+      when :name_only, :full
+        @target.name
+      else
+        "All #{@target.name.pluralize}"
+      end
+    elsif @target.respond_to?(:title)
+      case format
+      when :full
+        "#{@target.class.name} #{@target.id}: #{@target.title}"
+      else
+        @target.title
+      end
+    elsif @target.respond_to?(:name)
+      case format
+      when :full
+        "#{@target.class.name} #{@target.id}: #{@target.name}"
+      else
+        @target.name
+      end
+    elsif @target.respond_to?(:value)
+      case format
+      when :full
+        "#{@target.class.name} #{@target.id}: #{@target.value}"
+      else
+        @target.value
+      end
+    else
+      case format
+      when :full
+        "#{@analysable_type}#{" #{@analysable_id}" if @analysable_id.present?}"
+      else
+        @analysable_type
+      end
+    end
+  end
+
+  def target_filename_label
+    if @target.respond_to?(:id)
+      "#{@analysable_type}-#{@analysable_id}"
+    else
+      @analysable_type
+    end
+  end
+
+  def self.sanitize_html(text)
+    return "" if text.blank?
+
+    decoded = Nokogiri::HTML.fragment(text.to_s).text
+    decoded.squish
+  end
+
+  def self.compile_context_for_target(target, i18n_scope:, comments_count: nil)
+    parts = []
+
+    target_type = I18n.t("#{i18n_scope}.type.#{target.class.name.underscore}")
+    parts << I18n.t("#{i18n_scope}.base", type: target_type)
+
+    if target.respond_to?(:title)
+      parts << I18n.t("#{i18n_scope}.title", title: target.title)
+    elsif target.respond_to?(:name)
+      parts << I18n.t("#{i18n_scope}.name", name: target.name)
+    else
+      raise "Target #{target.class.name} does not respond to title or name"
+    end
+
+    if target.respond_to?(:summary)
+      parts << I18n.t("#{i18n_scope}.summary", summary: sanitize_html(target.summary))
+    end
+
+    if target.respond_to?(:description) && target.description.present?
+      parts << I18n.t("#{i18n_scope}.description", description: sanitize_html(target.description))
+    end
+
+    if target.respond_to?(:text) && target.text.present?
+      parts << I18n.t("#{i18n_scope}.text", text: sanitize_html(target.text))
+    end
+
+    parts.concat(compile_class_specific_context(target, i18n_scope: i18n_scope))
+
+    parts << "\n## Meta"
+    if target.respond_to?(:geozone) && target.geozone.present?
+      parts << I18n.t("#{i18n_scope}.location", location: target.geozone.name)
+    end
+    if target.respond_to?(:tag_list) && target.tag_list.any?
+      parts << I18n.t("#{i18n_scope}.tags", tags: target.tag_list.join(", "))
+    end
+    comment_count = comments_count ||
+                    (
+                      target.respond_to?(:comments_count) ? target.comments_count : 0
+                    ) || 0
+    parts << I18n.t("#{i18n_scope}.comments", count: comment_count)
+    parts << I18n.t("#{i18n_scope}.created", date: target.created_at.strftime("%B %d, %Y"))
+    if target.respond_to?(:published?) && target.respond_to?(:published_at) && target.published?
+      parts << I18n.t("#{i18n_scope}.published", date: target.published_at.strftime("%B %d, %Y"))
+    end
+
+    parts.join("\n")
+  end
+
+  def self.compile_class_specific_context(target, i18n_scope:)
+    parts = []
+
+    case target.class.name
+    when "Poll"
+      if target.questions.any?
+        parts << I18n.t("#{i18n_scope}.poll.questions_header",
+                        count: target.questions.count)
+        target.questions.each_with_index do |question, index|
+          question_type_label = if question.open?
+                                  I18n.t("#{i18n_scope}.poll.question_type.open_ended")
+                                elsif question.multiple?
+                                  I18n.t("#{i18n_scope}.poll.question_type.multiple_choice")
+                                else
+                                  I18n.t("#{i18n_scope}.poll.question_type.unique_choice")
+                                end
+          parts << I18n.t("#{i18n_scope}.poll.question_with_type",
+                          number: index + 1,
+                          type: question_type_label,
+                          title: question.title)
+          if question.accepts_options? && question.question_options.any?
+            question.question_options.each_with_index do |question_option, opt_index|
+              parts << I18n.t("#{i18n_scope}.poll.question_option_with_votes",
+                              number: opt_index + 1,
+                              title: question_option.title,
+                              votes: question_option.total_votes)
+            end
+          end
+        end
+
+        if target.questions.any?(&:open?)
+          parts << I18n.t("#{i18n_scope}.poll.combined_answers_note")
+        end
+      end
+    when "Poll::Question"
+      parts << I18n.t("#{i18n_scope}.poll_question.question_title", title: target.title)
+      if target.accepts_options? && target.question_options.any?
+        target.question_options.each_with_index do |question_option, opt_index|
+          parts << I18n.t("#{i18n_scope}.poll.question_option",
+                          number: opt_index + 1,
+                          title: question_option.title)
+        end
+      elsif target.open?
+        parts << I18n.t("#{i18n_scope}.poll_question.open_ended",
+                        answers_count: target.answers.count)
+      end
+    when "Proposal"
+      parts << I18n.t("#{i18n_scope}.proposal.votes",
+                      total_votes: target.total_votes,
+                      required_votes: Proposal.votes_needed_for_success)
+    when "Debate"
+      parts << I18n.t("#{i18n_scope}.debate.votes",
+                      votes_up: target.cached_votes_up,
+                      votes_down: target.cached_votes_down)
+    when "Legislation::Question"
+      parts << I18n.t("#{i18n_scope}.legislation_question.process",
+                      process_title: target.process.title)
+      if target.question_options.any?
+        parts << I18n.t("#{i18n_scope}.legislation_question.responses_header")
+        target.question_options.each do |option|
+          parts << I18n.t("#{i18n_scope}.legislation_question.option",
+                          value: option.value,
+                          answers_count: option.answers_count)
+        end
+      end
+    when "Legislation::Proposal"
+      parts << I18n.t("#{i18n_scope}.legislation_proposal.process",
+                      process_title: target.process.title)
+      parts << I18n.t("#{i18n_scope}.legislation_proposal.votes",
+                      votes_up: target.cached_votes_up,
+                      votes_down: target.cached_votes_down)
+    when "Budget"
+      parts << I18n.t("#{i18n_scope}.budget.name", name: target.name) if target.respond_to?(:name)
+      parts << I18n.t("#{i18n_scope}.budget.phase",
+                      phase: target.phase) if target.respond_to?(:phase)
+    when "Budget::Group"
+      parts << I18n.t("#{i18n_scope}.budget_group.name",
+                      name: target.name) if target.respond_to?(:name)
+      if target.respond_to?(:budget) && target.budget.present?
+        parts << I18n.t("#{i18n_scope}.budget_group.budget",
+                        budget_name: target.budget.name)
+      end
+    end
+
+    parts
+  end
+
+  private
+
+    def format_user_answer_for_question(question, user_answers)
+      if question.open?
+        user_answers.first.answer.to_s
+      elsif question.accepts_options? && question.question_options.any?
+        selected_options = user_answers.map { |answer| answer.option&.title }.compact
+        selected_options.join(", ")
+      else
+        ""
+      end
+    end
+end

--- a/app/lib/sensemaker.rb
+++ b/app/lib/sensemaker.rb
@@ -1,0 +1,5 @@
+module Sensemaker
+  def self.enabled?
+    ::Llm::Config.configured? && Setting["llm.use_sensemaker"].present?
+  end
+end

--- a/app/lib/sensemaker/backend.rb
+++ b/app/lib/sensemaker/backend.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Sensemaker
+  module Backend
+    def self.for(job, runtime_config:)
+      Node.new(job, runtime_config: runtime_config)
+    end
+  end
+end

--- a/app/lib/sensemaker/backend/node.rb
+++ b/app/lib/sensemaker/backend/node.rb
@@ -1,0 +1,181 @@
+# frozen_string_literal: true
+
+require "shellwords"
+
+module Sensemaker
+  module Backend
+    class Node
+      attr_reader :job, :artefacts, :runtime_config
+
+      def initialize(job, runtime_config:)
+        @job = job
+        @artefacts = job.artefacts
+        @runtime_config = runtime_config
+      end
+
+      def build_command
+        return build_report_ui_command if report?
+
+        model_name = runtime_config.model
+        additional_context = job.additional_context.presence if requires_input?
+
+        command_parts = ["npx ts-node #{script_path}"]
+        command_parts << "--modelName #{Shellwords.escape(model_name)}" if model_name.present?
+
+        append_llm_flags(command_parts)
+
+        command = command_parts.join(" ")
+        command += " --inputFile #{artefacts.input_path}" if requires_input?
+        if additional_context.present?
+          command += " --additionalContext #{Shellwords.escape(additional_context.to_s)}"
+        end
+        if ScriptRegistry.output_flag(job.script) == :output_basename
+          command += " --outputBasename #{output_file}"
+        else
+          command += " --outputFile #{output_file}"
+        end
+
+        command
+      end
+
+      def script_path
+        if report?
+          "#{Sensemaker::Paths.report_ui_folder}/bin/cli.js"
+        else
+          "#{Sensemaker::Paths.sensemaker_package_folder}/runner-cli/#{job.script}"
+        end
+      end
+
+      def working_directory
+        if report?
+          Rails.root
+        else
+          Sensemaker::Paths.sensemaker_package_folder
+        end
+      end
+
+      def check_runtime_dependencies?
+        unless system("which node > /dev/null 2>&1")
+          job.record_error!(
+            "Node.js not found. Install Node.js to use the Sensemaker feature.\nPATH: #{ENV["PATH"]}"
+          )
+          return false
+        end
+
+        unless system("which npx > /dev/null 2>&1")
+          job.record_error!(
+            "NPX not found. Install NPX to use the Sensemaker feature.\nPATH: #{ENV["PATH"]}"
+          )
+          return false
+        end
+
+        return false unless file_exists?(Sensemaker::Paths.sensemaker_package_folder,
+                                         description: "sensemaking-tools package folder")
+        return false unless file_exists?(Sensemaker::Paths.sensemaker_data_folder,
+                                         description: "Sensemaker data folder")
+
+        if report?
+          return false unless file_exists?(Sensemaker::Paths.report_ui_folder,
+                                           description: "sensemaking-report-ui package folder")
+
+          artefacts.input_artefact_paths.each do |artefact_path|
+            return false unless file_exists?(artefact_path, description: "Report input artefact")
+          end
+        else
+          return false unless file_exists?(artefacts.input_path, description: "Input file")
+        end
+
+        return false unless file_exists?(script_path, description: "Script file")
+
+        true
+      end
+
+      def after_input_prepared
+        if logical_name == :advanced
+          return Sensemaker::CsvExporter.provide_defaults_for_zero_vote_comments(artefacts.input_path)
+        end
+
+        write_report_metadata if report?
+        nil
+      end
+
+      def redact_command(command)
+        command.to_s.gsub(/--apiKey\s+\S+/, "--apiKey [REDACTED]")
+      end
+
+      def output_file_name
+        artefacts.output_file_name
+      end
+
+      private
+
+        def logical_name
+          ScriptRegistry.logical_name(job.script)
+        end
+
+        def report?
+          logical_name == :report
+        end
+
+        def requires_input?
+          ScriptRegistry.requires_input?(job.script)
+        end
+
+        def output_file
+          artefacts.default_output_path
+        end
+
+        def build_report_ui_command
+          conversation = job.conversation
+          target_label = conversation.target_label(format: :full)
+          base = artefacts.input_path
+
+          [
+            "npx sensemaking-report-ui inline",
+            "--topics #{Shellwords.escape("#{base}-topic-stats.json")}",
+            "--summary #{Shellwords.escape("#{base}-summary.json")}",
+            "--comments #{Shellwords.escape("#{base}-comments-with-scores.json")}",
+            "--metadata #{Shellwords.escape(artefacts.metadata_path)}",
+            "--reportTitle #{Shellwords.escape("Report for #{target_label}")}",
+            "--outputDir #{Shellwords.escape(artefacts.job_directory.to_s)}",
+            "--outputFile #{Shellwords.escape(output_file_name)}"
+          ].join(" ")
+        end
+
+        def append_llm_flags(command_parts)
+          case runtime_config.adapter
+          when "vertex"
+            command_parts << "--adapter vertex"
+            command_parts << "--vertexProject #{Shellwords.escape(runtime_config.vertex_project_id)}"
+            command_parts << "--vertexLocation #{Shellwords.escape(runtime_config.vertex_location)}"
+          when "openai-compatible"
+            command_parts << "--adapter openai-compatible"
+            command_parts << "--provider #{Shellwords.escape(runtime_config.compat_provider)}"
+            api_key = runtime_config.api_key
+            command_parts << "--apiKey #{Shellwords.escape(api_key)}" if api_key.present?
+          when "ollama"
+            command_parts << "--adapter ollama"
+          end
+
+          base_url = runtime_config.base_url
+          command_parts << "--baseUrl #{Shellwords.escape(base_url)}" if base_url.present?
+        end
+
+        def write_report_metadata
+          artefacts.ensure_directory!
+          metadata_path = artefacts.metadata_path
+          return if File.exist?(metadata_path)
+
+          title = job.conversation.target_label(format: :full)
+          File.write(metadata_path, { title: title }.to_json)
+        end
+
+        def file_exists?(file_path, description: "File or directory")
+          return true if File.exist?(file_path)
+
+          job.record_error!("#{description} not found: #{file_path}")
+          false
+        end
+    end
+  end
+end

--- a/app/lib/sensemaker/conversation.rb
+++ b/app/lib/sensemaker/conversation.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module Sensemaker
+  CommentLikeItem = Conversation::CommentLikeItem
+
+  class Conversation < ::Conversation
+  end
+end

--- a/app/lib/sensemaker/csv_exporter.rb
+++ b/app/lib/sensemaker/csv_exporter.rb
@@ -1,0 +1,122 @@
+require "csv"
+
+module Sensemaker
+  class CsvExporter
+    EXPORT_HEADERS = %w[comment-id comment_text agrees disagrees passes author-id].freeze
+
+    attr_reader :conversation, :include_votes
+
+    def initialize(conversation, options = {})
+      raise ArgumentError,
+            "conversation must be a Sensemaker::Conversation" unless conversation.is_a?(Conversation)
+
+      @conversation = conversation
+      @include_votes = options.fetch(:include_votes, true)
+    end
+
+    def export_to_csv(file_path = nil)
+      file_path ||= default_file_path
+      FileUtils.mkdir_p(File.dirname(file_path))
+
+      CSV.open(file_path, "w", write_headers: true, headers: self.class::EXPORT_HEADERS) do |csv|
+        export_data.each do |row|
+          csv << row
+        end
+      end
+
+      file_path
+    end
+
+    def export_to_string
+      CSV.generate(headers: true) do |csv|
+        csv << self.class::EXPORT_HEADERS
+        export_data.each do |row|
+          csv << row
+        end
+      end
+    end
+
+    def self.provide_defaults_for_zero_vote_comments(csv_file_path)
+      return unless File.exist?(csv_file_path)
+
+      rows = []
+      defaults_applied = false
+      comments_count = 0
+
+      CSV.foreach(csv_file_path, headers: true) do |row|
+        comments_count += 1
+        agrees = (row["agrees"] || 0).to_i
+        disagrees = (row["disagrees"] || 0).to_i
+        passes = (row["passes"] || 0).to_i
+
+        if agrees.zero? && disagrees.zero? && passes.zero?
+          row["agrees"] = "0" if row["agrees"].nil?
+          row["disagrees"] = "0" if row["disagrees"].nil?
+          row["passes"] = "1"
+          defaults_applied = true
+        end
+
+        rows << row
+      end
+
+      if defaults_applied
+        FileUtils.cp(csv_file_path, "#{csv_file_path}.unfiltered")
+        headers = CSV.read("#{csv_file_path}.unfiltered", headers: true).headers
+        headers = (headers + %w[agrees disagrees passes]).uniq
+        CSV.open(csv_file_path, "w", write_headers: true, headers: headers) do |csv|
+          rows.each { |row| csv << headers.map { |header| row[header] } }
+        end
+        Rails.logger.debug(
+          "Default vote passes applied for zero-vote comments in #{csv_file_path}"
+        )
+      else
+        Rails.logger.debug("All comments have votes, no defaults required")
+      end
+
+      comments_count
+    end
+
+    private
+
+      def export_data
+        data = []
+        data.concat(comments_as_rows)
+        data
+      end
+
+      def comments_as_rows
+        items = @conversation.comments
+
+        items.map do |item|
+          [
+            item_id(item),
+            item.body,
+            item.cached_votes_up || 0,
+            item.cached_votes_down || 0,
+            item_votes_neutral(item),
+            item.user_id
+          ]
+        end
+      end
+
+      def item_id(item)
+        if item.is_a?(CommentLikeItem)
+          "item_#{item.id}"
+        else
+          "comment_#{item.id}"
+        end
+      end
+
+      def item_votes_neutral(item)
+        total = item.cached_votes_total || 0
+        up = item.cached_votes_up || 0
+        down = item.cached_votes_down || 0
+        [total - up - down, 0].max
+      end
+
+      def default_file_path
+        data_folder = Sensemaker::Paths.sensemaker_data_folder
+        File.join(data_folder, "sensemaker-input.csv")
+      end
+  end
+end

--- a/app/lib/sensemaker/csv_exporter.rb
+++ b/app/lib/sensemaker/csv_exporter.rb
@@ -1,0 +1,122 @@
+require "csv"
+
+module Sensemaker
+  class CsvExporter
+    EXPORT_HEADERS = %w[participant_id survey_text agrees disagrees passes author-id].freeze
+
+    attr_reader :conversation, :include_votes
+
+    def initialize(conversation, options = {})
+      raise ArgumentError,
+            "conversation must be a Sensemaker::Conversation" unless conversation.is_a?(Conversation)
+
+      @conversation = conversation
+      @include_votes = options.fetch(:include_votes, true)
+    end
+
+    def export_to_csv(file_path = nil)
+      file_path ||= default_file_path
+      FileUtils.mkdir_p(File.dirname(file_path))
+
+      CSV.open(file_path, "w", write_headers: true, headers: self.class::EXPORT_HEADERS) do |csv|
+        export_data.each do |row|
+          csv << row
+        end
+      end
+
+      file_path
+    end
+
+    def export_to_string
+      CSV.generate(headers: true) do |csv|
+        csv << self.class::EXPORT_HEADERS
+        export_data.each do |row|
+          csv << row
+        end
+      end
+    end
+
+    def self.provide_defaults_for_zero_vote_comments(csv_file_path)
+      return unless File.exist?(csv_file_path)
+
+      rows = []
+      defaults_applied = false
+      comments_count = 0
+
+      CSV.foreach(csv_file_path, headers: true) do |row|
+        comments_count += 1
+        agrees = (row["agrees"] || 0).to_i
+        disagrees = (row["disagrees"] || 0).to_i
+        passes = (row["passes"] || 0).to_i
+
+        if agrees.zero? && disagrees.zero? && passes.zero?
+          row["agrees"] = "0" if row["agrees"].nil?
+          row["disagrees"] = "0" if row["disagrees"].nil?
+          row["passes"] = "1"
+          defaults_applied = true
+        end
+
+        rows << row
+      end
+
+      if defaults_applied
+        FileUtils.cp(csv_file_path, "#{csv_file_path}.unfiltered")
+        headers = CSV.read("#{csv_file_path}.unfiltered", headers: true).headers
+        headers = (headers + %w[agrees disagrees passes]).uniq
+        CSV.open(csv_file_path, "w", write_headers: true, headers: headers) do |csv|
+          rows.each { |row| csv << headers.map { |header| row[header] } }
+        end
+        Rails.logger.debug(
+          "Default vote passes applied for zero-vote comments in #{csv_file_path}"
+        )
+      else
+        Rails.logger.debug("All comments have votes, no defaults required")
+      end
+
+      comments_count
+    end
+
+    private
+
+      def export_data
+        data = []
+        data.concat(comments_as_rows)
+        data
+      end
+
+      def comments_as_rows
+        items = @conversation.comments
+
+        items.map do |item|
+          [
+            item_id(item),
+            item.body,
+            item.cached_votes_up || 0,
+            item.cached_votes_down || 0,
+            item_votes_neutral(item),
+            item.user_id
+          ]
+        end
+      end
+
+      def item_id(item)
+        if item.is_a?(CommentLikeItem)
+          "item_#{item.id}"
+        else
+          "comment_#{item.id}"
+        end
+      end
+
+      def item_votes_neutral(item)
+        total = item.cached_votes_total || 0
+        up = item.cached_votes_up || 0
+        down = item.cached_votes_down || 0
+        [total - up - down, 0].max
+      end
+
+      def default_file_path
+        data_folder = Sensemaker::Paths.sensemaker_data_folder
+        File.join(data_folder, "sensemaker-input.csv")
+      end
+  end
+end

--- a/app/lib/sensemaker/job_artefacts.rb
+++ b/app/lib/sensemaker/job_artefacts.rb
@@ -1,0 +1,136 @@
+module Sensemaker
+  class JobArtefacts
+    attr_reader :job
+
+    DEFAULT_OUTPUT_BASENAME = ->(_job) { "output.csv" }
+    DEFAULT_INPUT_PATH = ->(job) { File.join(Sensemaker::Paths.job_directory(job), "input.csv") }
+
+    def initialize(job)
+      @job = job
+    end
+
+    def job_directory
+      Sensemaker::Paths.job_directory(job)
+    end
+
+    def relative_job_directory
+      Sensemaker::Paths.relative_job_directory(job)
+    end
+
+    def ensure_directory!
+      FileUtils.mkdir_p(job_directory)
+    end
+
+    def output_file_name
+      config[:output_basename].call(job)
+    end
+
+    def multiple_outputs?
+      config[:output_suffixes].any?
+    end
+
+    def default_output_path
+      File.join(job_directory, output_file_name)
+    end
+
+    def relative_output_path
+      File.join(relative_job_directory, output_file_name)
+    end
+
+    def persisted_output_path
+      path = job.read_attribute(:persisted_output)
+      return nil if path.blank?
+
+      Rails.root.join(path)
+    end
+
+    def output_artefact_paths
+      base_path = if job.persisted_output.present?
+                    persisted_output_path.to_s
+                  else
+                    default_output_path
+                  end
+
+      suffixes = config[:output_suffixes]
+      suffixes.empty? ? [base_path] : suffixes.map { |suffix| "#{base_path}#{suffix}" }
+    end
+
+    def existing_output_artefact_paths
+      output_artefact_paths.select { |path| File.exist?(path) }
+    end
+
+    def input_path
+      stored = job.read_attribute(:input_file)
+      return stored if stored.present?
+
+      default = config[:default_input_path]
+      default&.call(job)
+    end
+
+    def input_artefact_paths
+      base_path = input_path.to_s
+      return [] if base_path.blank?
+
+      input_suffixes = config[:input_suffixes]
+      input_suffixes.empty? ? [base_path] : input_suffixes.map { |suffix| "#{base_path}#{suffix}" }
+    end
+
+    def existing_input_artefact_paths
+      input_artefact_paths.select { |path| File.exist?(path) }
+    end
+
+    def metadata_path
+      path = input_path
+      return nil if path.blank?
+
+      "#{path}-metadata.json"
+    end
+
+    def complete?
+      output_artefact_paths.all? { |path| File.exist?(path) }
+    end
+
+    def cleanup
+      result = []
+      result.concat(cleanup_job_directory)
+      result.concat(cleanup_persisted_output)
+      result.flatten!
+      result.compact!
+      result
+    rescue StandardError
+      nil
+    end
+
+    private
+
+      def config
+        Sensemaker::ScriptRegistry.artefact_config(job.script) || default_config
+      end
+
+      def default_config
+        {
+          output_basename: DEFAULT_OUTPUT_BASENAME,
+          output_suffixes: [],
+          default_input_path: DEFAULT_INPUT_PATH,
+          input_suffixes: []
+        }
+      end
+
+      def cleanup_job_directory
+        return [] unless Dir.exist?(job_directory)
+
+        [FileUtils.rm_rf(job_directory)]
+      end
+
+      def cleanup_persisted_output
+        path = persisted_output_path
+        return [] unless path.present? && File.exist?(path)
+
+        job_dir = File.expand_path(job_directory)
+        persisted = File.expand_path(path.to_s)
+        return [] if persisted == job_dir || persisted.start_with?("#{job_dir}/")
+
+        [FileUtils.rm_f(path)]
+      end
+  end
+end

--- a/app/lib/sensemaker/job_artefacts.rb
+++ b/app/lib/sensemaker/job_artefacts.rb
@@ -1,0 +1,164 @@
+module Sensemaker
+  class JobArtefacts
+    attr_reader :job
+
+    SCRIPT_CONFIG = {
+      "health_check_runner.ts" => {
+        output_basename: ->(job) { "health-check-#{job.id}.txt" },
+        output_suffixes: [],
+        default_input_path: nil,
+        input_suffixes: []
+      },
+      "categorization_runner.ts" => {
+        output_basename: ->(job) { "categorization-output-#{job.id}.csv" },
+        output_suffixes: [],
+        default_input_path: ->(job) { "#{Sensemaker::Paths.sensemaker_data_folder}/input-#{job.id}.csv" },
+        input_suffixes: []
+      },
+      "advanced_runner.ts" => {
+        output_basename: ->(job) { "output-#{job.id}" },
+        output_suffixes: %w[-summary.json -topic-stats.json -comments-with-scores.json],
+        default_input_path: ->(job) {
+          "#{Sensemaker::Paths.sensemaker_data_folder}/categorization-output-#{job.id}.csv"
+        },
+        input_suffixes: []
+      },
+      "runner.ts" => {
+        output_basename: ->(job) { "output-#{job.id}" },
+        output_suffixes: %w[-summary.json -summary.html -summary.md -summaryAndSource.csv],
+        default_input_path: ->(job) { "#{Sensemaker::Paths.sensemaker_data_folder}/input-#{job.id}.csv" },
+        input_suffixes: []
+      },
+      "sensemaking-report-ui" => {
+        output_basename: ->(job) { "report-#{job.id}.html" },
+        output_suffixes: [],
+        default_input_path: ->(_job) { "#{Sensemaker::Paths.sensemaker_data_folder}/advanced-output" },
+        input_suffixes: %w[-topic-stats.json -summary.json -comments-with-scores.json -metadata.json]
+      }
+    }.freeze
+
+    DEFAULT_OUTPUT_BASENAME = ->(job) { "output-#{job.id}.csv" }
+    DEFAULT_INPUT_PATH = ->(job) { "#{Sensemaker::Paths.sensemaker_data_folder}/input-#{job.id}.csv" }
+
+    def initialize(job)
+      @job = job
+    end
+
+    def output_file_name
+      config[:output_basename].call(job)
+    end
+
+    def multiple_outputs?
+      config[:output_suffixes].any?
+    end
+
+    def default_output_path
+      File.join(Sensemaker::Paths.sensemaker_data_folder, output_file_name)
+    end
+
+    def relative_output_path
+      File.join(Sensemaker::Paths.sensemaker_relative_data_folder, output_file_name)
+    end
+
+    def persisted_output_path
+      path = job.read_attribute(:persisted_output)
+      return nil if path.blank?
+
+      Rails.root.join(path)
+    end
+
+    def output_artefact_paths
+      base_path = if job.persisted_output.present?
+                    persisted_output_path.to_s
+                  else
+                    default_output_path
+                  end
+
+      suffixes = config[:output_suffixes]
+      suffixes.empty? ? [base_path] : suffixes.map { |suffix| "#{base_path}#{suffix}" }
+    end
+
+    def existing_output_artefact_paths
+      output_artefact_paths.select { |path| File.exist?(path) }
+    end
+
+    def input_path
+      stored = job.read_attribute(:input_file)
+      return stored if stored.present?
+
+      default = config[:default_input_path]
+      default&.call(job)
+    end
+
+    def input_artefact_paths
+      base_path = input_path.to_s
+      return [] if base_path.blank?
+
+      input_suffixes = config[:input_suffixes]
+      input_suffixes.empty? ? [base_path] : input_suffixes.map { |suffix| "#{base_path}#{suffix}" }
+    end
+
+    def existing_input_artefact_paths
+      input_artefact_paths.select { |path| File.exist?(path) }
+    end
+
+    def metadata_path
+      path = input_path
+      return nil if path.blank?
+
+      "#{path}-metadata.json"
+    end
+
+    def complete?
+      output_artefact_paths.all? { |path| File.exist?(path) }
+    end
+
+    def cleanup
+      result = []
+      result.concat(cleanup_input_files)
+      result.concat(cleanup_output_files)
+      result.concat(cleanup_persisted_output)
+      result.flatten!
+      result.compact!
+      result
+    rescue StandardError
+      nil
+    end
+
+    private
+
+      def config
+        SCRIPT_CONFIG.fetch(job.script) do
+          {
+            output_basename: DEFAULT_OUTPUT_BASENAME,
+            output_suffixes: [],
+            default_input_path: DEFAULT_INPUT_PATH,
+            input_suffixes: []
+          }
+        end
+      end
+
+      def cleanup_input_files
+        result = input_artefact_paths.map { |path| FileUtils.rm_f(path) }
+
+        default_csv = config[:default_input_path]&.call(job)
+        if default_csv.present?
+          result << FileUtils.rm_f(default_csv)
+          result << FileUtils.rm_f("#{default_csv}.unfiltered")
+        end
+
+        result
+      end
+
+      def cleanup_output_files
+        output_artefact_paths.map { |path| FileUtils.rm_f(path) }
+      end
+
+      def cleanup_persisted_output
+        path = persisted_output_path
+        return [] unless path.present? && File.exist?(path)
+
+        [FileUtils.rm_f(path)]
+      end
+  end
+end

--- a/app/lib/sensemaker/job_runner.rb
+++ b/app/lib/sensemaker/job_runner.rb
@@ -1,0 +1,208 @@
+require "shellwords"
+
+module Sensemaker
+  class JobRunner
+    TIMEOUT = 1800
+    attr_reader :job, :backend
+
+    def initialize(job)
+      @job = job
+      @runtime_config = Sensemaker::RuntimeConfig.new(
+        setting: Setting,
+        llm_context: Llm::Config.context
+      )
+      @backend = Sensemaker::Backend.for(
+        job,
+        runtime_config: @runtime_config
+      )
+    end
+
+    def run
+      execute_job_workflow
+    end
+    handle_asynchronously :run, queue: "sensemaker"
+
+    def run_synchronously
+      execute_job_workflow
+    end
+
+    def artefacts
+      job.artefacts
+    end
+
+    def output_file_name
+      artefacts.output_file_name
+    end
+
+    def output_file
+      artefacts.default_output_path
+    end
+
+    def self.enabled?
+      Sensemaker.enabled?
+    end
+
+    private
+
+      def runtime_config
+        @runtime_config
+      end
+
+      def execute_job_workflow
+        job.update!(started_at: Time.current)
+        artefacts.ensure_directory!
+
+        comments_prepared_count = prepare_input_data
+        return unless check_dependencies?
+        return if execute_script.blank?
+
+        attribs = { finished_at: Time.current }
+        if artefacts.complete?
+          attribs[:comments_analysed] = comments_prepared_count
+        else
+          attribs = attribs.merge(error: "Output file(s) not found")
+        end
+        job.update!(attribs)
+      rescue Exception => e
+        handle_error(e)
+        raise e
+      end
+
+      def prepare_with_prep_job(prep_script)
+        prep_job = Sensemaker::Job.create!(
+          user: job.user,
+          parent_job: job,
+          analysable_type: job.analysable_type,
+          analysable_id: job.analysable_id,
+          script: prep_script,
+          additional_context: job.additional_context
+        )
+
+        prep_runner = Sensemaker::JobRunner.new(prep_job)
+        prep_runner.run_synchronously
+
+        if prep_job.reload.errored?
+          raise "Preparation job #{prep_job.id} failed"
+        end
+
+        job.input_file = prep_runner.output_file
+        job.save!
+
+        prep_job.comments_analysed
+      end
+
+      def prepare_input_data
+        conversation = job.conversation
+        comments_prepared_count = 0
+        persisted_input_missing = job.read_attribute(:input_file).blank?
+        prep_script = Sensemaker::ScriptRegistry.prep_steps(job.script).first
+
+        if job.additional_context.blank?
+          job.update!(additional_context: conversation.compile_context)
+        end
+
+        if persisted_input_missing && prep_script
+          comments_prepared_count = prepare_with_prep_job(prep_script)
+        elsif persisted_input_missing
+          comments_prepared_count = conversation.comments.size
+          generated_input_path = artefacts.input_path
+          exporter = Sensemaker::CsvExporter.new(conversation)
+          exporter.export_to_csv(generated_input_path)
+          job.update!(input_file: generated_input_path)
+        end
+
+        after_prep_count = backend.after_input_prepared
+        comments_prepared_count = after_prep_count unless after_prep_count.nil?
+
+        comments_prepared_count
+      end
+
+      def check_dependencies?
+        if Tenant.current_secrets.sensemaker_data_folder.blank?
+          job.record_error!(
+            "Sensemaker data folder not configured. Add 'sensemaker_data_folder' to your secrets.yml"
+          )
+          return false
+        end
+
+        adapter = runtime_config.adapter
+
+        if adapter == "vertex" && runtime_config.vertex_project_id.blank?
+          job.record_error!(
+            "Vertex AI is not configured. Set tenant secrets llm.vertexai_project_id " \
+            "(and optionally vertexai_location)."
+          )
+          return false
+        end
+
+        if adapter.blank?
+          job.record_error!(
+            "Sensemaker LLM provider is not supported. Current provider: " \
+            "#{runtime_config.provider.presence || "(not set)"}."
+          )
+          return false
+        end
+
+        if runtime_config.model.blank?
+          job.record_error!(
+            "Sensemaker requires an LLM model to be selected. Set it in Admin → Settings → LLM."
+          )
+          return false
+        end
+
+        if adapter == "openai-compatible" && runtime_config.api_key.blank?
+          job.record_error!(
+            "Sensemaker requires an API key for provider '#{runtime_config.compat_provider}'. " \
+            "Set tenant secret llm.#{runtime_config.compat_provider}_api_key."
+          )
+          return false
+        end
+
+        key_path = Rails.application.secrets.google_application_credentials
+        if key_path.present?
+          path = (File.expand_path(key_path) == key_path) ? key_path : Rails.root.join(key_path).to_s
+          return false unless file_exists?(path,
+                                           description: "Key file (apis.google_application_credentials)")
+        end
+
+        backend.check_runtime_dependencies?
+      end
+
+      def execute_script
+        target_folder = backend.working_directory
+        command = "cd #{target_folder} && timeout #{TIMEOUT} #{backend.build_command}"
+        Rails.logger.debug("Executing script: #{backend.redact_command(command)}")
+        output = `#{command} 2>&1`
+
+        result = process_exit_status
+        if result.eql?(0)
+          Rails.logger.debug("Script executed successfully: #{output}")
+          output
+        else
+          output = "Timeout: #{TIMEOUT} seconds\n#{output}" if result.eql?(124)
+          output = output.truncate(20000)
+          message = "Command: #{backend.redact_command(command)}\n\n#{output}"
+          job.record_error!(message)
+          nil
+        end
+      end
+
+      def handle_error(error)
+        message = error.message
+        backtrace = error.backtrace.select { |line| line.include?("job_runner.rb") }
+        full_error = ([message] + backtrace).join("<br>")
+        job.update!(finished_at: Time.current, error: full_error)
+      end
+
+      def process_exit_status
+        $?.exitstatus
+      end
+
+      def file_exists?(file_path, description: "File or directory")
+        return true if File.exist?(file_path)
+
+        job.record_error!("#{description} not found: #{file_path}")
+        false
+      end
+  end
+end

--- a/app/lib/sensemaker/job_runner.rb
+++ b/app/lib/sensemaker/job_runner.rb
@@ -1,0 +1,371 @@
+require "shellwords"
+
+module Sensemaker
+  class JobRunner
+    TIMEOUT = 1800
+    attr_reader :job
+
+    SCRIPTS = [
+      "health_check_runner.ts",
+      "categorization_runner.ts",
+      "runner.ts",
+      "advanced_runner.ts",
+      "sensemaking-report-ui"
+    ].freeze
+
+    def initialize(job)
+      @job = job
+    end
+
+    def run
+      execute_job_workflow
+    end
+    handle_asynchronously :run, queue: "sensemaker"
+
+    def run_synchronously
+      execute_job_workflow
+    end
+
+    def artefacts
+      job.artefacts
+    end
+
+    def output_file_name
+      artefacts.output_file_name
+    end
+
+    def output_file
+      artefacts.default_output_path
+    end
+
+    def script_file
+      if job.script == "sensemaking-report-ui"
+        "#{Sensemaker::Paths.report_ui_folder}/bin/cli.js"
+      else
+        "#{Sensemaker::Paths.sensemaker_package_folder}/runner-cli/#{job.script}"
+      end
+    end
+
+    def sensemaker_adapter
+      runtime_config.adapter
+    end
+
+    def sensemaker_provider
+      runtime_config.compat_provider
+    end
+
+    def sensemaker_api_key
+      runtime_config.api_key
+    end
+
+    def sensemaker_base_url
+      runtime_config.base_url
+    end
+
+    def self.enabled?
+      Sensemaker.enabled?
+    end
+
+    def build_command
+      if job.script == "sensemaking-report-ui"
+        conversation = job.conversation
+        target_label = conversation.target_label(format: :full)
+        base = artefacts.input_path
+        data_folder = Sensemaker::Paths.sensemaker_data_folder
+
+        return [
+          "npx sensemaking-report-ui inline",
+          "--topics #{Shellwords.escape("#{base}-topic-stats.json")}",
+          "--summary #{Shellwords.escape("#{base}-summary.json")}",
+          "--comments #{Shellwords.escape("#{base}-comments-with-scores.json")}",
+          "--metadata #{Shellwords.escape(artefacts.metadata_path)}",
+          "--reportTitle #{Shellwords.escape("Report for #{target_label}")}",
+          "--outputDir #{Shellwords.escape(data_folder.to_s)}",
+          "--outputFile #{Shellwords.escape(output_file_name)}"
+        ].join(" ")
+      end
+
+      model_name = runtime_config.model
+      additional_context = nil
+      additional_context = job.additional_context.presence unless job.script == "health_check_runner.ts"
+
+      command_parts = ["npx ts-node #{script_file}"]
+      command_parts << "--modelName #{Shellwords.escape(model_name)}" if model_name.present?
+
+      case sensemaker_adapter
+      when "vertex"
+        command_parts << "--adapter vertex"
+        command_parts << "--vertexProject #{Shellwords.escape(runtime_config.vertex_project_id)}"
+        command_parts << "--vertexLocation #{Shellwords.escape(runtime_config.vertex_location)}"
+      when "openai-compatible"
+        command_parts << "--adapter openai-compatible"
+        command_parts << "--provider #{Shellwords.escape(sensemaker_provider)}"
+        command_parts << "--apiKey #{Shellwords.escape(sensemaker_api_key)}" if sensemaker_api_key.present?
+      when "ollama"
+        command_parts << "--adapter ollama"
+      end
+      command_parts << "--baseUrl #{Shellwords.escape(sensemaker_base_url)}" if sensemaker_base_url.present?
+
+      command = command_parts.join(" ")
+      command += " --inputFile #{artefacts.input_path}" unless job.script == "health_check_runner.ts"
+      if additional_context.present?
+        command += " --additionalContext #{Shellwords.escape(additional_context.to_s)}"
+      end
+      if ["advanced_runner.ts", "runner.ts"].include?(job.script)
+        command += " --outputBasename #{output_file}"
+      else
+        command += " --outputFile #{output_file}"
+      end
+
+      command
+    end
+
+    private
+
+      def llm_context
+        @llm_context ||= Llm::Config.context
+      end
+
+      def runtime_config
+        @runtime_config ||= Sensemaker::RuntimeConfig.new(setting: Setting, llm_context: llm_context)
+      end
+
+      def execute_job_workflow
+        job.update!(started_at: Time.current)
+
+        comments_prepared_count = prepare_input_data
+        return unless check_dependencies?
+        return if execute_script.blank?
+
+        attribs = { finished_at: Time.current }
+        if artefacts.complete?
+          attribs[:comments_analysed] = comments_prepared_count
+        else
+          attribs = attribs.merge(error: "Output file(s) not found")
+        end
+        job.update!(attribs)
+      rescue Exception => e
+        handle_error(e)
+        raise e
+      end
+
+      def prepare_with_categorization_job
+        categorization_job = Sensemaker::Job.create!(
+          user: job.user,
+          parent_job: job,
+          analysable_type: job.analysable_type,
+          analysable_id: job.analysable_id,
+          script: "categorization_runner.ts",
+          additional_context: job.additional_context
+        )
+
+        categorization_runner = Sensemaker::JobRunner.new(categorization_job)
+        categorization_runner.run_synchronously
+
+        if categorization_job.reload.errored?
+          raise "Preparation job #{categorization_job.id} failed"
+        end
+
+        job.input_file = categorization_runner.output_file
+        job.save!
+
+        categorization_job.comments_analysed
+      end
+
+      def prepare_with_advanced_runner_job
+        advanced_job = Sensemaker::Job.create!(
+          user: job.user,
+          parent_job: job,
+          analysable_type: job.analysable_type,
+          analysable_id: job.analysable_id,
+          script: "advanced_runner.ts",
+          additional_context: job.additional_context
+        )
+
+        advanced_runner = Sensemaker::JobRunner.new(advanced_job)
+        advanced_runner.run_synchronously
+
+        if advanced_job.reload.errored?
+          raise "Preparation job #{advanced_job.id} failed"
+        end
+
+        job.input_file = advanced_runner.output_file
+        job.save!
+
+        advanced_job.comments_analysed
+      end
+
+      def prepare_input_data
+        conversation = job.conversation
+        comments_prepared_count = 0
+        persisted_input_missing = job.read_attribute(:input_file).blank?
+
+        if job.additional_context.blank?
+          job.update!(additional_context: conversation.compile_context)
+        end
+
+        if persisted_input_missing && job.script.eql?("advanced_runner.ts")
+          comments_prepared_count = prepare_with_categorization_job
+        elsif persisted_input_missing && job.script.eql?("sensemaking-report-ui")
+          comments_prepared_count = prepare_with_advanced_runner_job
+        elsif persisted_input_missing
+          comments_prepared_count = conversation.comments.size
+          generated_input_path = artefacts.input_path
+          exporter = Sensemaker::CsvExporter.new(conversation)
+          exporter.export_to_csv(generated_input_path)
+          job.update!(input_file: generated_input_path)
+        end
+
+        if job.script.eql?("advanced_runner.ts")
+          comments_prepared_count = Sensemaker::CsvExporter.provide_defaults_for_zero_vote_comments(
+            artefacts.input_path
+          )
+        end
+
+        write_report_metadata if job.script.eql?("sensemaking-report-ui")
+
+        comments_prepared_count
+      end
+
+      def write_report_metadata
+        metadata_path = artefacts.metadata_path
+        return if File.exist?(metadata_path)
+
+        conversation = job.conversation
+        title = conversation.target_label(format: :full)
+        File.write(metadata_path, { title: title }.to_json)
+      end
+
+      def check_dependencies?
+        if Tenant.current_secrets.sensemaker_data_folder.blank?
+          message = "Sensemaker data folder not configured. Add 'sensemaker_data_folder' to your secrets.yml"
+          job.update!(finished_at: Time.current, error: message)
+          Rails.logger.error(message)
+          return false
+        end
+
+        if sensemaker_adapter == "vertex" && runtime_config.vertex_project_id.blank?
+          message = "Vertex AI is not configured. Set tenant secrets llm.vertexai_project_id " \
+                    "(and optionally vertexai_location)."
+          job.update!(finished_at: Time.current, error: message)
+          Rails.logger.error(message)
+          return false
+        end
+
+        if sensemaker_adapter.blank?
+          message = "Sensemaker LLM provider is not supported. Current provider: " \
+                    "#{runtime_config.provider.presence || "(not set)"}."
+          job.update!(finished_at: Time.current, error: message)
+          Rails.logger.error(message)
+          return false
+        end
+
+        if runtime_config.model.blank?
+          message = "Sensemaker requires an LLM model to be selected. Set it in Admin → Settings → LLM."
+          job.update!(finished_at: Time.current, error: message)
+          Rails.logger.error(message)
+          return false
+        end
+
+        if sensemaker_adapter == "openai-compatible" && sensemaker_api_key.blank?
+          message = "Sensemaker requires an API key for provider '#{sensemaker_provider}'. " \
+                    "Set tenant secret llm.#{sensemaker_provider}_api_key."
+          job.update!(finished_at: Time.current, error: message)
+          Rails.logger.error(message)
+          return false
+        end
+
+        key_path = Rails.application.secrets.google_application_credentials
+        if key_path.present?
+          path = (File.expand_path(key_path) == key_path) ? key_path : Rails.root.join(key_path).to_s
+          return false unless file_exists?(path,
+                                           description: "Key file (apis.google_application_credentials)")
+        end
+
+        unless system("which node > /dev/null 2>&1")
+          message = "Node.js not found. Install Node.js to use the Sensemaker feature."
+          message += "\nPATH: #{ENV["PATH"]}"
+          job.update!(finished_at: Time.current, error: message)
+          Rails.logger.error(message)
+          return false
+        end
+
+        unless system("which npx > /dev/null 2>&1")
+          message = "NPX not found. Install NPX to use the Sensemaker feature."
+          message += "\nPATH: #{ENV["PATH"]}"
+          job.update!(finished_at: Time.current, error: message)
+          Rails.logger.error(message)
+          return false
+        end
+
+        return false unless file_exists?(Sensemaker::Paths.sensemaker_package_folder,
+                                         description: "sensemaking-tools package folder")
+        return false unless file_exists?(Sensemaker::Paths.sensemaker_data_folder,
+                                         description: "Sensemaker data folder")
+
+        if job.script == "sensemaking-report-ui"
+          return false unless file_exists?(Sensemaker::Paths.report_ui_folder,
+                                           description: "sensemaking-report-ui package folder")
+
+          artefacts.input_artefact_paths.each do |artefact_path|
+            return false unless file_exists?(artefact_path, description: "Report input artefact")
+          end
+        else
+          return false unless file_exists?(artefacts.input_path, description: "Input file")
+        end
+
+        return false unless file_exists?(script_file, description: "Script file")
+
+        true
+      end
+
+      def execute_script
+        target_folder = if job.script == "sensemaking-report-ui"
+                          Rails.root
+                        else
+                          Sensemaker::Paths.sensemaker_package_folder
+                        end
+
+        command = "cd #{target_folder} && timeout #{TIMEOUT} #{build_command}"
+        Rails.logger.debug("Executing script: #{redact_command(command)}")
+        output = `#{command} 2>&1`
+
+        result = process_exit_status
+        if result.eql?(0)
+          Rails.logger.debug("Script executed successfully: #{output}")
+          output
+        else
+          output = "Timeout: #{TIMEOUT} seconds\n#{output}" if result.eql?(124)
+          output = output.truncate(20000)
+          message = "Command: #{redact_command(command)}\n\n#{output}"
+          job.update!(finished_at: Time.current, error: message)
+          Rails.logger.error("Sensemaker::JobRunner error: #{output}")
+          nil
+        end
+      end
+
+      def handle_error(error)
+        message = error.message
+        backtrace = error.backtrace.select { |line| line.include?("job_runner.rb") }
+        full_error = ([message] + backtrace).join("<br>")
+        job.update!(finished_at: Time.current, error: full_error)
+      end
+
+      def process_exit_status
+        $?.exitstatus
+      end
+
+      def file_exists?(file_path, description: "File or directory")
+        return true if File.exist?(file_path)
+
+        message = "#{description} not found: #{file_path}"
+        job.update!(finished_at: Time.current, error: message)
+        Rails.logger.error(message)
+        false
+      end
+
+      def redact_command(command)
+        command.to_s.gsub(/--apiKey\s+\S+/, "--apiKey [REDACTED]")
+      end
+  end
+end

--- a/app/lib/sensemaker/paths.rb
+++ b/app/lib/sensemaker/paths.rb
@@ -1,0 +1,39 @@
+module Sensemaker
+  module Paths
+    def self.sensemaker_package_folder
+      if Rails.env.test?
+        Rails.root.join("tmp/sensemaker_test_folder/package")
+      else
+        Rails.root.join("node_modules/@cosla/sensemaking-tools")
+      end
+    end
+
+    def self.sensemaker_folder
+      if Rails.env.test?
+        Rails.root.join("tmp/sensemaker_test_folder")
+      else
+        Rails.root.join("vendor/sensemaking-tools")
+      end
+    end
+
+    def self.sensemaker_relative_data_folder
+      if Rails.env.test?
+        "tmp/sensemaker_test_folder/data"
+      else
+        Tenant.current_secrets.sensemaker_data_folder
+      end
+    end
+
+    def self.sensemaker_data_folder
+      Rails.root.join(sensemaker_relative_data_folder)
+    end
+
+    def self.report_ui_folder
+      if Rails.env.test?
+        Rails.root.join("tmp/sensemaker_test_folder/report-ui")
+      else
+        Rails.root.join("node_modules/@cosla/sensemaking-report-ui")
+      end
+    end
+  end
+end

--- a/app/lib/sensemaker/paths.rb
+++ b/app/lib/sensemaker/paths.rb
@@ -28,6 +28,14 @@ module Sensemaker
       Rails.root.join(sensemaker_relative_data_folder)
     end
 
+    def self.job_directory(job)
+      File.join(sensemaker_data_folder, "job-#{job.id}")
+    end
+
+    def self.relative_job_directory(job)
+      File.join(sensemaker_relative_data_folder, "job-#{job.id}")
+    end
+
     def self.report_ui_folder
       if Rails.env.test?
         Rails.root.join("tmp/sensemaker_test_folder/report-ui")

--- a/app/lib/sensemaker/runtime_config.rb
+++ b/app/lib/sensemaker/runtime_config.rb
@@ -1,0 +1,86 @@
+module Sensemaker
+  class RuntimeConfig
+    attr_reader :setting, :llm_context
+
+    def initialize(setting: Setting, llm_context: Llm::Config.context)
+      @setting = setting
+      @llm_context = llm_context
+    end
+
+    def provider
+      setting["llm.provider"].to_s.downcase.strip
+    end
+
+    def model
+      setting["llm.model"].to_s.presence
+    end
+
+    def adapter
+      case provider
+      when /vertex/
+        "vertex"
+      when /ollama/
+        "ollama"
+      when /openai/, /openrouter/, /mistral/
+        "openai-compatible"
+      end
+    end
+
+    def compat_provider
+      case provider
+      when /openai/
+        "openai"
+      when /openrouter/
+        "openrouter"
+      when /mistral/
+        "mistral"
+      end
+    end
+
+    def api_key
+      provider_name = compat_provider
+      return nil if provider_name.blank?
+
+      key_method = "#{provider_name}_api_key"
+      return nil unless llm_config.respond_to?(key_method)
+
+      llm_config.public_send(key_method).to_s.presence
+    end
+
+    def base_url
+      case adapter
+      when "ollama"
+        return llm_config.ollama_api_base.to_s.presence if llm_config.respond_to?(:ollama_api_base)
+      when "openai-compatible"
+        case compat_provider
+        when "openai"
+          return llm_config.openai_api_base.to_s.presence if llm_config.respond_to?(:openai_api_base)
+        when "openrouter"
+          return llm_config.openrouter_api_base.to_s.presence if llm_config.respond_to?(:openrouter_api_base)
+        when "mistral"
+          return llm_config.mistral_api_base.to_s.presence if llm_config.respond_to?(:mistral_api_base)
+        end
+      end
+
+      nil
+    end
+
+    def vertex_project_id
+      llm_config.vertexai_project_id.to_s
+    end
+
+    def vertex_location
+      llm_config.vertexai_location.to_s.presence || "global"
+    end
+
+    def supported?
+      adapter.present?
+    end
+
+    private
+
+      def llm_config
+        llm_context.config
+      end
+  end
+end

--- a/app/lib/sensemaker/script_registry.rb
+++ b/app/lib/sensemaker/script_registry.rb
@@ -1,0 +1,159 @@
+# frozen_string_literal: true
+
+module Sensemaker
+  module ScriptRegistry
+    REPORT_UI = "sensemaking-report-ui"
+    HEALTH_CHECK = "health_check_runner.ts"
+    CATEGORIZE = "categorization_runner.ts"
+    ADVANCED = "advanced_runner.ts"
+    SUMMARY = "runner.ts"
+
+    REGISTRY = {
+      HEALTH_CHECK => {
+        backend: :node,
+        logical_name: :health_check,
+        publishable: false,
+        internal: false,
+        requires_input: false,
+        prep_steps: [],
+        i18n_key: "health_check_runner_ts",
+        output_flag: :output_file,
+        artefact_config: {
+          output_basename: ->(_job) { "health-check.txt" },
+          output_suffixes: [],
+          default_input_path: nil,
+          input_suffixes: []
+        }
+      },
+      CATEGORIZE => {
+        backend: :node,
+        logical_name: :categorize,
+        publishable: false,
+        internal: false,
+        requires_input: true,
+        prep_steps: [],
+        i18n_key: "categorization_runner_ts",
+        output_flag: :output_file,
+        artefact_config: {
+          output_basename: ->(_job) { "categorization-output.csv" },
+          output_suffixes: [],
+          default_input_path: ->(job) {
+            File.join(Sensemaker::Paths.job_directory(job), "input.csv")
+          },
+          input_suffixes: []
+        }
+      },
+      ADVANCED => {
+        backend: :node,
+        logical_name: :advanced,
+        publishable: false,
+        internal: true,
+        requires_input: true,
+        prep_steps: [CATEGORIZE],
+        i18n_key: "advanced_runner_ts",
+        output_flag: :output_basename,
+        artefact_config: {
+          output_basename: ->(_job) { "output" },
+          output_suffixes: %w[-summary.json -topic-stats.json -comments-with-scores.json],
+          default_input_path: ->(job) {
+            File.join(Sensemaker::Paths.job_directory(job), "categorization-output.csv")
+          },
+          input_suffixes: []
+        }
+      },
+      SUMMARY => {
+        backend: :node,
+        logical_name: :summary,
+        publishable: true,
+        internal: false,
+        requires_input: true,
+        prep_steps: [],
+        i18n_key: "runner_ts",
+        output_flag: :output_basename,
+        artefact_config: {
+          output_basename: ->(_job) { "output" },
+          output_suffixes: %w[-summary.json -summary.html -summary.md -summaryAndSource.csv],
+          default_input_path: ->(job) {
+            File.join(Sensemaker::Paths.job_directory(job), "input.csv")
+          },
+          input_suffixes: []
+        }
+      },
+      REPORT_UI => {
+        backend: :node,
+        logical_name: :report,
+        publishable: true,
+        internal: false,
+        requires_input: true,
+        prep_steps: [ADVANCED],
+        i18n_key: "sensemaking_report_ui",
+        output_flag: :output_file,
+        artefact_config: {
+          output_basename: ->(_job) { "report.html" },
+          output_suffixes: [],
+          default_input_path: ->(job) {
+            File.join(Sensemaker::Paths.job_directory(job), "advanced-output")
+          },
+          input_suffixes: %w[-topic-stats.json -summary.json -comments-with-scores.json -metadata.json]
+        }
+      }
+    }.freeze
+
+    def self.all
+      REGISTRY.keys
+    end
+
+    def self.known?(script)
+      REGISTRY.key?(script)
+    end
+
+    def self.for_backend(backend)
+      REGISTRY.select { |_id, config| config[:backend] == backend.to_sym }.keys
+    end
+
+    def self.user_selectable
+      REGISTRY.reject { |_id, config| config[:internal] }.keys
+    end
+
+    def self.publishable
+      REGISTRY.select { |_id, config| config[:publishable] }.keys
+    end
+
+    def self.backend_for(script)
+      config_for(script)&.fetch(:backend)
+    end
+
+    def self.logical_name(script)
+      config_for(script)&.fetch(:logical_name)
+    end
+
+    def self.prep_steps(script)
+      config_for(script)&.fetch(:prep_steps) || []
+    end
+
+    def self.i18n_key(script)
+      config_for(script)&.fetch(:i18n_key)
+    end
+
+    def self.artefact_config(script)
+      config_for(script)&.fetch(:artefact_config)
+    end
+
+    def self.scripts_for_logical_name(name)
+      REGISTRY.select { |_id, config| config[:logical_name] == name.to_sym }.keys
+    end
+
+    def self.output_flag(script)
+      config_for(script)&.fetch(:output_flag, :output_file)
+    end
+
+    def self.requires_input?(script)
+      config_for(script)&.fetch(:requires_input, true)
+    end
+
+    def self.config_for(script)
+      REGISTRY[script]
+    end
+    private_class_method :config_for
+  end
+end

--- a/app/models/budget/group.rb
+++ b/app/models/budget/group.rb
@@ -22,6 +22,7 @@ class Budget
     belongs_to :budget
 
     has_many :headings, dependent: :destroy
+    has_many :investments, through: :headings
 
     validates_translation :name, presence: true
     validates :budget_id, presence: true

--- a/app/models/sensemaker/job.rb
+++ b/app/models/sensemaker/job.rb
@@ -26,11 +26,18 @@ module Sensemaker
 
     belongs_to :analysable, polymorphic: true, optional: true
 
+    before_save :set_persisted_output_if_successful
+    after_destroy :cleanup_associated_files
+
     scope :published, -> { where(published: true) }
     scope :unpublished, -> { where(published: false) }
 
     def artefacts
       @artefacts ||= Sensemaker::JobArtefacts.new(self)
+    end
+
+    def conversation
+      @conversation ||= Sensemaker::Conversation.new(analysable_type, analysable_id)
     end
 
     def started?
@@ -87,6 +94,11 @@ module Sensemaker
       update!(finished_at: Time.current, error: "Cancelled")
     end
 
+    def record_error!(message)
+      update!(finished_at: Time.current, error: message)
+      Rails.logger.error(message)
+    end
+
     def self.for_budget(budget)
       group_subquery = budget.groups.select(:id)
       published.where(analysable_type: "Budget", analysable_id: budget.id).or(
@@ -107,5 +119,26 @@ module Sensemaker
         .or(published.where(analysable_type: "Legislation::QuestionOption",
                             analysable_id: question_options_subquery))
     end
+
+    private
+
+      def set_persisted_output_if_successful
+        return unless finished_at.present? && error.nil?
+        return if persisted_output.present?
+
+        if artefacts.complete?
+          self.persisted_output = artefacts.relative_output_path
+        end
+      end
+
+      def cleanup_associated_files
+        result = artefacts.cleanup
+        if result.nil?
+          Rails.logger.warn("Failed to cleanup files for job #{id}")
+        else
+          Rails.logger.info("Cleaned up files for job #{id}: #{result.inspect}")
+        end
+        result
+      end
   end
 end

--- a/app/models/sensemaker/job.rb
+++ b/app/models/sensemaker/job.rb
@@ -29,6 +29,10 @@ module Sensemaker
     scope :published, -> { where(published: true) }
     scope :unpublished, -> { where(published: false) }
 
+    def artefacts
+      @artefacts ||= Sensemaker::JobArtefacts.new(self)
+    end
+
     def started?
       started_at.present?
     end

--- a/app/models/sensemaker/job.rb
+++ b/app/models/sensemaker/job.rb
@@ -1,0 +1,107 @@
+module Sensemaker
+  class Job < ApplicationRecord
+    self.table_name = "sensemaker_jobs"
+
+    ANALYSABLE_TYPES = [
+      "Debate",
+      "Proposal",
+      "Poll",
+      "Poll::Question",
+      "Legislation::Question",
+      "Legislation::Proposal",
+      "Legislation::QuestionOption",
+      "Budget",
+      "Budget::Group"
+    ].freeze
+
+    validates :analysable_type, inclusion: { in: ANALYSABLE_TYPES }
+
+    belongs_to :user, optional: false
+    belongs_to :parent_job, class_name: "Sensemaker::Job", optional: true
+    has_many :children, class_name: "Sensemaker::Job", foreign_key: :parent_job_id, inverse_of: :parent_job,
+                        dependent: :nullify
+
+    validates :analysable_type, presence: true
+    validates :analysable_id, presence: true
+
+    belongs_to :analysable, polymorphic: true, optional: true
+
+    scope :published, -> { where(published: true) }
+    scope :unpublished, -> { where(published: false) }
+
+    def started?
+      started_at.present?
+    end
+
+    def finished?
+      finished_at.present?
+    end
+
+    def errored?
+      error.present?
+    end
+
+    def cancelled?
+      finished_at.present? && error.eql?("Cancelled")
+    end
+
+    def running?
+      started? && !finished?
+    end
+
+    def status
+      if cancelled?
+        "Cancelled"
+      elsif errored?
+        "Failed"
+      elsif finished?
+        "Completed"
+      elsif started?
+        "Running"
+      else
+        "Unstarted"
+      end
+    end
+
+    def self.unstarted
+      where(started_at: nil).where(finished_at: nil)
+    end
+
+    def self.running
+      where.not(started_at: nil).where(finished_at: nil)
+    end
+
+    def self.successful
+      where(error: nil).where.not(finished_at: nil)
+    end
+
+    def self.failed
+      where.not(error: nil).where.not(finished_at: nil)
+    end
+
+    def cancel!
+      update!(finished_at: Time.current, error: "Cancelled")
+    end
+
+    def self.for_budget(budget)
+      group_subquery = budget.groups.select(:id)
+      published.where(analysable_type: "Budget", analysable_id: budget.id).or(
+        published.where(analysable_type: "Budget::Group", analysable_id: group_subquery)
+      )
+    end
+
+    def self.for_process(process)
+      proposals_subquery = process.proposals.select(:id)
+      questions_subquery = process.questions.select(:id)
+      question_options_subquery = Legislation::QuestionOption
+                                  .where(legislation_question_id: questions_subquery)
+                                  .select(:id)
+
+      published
+        .where(analysable_type: "Legislation::Proposal", analysable_id: proposals_subquery)
+        .or(published.where(analysable_type: "Legislation::Question", analysable_id: questions_subquery))
+        .or(published.where(analysable_type: "Legislation::QuestionOption",
+                            analysable_id: question_options_subquery))
+    end
+  end
+end

--- a/app/models/sensemaker/job.rb
+++ b/app/models/sensemaker/job.rb
@@ -22,7 +22,7 @@ module Sensemaker
                         dependent: :nullify
 
     validates :analysable_type, presence: true
-    validates :analysable_id, presence: true
+    validates :analysable_id, presence: true, unless: -> { analysable_type == "Proposal" }
 
     belongs_to :analysable, polymorphic: true, optional: true
 

--- a/app/models/sensemaker/job.rb
+++ b/app/models/sensemaker/job.rb
@@ -26,11 +26,18 @@ module Sensemaker
 
     belongs_to :analysable, polymorphic: true, optional: true
 
+    before_save :set_persisted_output_if_successful
+    after_destroy :cleanup_associated_files
+
     scope :published, -> { where(published: true) }
     scope :unpublished, -> { where(published: false) }
 
     def artefacts
       @artefacts ||= Sensemaker::JobArtefacts.new(self)
+    end
+
+    def conversation
+      @conversation ||= Sensemaker::Conversation.new(analysable_type, analysable_id)
     end
 
     def started?
@@ -107,5 +114,26 @@ module Sensemaker
         .or(published.where(analysable_type: "Legislation::QuestionOption",
                             analysable_id: question_options_subquery))
     end
+
+    private
+
+      def set_persisted_output_if_successful
+        return unless finished_at.present? && error.nil?
+        return if persisted_output.present?
+
+        if artefacts.complete?
+          self.persisted_output = artefacts.relative_output_path
+        end
+      end
+
+      def cleanup_associated_files
+        result = artefacts.cleanup
+        if result.nil?
+          Rails.logger.warn("Failed to cleanup files for job #{id}")
+        else
+          Rails.logger.info("Cleaned up files for job #{id}: #{result.inspect}")
+        end
+        result
+      end
   end
 end

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -193,7 +193,8 @@ class Setting < ApplicationRecord
         "llm.provider": nil,
         "llm.model": nil,
         "llm.use_llm_for_translations": false,
-        "llm.use_ai_image_suggestions": false
+        "llm.use_ai_image_suggestions": false,
+        "llm.use_sensemaker": false
       }
     end
 

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -180,3 +180,15 @@ task :setup_puma do
   after "setup_puma", "puma:install"
   after "setup_puma", "puma:enable"
 end
+
+task :setup_delayed_job_environment do
+  on roles(fetch(:delayed_job_roles)) do
+    fnm_setup = fetch(:fnm_setup_command)
+    SSHKit.config.command_map.prefix[:bundle].unshift(-> { "#{fnm_setup} && EXECJS_RUNTIME='' " })
+  end
+end
+
+before "delayed_job:start", "setup_delayed_job_environment"
+before "delayed_job:restart", "setup_delayed_job_environment"
+before "delayed_job:stop", "setup_delayed_job_environment"
+before "delayed_job:status", "setup_delayed_job_environment"

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -33,7 +33,8 @@ set :use_sudo, false
 
 set :linked_files, %w[config/database.yml config/secrets.yml]
 set :linked_dirs, %w[.bundle log tmp public/system public/assets
-                     public/ckeditor_assets public/machine_learning/data storage]
+                     public/ckeditor_assets public/machine_learning/data storage
+                     vendor/sensemaking-tools]
 
 set :keep_releases, 5
 
@@ -74,6 +75,7 @@ namespace :deploy do
   after "deploy:migrate", "add_new_settings"
 
   after :publishing, "setup_puma"
+
   after :finished, "refresh_sitemap"
 
   desc "Deploys and runs the tasks needed to upgrade to a new release"

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -49,6 +49,7 @@ data:
     - config/locales/%{locale}/sdg_management.yml
     - config/locales/%{locale}/seeds.yml
     - config/locales/%{locale}/stats.yml
+    - config/locales/%{locale}/conversation.yml
 
   # Locale files to write new keys to, based on a list of key pattern => file rules. Matched from top to bottom:
   # `i18n-tasks normalize -p` will force move the keys according to these rules
@@ -179,6 +180,7 @@ ignore_unused:
   - "moderation.debates.index.orders.*"
   - "moderation.budget_investments.index.filter*"
   - "moderation.budget_investments.index.orders.*"
+  - "conversation.context.*"
   - "moderation.proposal_notifications.index.filter*"
   - "moderation.proposal_notifications.index.orders.*"
   - "valuation.budgets.index.filter*"

--- a/config/locales/en/conversation.yml
+++ b/config/locales/en/conversation.yml
@@ -1,0 +1,68 @@
+en:
+  conversation:
+    context:
+      base: "Analysing %{type} from the Consul Democracy platform"
+      title: "Title: %{title}"
+      name: "Name: %{name}"
+      summary: "Summary: %{summary}"
+      description: "Description: %{description}"
+      text: "Text: %{text}"
+      location: "Location: %{location}"
+      tags: "- Tags: %{tags}"
+      comments: "- Comments: %{count}"
+      created: "- Created: %{date}"
+      published: "- Published: %{date}"
+      type:
+        budget: "Participatory budget"
+        budget/group: "Participatory budget group"
+        proposal: "Citizen proposal"
+        debate: "Citizen debate"
+        legislation/proposal: "Collaborative legislation proposal"
+        legislation/question: "Collaborative legislation debate"
+        legislation/question_option: "Collaborative legislation debate segmented by option"
+        poll: "Poll"
+        poll/question: "Poll question"
+      proposal:
+        votes: "This proposal has %{total_votes} votes out of %{required_votes} required to be successful"
+
+      legislation_proposal:
+        process: "This proposal is part of the legislation process, \"%{process_title}\""
+        votes: "This proposal has %{votes_up} votes for and %{votes_down} votes against"
+
+      debate:
+        votes: "This debate has %{votes_up} votes for and %{votes_down} votes against"
+
+      legislation_question:
+        process: "This debate is part of the legislation process, \"%{process_title}\""
+        responses_header: "### Debate Responses"
+        option: "- %{value} (%{answers_count} responses)"
+
+      question_option:
+        filter_note: "Note: Comments in this analysis are filtered to only include comments from users who selected the option \"%{option_value}\" in their response to this debate."
+
+      budget:
+        name: "Budget: %{name}"
+        phase: "Phase: %{phase}"
+
+      budget_group:
+        name: "Budget Group: %{name}"
+        budget: "Part of budget: %{budget_name}"
+
+      proposals:
+        all: "These are the proposals that have been submitted to the consul citizen participation platform. Citizens' proposals are an opportunity for neighbours and collectives to decide directly how they want their city to be, after getting sufficient support and submitting to a citizens' vote."
+
+      poll:
+        questions_header: "This Poll is composed of %{count} question(s). The questions are as follows:"
+        question_with_type: "  Q%{number} (%{type}): %{title}"
+        question_option: "     - Option %{number}: %{title}"
+        question_option_with_votes: "      - Option %{number}: %{title} (%{votes} votes)"
+        combined_answers_note: "The attached comments include each author's answers. These are separated by the pipe \"|\" character and labelled as Q1, Q2, etc.."
+        question_type:
+          unique_choice: "Single choice"
+          multiple_choice: "Multiple choice"
+          open_ended: "Open ended"
+
+      poll_question:
+        question_title: "Question: %{title}"
+        filter_note: "Note: This analysis focuses on the poll question \"%{question_title}\"."
+        open_ended: "This is an open-ended question with %{answers_count} text responses."

--- a/config/locales/en/settings.yml
+++ b/config/locales/en/settings.yml
@@ -254,3 +254,5 @@ en:
       model_description: "The LLM model to use."
       use_ai_image_suggestions: "AI Image Suggestions"
       use_ai_image_suggestions_description: "Allow users to use AI for suggesting images from Pexels, instead of uploading their own."
+      use_sensemaker: "Sensemaker"
+      use_sensemaker_description: "Enable Sensemaker integration to help make sense of large-scale conversations."

--- a/config/locales/es/conversation.yml
+++ b/config/locales/es/conversation.yml
@@ -1,0 +1,68 @@
+es:
+  conversation:
+    context:
+      base: "Analizando %{type} de la plataforma Consul Democracy"
+      title: "Título: %{title}"
+      name: "Nombre: %{name}"
+      summary: "Resumen: %{summary}"
+      description: "Descripción: %{description}"
+      text: "Texto: %{text}"
+      location: "Ubicación: %{location}"
+      tags: "- Etiquetas: %{tags}"
+      comments: "- Comentarios: %{count}"
+      created: "- Creado: %{date}"
+      published: "- Publicado: %{date}"
+      type:
+        budget: "Presupuesto participativo"
+        budget/group: "Grupo de presupuesto participativo"
+        proposal: "Propuesta ciudadana"
+        debate: "Debate ciudadano"
+        legislation/proposal: "Propuesta legislativa colaborativa"
+        legislation/question: "Debate legislativo colaborativo"
+        legislation/question_option: "Debate legislativo colaborativo segmentado por opción"
+        poll: "Encuesta"
+        poll/question: "Pregunta de encuesta"
+      proposal:
+        votes: "Esta propuesta tiene %{total_votes} votos de los %{required_votes} necesarios para ser exitosa"
+
+      legislation_proposal:
+        process: "Esta propuesta forma parte del proceso legislativo \"%{process_title}\""
+        votes: "Esta propuesta tiene %{votes_up} votos a favor y %{votes_down} votos en contra"
+
+      debate:
+        votes: "Este debate tiene %{votes_up} votos a favor y %{votes_down} votos en contra"
+
+      legislation_question:
+        process: "Este debate forma parte del proceso legislativo \"%{process_title}\""
+        responses_header: "### Respuestas del Debate"
+        option: "- %{value} (%{answers_count} respuestas)"
+
+      question_option:
+        filter_note: "Nota: Los comentarios en este análisis están filtrados para incluir solo los comentarios de usuarios que seleccionaron la opción \"%{option_value}\" en su respuesta a este debate."
+
+      budget:
+        name: "Presupuesto: %{name}"
+        phase: "Fase: %{phase}"
+
+      budget_group:
+        name: "Grupo de Presupuesto: %{name}"
+        budget: "Parte del presupuesto: %{budget_name}"
+
+      proposals:
+        all: "Estas son las propuestas que se han presentado a la plataforma de participación ciudadana consul. Las propuestas ciudadanas son una oportunidad para que los vecinos y colectivos decidan directamente cómo quieren que sea su ciudad, después de obtener suficiente apoyo y someterse a una votación ciudadana."
+
+      poll:
+        questions_header: "Esta Encuesta está compuesta de %{count} pregunta(s). Las preguntas son las siguientes:"
+        question_with_type: "  P%{number} (%{type}): %{title}"
+        question_option: "     - Opción %{number}: %{title}"
+        question_option_with_votes: "      - Opción %{number}: %{title} (%{votes} votos)"
+        combined_answers_note: "Los comentarios adjuntos incluyen las respuestas de cada autor. Estas están separadas por el carácter de barra vertical \"|\" y etiquetadas como P1, P2, etc.."
+        question_type:
+          unique_choice: "Elección única"
+          multiple_choice: "Elección múltiple"
+          open_ended: "Respuesta abierta"
+
+      poll_question:
+        question_title: "Pregunta: %{title}"
+        filter_note: "Nota: Este análisis se centra en la pregunta de la encuesta \"%{question_title}\"."
+        open_ended: "Esta es una pregunta de respuesta abierta con %{answers_count} respuestas de texto."

--- a/config/locales/es/settings.yml
+++ b/config/locales/es/settings.yml
@@ -254,3 +254,5 @@ es:
       model_description: "El modelo LLM a usar."
       use_ai_image_suggestions: "Sugerencias de Imágenes con IA"
       use_ai_image_suggestions_description: "Permitir a los usuarios usar IA para sugerir imágenes de Pexels, en lugar de subir las suyas propias."
+      use_sensemaker: "Sensemaker"
+      use_sensemaker_description: "Habilita la integración de Sensemaker para ayudar a analizar y comprender conversaciones a gran escala."

--- a/config/secrets.yml.example
+++ b/config/secrets.yml.example
@@ -1,3 +1,6 @@
+sensemaker: &sensemaker
+  sensemaker_data_folder: "vendor/sensemaking-tools/data"
+
 llm: &llm
   # Provide keys for the LLM providers you intend to use.
   # consult RubyLLM https://rubyllm.com/configuration#global-configuration-rubyllmconfigure configuration for all supported providers and use the same key names here.
@@ -42,10 +45,12 @@ development:
       # maximum_attempts: 20
       # unlock_in: 1 # In hours
   <<: *maps
+  <<: *sensemaker
 
 test:
   # time_zone: ""
   <<: *maps
+  <<: *sensemaker
 
 staging:
   # secret_key_base: ""
@@ -115,6 +120,7 @@ staging:
   oidc_issuer: ""
   <<: *maps
   <<: *apis
+  <<: *sensemaker
 
 preproduction:
   # secret_key_base: ""
@@ -184,6 +190,7 @@ preproduction:
   oidc_issuer: ""
   <<: *maps
   <<: *apis
+  <<: *sensemaker
 
 production:
   # secret_key_base: ""
@@ -252,3 +259,4 @@ production:
   oidc_issuer: ""
   <<: *maps
   <<: *apis
+  <<: *sensemaker

--- a/db/migrate/20251113104941_create_sensemaker_jobs.rb
+++ b/db/migrate/20251113104941_create_sensemaker_jobs.rb
@@ -1,0 +1,23 @@
+class CreateSensemakerJobs < ActiveRecord::Migration[7.1]
+  def change
+    create_table :sensemaker_jobs do |t|
+      t.datetime :started_at
+      t.datetime :finished_at
+      t.string :script
+      t.integer :pid
+      t.text :error
+      t.references :user, null: false, foreign_key: true
+      t.string :analysable_type, null: false
+      t.integer :analysable_id
+      t.timestamps
+      t.text :additional_context
+      t.references :parent_job, foreign_key: { to_table: :sensemaker_jobs }
+      t.string :input_file
+      t.string :persisted_output
+      t.boolean :published, default: false
+      t.integer :comments_analysed, default: 0
+    end
+
+    add_index :sensemaker_jobs, [:analysable_type, :analysable_id]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_10_09_085528) do
+ActiveRecord::Schema[8.0].define(version: 2025_11_13_104941) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -1440,6 +1440,28 @@ ActiveRecord::Schema[8.0].define(version: 2025_10_09_085528) do
     t.index ["goal_id"], name: "index_sdg_targets_on_goal_id"
   end
 
+  create_table "sensemaker_jobs", force: :cascade do |t|
+    t.datetime "started_at"
+    t.datetime "finished_at"
+    t.string "script"
+    t.integer "pid"
+    t.text "error"
+    t.bigint "user_id", null: false
+    t.string "analysable_type", null: false
+    t.integer "analysable_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.text "additional_context"
+    t.bigint "parent_job_id"
+    t.string "input_file"
+    t.string "persisted_output"
+    t.boolean "published", default: false
+    t.integer "comments_analysed", default: 0
+    t.index ["analysable_type", "analysable_id"], name: "index_sensemaker_jobs_on_analysable_type_and_analysable_id"
+    t.index ["parent_job_id"], name: "index_sensemaker_jobs_on_parent_job_id"
+    t.index ["user_id"], name: "index_sensemaker_jobs_on_user_id"
+  end
+
   create_table "settings", id: :serial, force: :cascade do |t|
     t.string "key"
     t.string "value"
@@ -1818,6 +1840,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_10_09_085528) do
   add_foreign_key "related_content_scores", "related_contents"
   add_foreign_key "related_content_scores", "users"
   add_foreign_key "sdg_managers", "users"
+  add_foreign_key "sensemaker_jobs", "sensemaker_jobs", column: "parent_job_id"
+  add_foreign_key "sensemaker_jobs", "users"
   add_foreign_key "users", "geozones"
   add_foreign_key "valuators", "users"
 end

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,6 +6,8 @@
     "": {
       "name": "consuldemocracy",
       "dependencies": {
+        "@cosla/sensemaking-report-ui": "^0.1.2",
+        "@cosla/sensemaking-tools": "^1.2.0",
         "@deltablot/dropzone": "^7.4.3",
         "@fortawesome/fontawesome-free": "^6.7.2",
         "@rails/ujs": "^7.1.3-4",
@@ -110,6 +112,91 @@
       "license": "MIT",
       "dependencies": {
         "@keyv/serialize": "^1.1.1"
+      }
+    },
+    "node_modules/@cosla/sensemaker-visualizations": {
+      "version": "1.0.48",
+      "resolved": "https://registry.npmjs.org/@cosla/sensemaker-visualizations/-/sensemaker-visualizations-1.0.48.tgz",
+      "integrity": "sha512-95ELNz5sfgMEzymS/L6As4D1uONof8HxHtc0SJxWebMO2eF0Cu0THuwso5X2QXQr7dvicPQcn4fKRyO0cqhxaA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "d3": "^7.0.0"
+      }
+    },
+    "node_modules/@cosla/sensemaking-report-ui": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@cosla/sensemaking-report-ui/-/sensemaking-report-ui-0.1.2.tgz",
+      "integrity": "sha512-jInbFGgi2FYNcK0Jp52PSfGY8DPdECI4G1+N76GE89u5IhC/qKQ8rDjfoRLFMDvl2LU+d6BwDyzRFQ90cdELvg==",
+      "license": "ISC",
+      "dependencies": {
+        "@cosla/sensemaker-visualizations": "^1.0.48",
+        "inline-source": "^8.0.3",
+        "marked": "^15.0.3",
+        "mustache": "^4.2.0"
+      },
+      "bin": {
+        "sensemaking-report-ui": "bin/cli.js"
+      }
+    },
+    "node_modules/@cosla/sensemaking-tools": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@cosla/sensemaking-tools/-/sensemaking-tools-1.2.0.tgz",
+      "integrity": "sha512-SQaHKLb+dkh6WqczDRu2HjHRUKg9qlr8L++67hltFWcr6SqS9kyYGGsA+6UYYi0qzWN4FJZOrXsey7sypMyN9A==",
+      "license": "ISC",
+      "dependencies": {
+        "@google/genai": "^1.52.0",
+        "@sinclair/typebox": "^0.34.3",
+        "commander": "^13.1.0",
+        "csv-parse": "^5.6.0",
+        "csv-writer": "^1.6.0",
+        "marked": "^15.0.3",
+        "p-limit": "^3.1.0",
+        "ts-node": "^10.9.2",
+        "typescript": "^5.5.4"
+      }
+    },
+    "node_modules/@cosla/sensemaking-tools/node_modules/commander": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
+      "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cosla/sensemaking-tools/node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
     "node_modules/@csstools/css-parser-algorithms": {
@@ -435,6 +522,30 @@
         "node": ">=6"
       }
     },
+    "node_modules/@google/genai": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.52.0.tgz",
+      "integrity": "sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "google-auth-library": "^10.3.0",
+        "p-retry": "^4.6.2",
+        "protobufjs": "^7.5.4",
+        "ws": "^8.18.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/sdk": "^1.25.2"
+      },
+      "peerDependenciesMeta": {
+        "@modelcontextprotocol/sdk": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -487,6 +598,51 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/source-map": {
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
+      "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.25"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
     "node_modules/@keyv/serialize": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@keyv/serialize/-/serialize-1.1.1.tgz",
@@ -532,10 +688,73 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.2.tgz",
+      "integrity": "sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/@rails/ujs": {
       "version": "7.1.3-4",
       "resolved": "https://registry.npmjs.org/@rails/ujs/-/ujs-7.1.3-4.tgz",
       "integrity": "sha512-z0ckI5jrAJfImcObjMT1RBz2IxH6I5q6ZTMFex6AfxSQKZuuL8JxAXvg2CvBuodGCxKvybFVolDyMHXlBLeYAA=="
+    },
+    "node_modules/@sinclair/typebox": {
+      "version": "0.34.52",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.52.tgz",
+      "integrity": "sha512-XiMQh7qqVlxZzcVD+kkGMNGMzcTrDMLWI7S4x7z1MkCkbDPrekpZXEUK0eZqZFMuHQg2a2DZOcDIh9o5v3Gonw==",
+      "license": "MIT"
     },
     "node_modules/@sindresorhus/merge-streams": {
       "version": "4.0.0",
@@ -580,6 +799,30 @@
         "tslib": "^2.8.0"
       }
     },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.12.tgz",
+      "integrity": "sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==",
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "license": "MIT"
+    },
     "node_modules/@types/d3-selection": {
       "version": "3.0.11",
       "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
@@ -607,11 +850,365 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/node": {
+      "version": "26.1.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.2.tgz",
+      "integrity": "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
+    "node_modules/@types/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+      "license": "MIT"
+    },
+    "node_modules/@typescript/typescript-aix-ppc64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-aix-ppc64/-/typescript-aix-ppc64-7.0.2.tgz",
+      "integrity": "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-darwin-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-arm64/-/typescript-darwin-arm64-7.0.2.tgz",
+      "integrity": "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-darwin-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-x64/-/typescript-darwin-x64-7.0.2.tgz",
+      "integrity": "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-freebsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-arm64/-/typescript-freebsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-freebsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-x64/-/typescript-freebsd-x64-7.0.2.tgz",
+      "integrity": "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-arm": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm/-/typescript-linux-arm-7.0.2.tgz",
+      "integrity": "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm64/-/typescript-linux-arm64-7.0.2.tgz",
+      "integrity": "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-loong64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-loong64/-/typescript-linux-loong64-7.0.2.tgz",
+      "integrity": "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-mips64el": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-mips64el/-/typescript-linux-mips64el-7.0.2.tgz",
+      "integrity": "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-ppc64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-ppc64/-/typescript-linux-ppc64-7.0.2.tgz",
+      "integrity": "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-riscv64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-riscv64/-/typescript-linux-riscv64-7.0.2.tgz",
+      "integrity": "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-s390x": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-s390x/-/typescript-linux-s390x-7.0.2.tgz",
+      "integrity": "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-x64/-/typescript-linux-x64-7.0.2.tgz",
+      "integrity": "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-netbsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-arm64/-/typescript-netbsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-netbsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-x64/-/typescript-netbsd-x64-7.0.2.tgz",
+      "integrity": "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-openbsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-arm64/-/typescript-openbsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-openbsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-x64/-/typescript-openbsd-x64-7.0.2.tgz",
+      "integrity": "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-sunos-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-sunos-x64/-/typescript-sunos-x64-7.0.2.tgz",
+      "integrity": "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-win32-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-arm64/-/typescript-win32-arm64-7.0.2.tgz",
+      "integrity": "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-win32-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-x64/-/typescript-win32-x64-7.0.2.tgz",
+      "integrity": "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -628,6 +1225,27 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
+      "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/ajv": {
@@ -657,6 +1275,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "license": "MIT"
+    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -670,6 +1294,35 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/billboard.js": {
@@ -693,6 +1346,12 @@
         "d3-transition": "^3.0.1",
         "d3-zoom": "^3.0.0"
       }
+    },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+      "license": "ISC"
     },
     "node_modules/brace-expansion": {
       "version": "1.1.13",
@@ -724,6 +1383,18 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "license": "MIT"
     },
     "node_modules/cacheable": {
       "version": "2.3.4",
@@ -806,6 +1477,12 @@
         }
       }
     },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "license": "MIT"
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -846,6 +1523,22 @@
         "node": ">=12"
       }
     },
+    "node_modules/css-select": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
     "node_modules/css-tree": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
@@ -860,6 +1553,18 @@
         "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
       }
     },
+    "node_modules/css-what": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -870,6 +1575,93 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/csso": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/csso/-/csso-5.0.5.tgz",
+      "integrity": "sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "~2.2.0"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/csso/node_modules/css-tree": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.2.1.tgz",
+      "integrity": "sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA==",
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.0.28",
+        "source-map-js": "^1.0.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/csso/node_modules/mdn-data": {
+      "version": "2.0.28",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.28.tgz",
+      "integrity": "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g==",
+      "license": "CC0-1.0"
+    },
+    "node_modules/csv-parse": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-5.6.0.tgz",
+      "integrity": "sha512-l3nz3euub2QMg5ouu5U09Ew9Wf6/wQ8I++ch1loQ0ljmzhmfZYrH9fflS22i/PQEvsPvxCwxgz5q7UB8K1JO4Q==",
+      "license": "MIT"
+    },
+    "node_modules/csv-writer": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/csv-writer/-/csv-writer-1.6.0.tgz",
+      "integrity": "sha512-NOx7YDFWEsM/fTRAJjRpPp8t+MKRVvniAg9wQlUKx20MFrPs73WLJhFf5iteqrxNYnsy924K3Iroh3yNHeYd2g==",
+      "license": "MIT"
+    },
+    "node_modules/d3": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/d3/-/d3-7.9.0.tgz",
+      "integrity": "sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==",
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "d3-array": "3",
+        "d3-axis": "3",
+        "d3-brush": "3",
+        "d3-chord": "3",
+        "d3-color": "3",
+        "d3-contour": "4",
+        "d3-delaunay": "6",
+        "d3-dispatch": "3",
+        "d3-drag": "3",
+        "d3-dsv": "3",
+        "d3-ease": "3",
+        "d3-fetch": "3",
+        "d3-force": "3",
+        "d3-format": "3",
+        "d3-geo": "3",
+        "d3-hierarchy": "3",
+        "d3-interpolate": "3",
+        "d3-path": "3",
+        "d3-polygon": "3",
+        "d3-quadtree": "3",
+        "d3-random": "3",
+        "d3-scale": "4",
+        "d3-scale-chromatic": "3",
+        "d3-selection": "3",
+        "d3-shape": "3",
+        "d3-time": "3",
+        "d3-time-format": "4",
+        "d3-timer": "3",
+        "d3-transition": "3",
+        "d3-zoom": "3"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/d3-array": {
@@ -906,10 +1698,49 @@
         "node": ">=12"
       }
     },
+    "node_modules/d3-chord": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-3.0.1.tgz",
+      "integrity": "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==",
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "d3-path": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/d3-color": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
       "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-contour": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-4.0.2.tgz",
+      "integrity": "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==",
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "d3-array": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "delaunator": "5"
+      },
       "engines": {
         "node": ">=12"
       }
@@ -966,10 +1797,51 @@
         "node": ">=12"
       }
     },
+    "node_modules/d3-fetch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-3.0.1.tgz",
+      "integrity": "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==",
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "d3-dsv": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-force": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
+      "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-quadtree": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/d3-format": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
       "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-geo": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.1.tgz",
+      "integrity": "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==",
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "d3-array": "2.5.0 - 3"
+      },
       "engines": {
         "node": ">=12"
       }
@@ -1001,6 +1873,36 @@
         "node": ">=12"
       }
     },
+    "node_modules/d3-polygon": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-3.0.1.tgz",
+      "integrity": "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==",
+      "license": "ISC",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-quadtree": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
+      "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
+      "license": "ISC",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-random": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-3.0.1.tgz",
+      "integrity": "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==",
+      "license": "ISC",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/d3-scale": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
@@ -1011,6 +1913,20 @@
         "d3-interpolate": "1.2.0 - 3",
         "d3-time": "2.1.1 - 3",
         "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-interpolate": "1 - 3"
       },
       "engines": {
         "node": ">=12"
@@ -1098,11 +2014,19 @@
         "node": ">=12"
       }
     },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -1122,6 +2046,89 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/delaunator": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.1.0.tgz",
+      "integrity": "sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==",
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "robust-predicates": "^3.0.2"
+      }
+    },
+    "node_modules/diff": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
+      "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
@@ -1469,6 +2476,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -1542,6 +2555,29 @@
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
     "node_modules/file-entry-cache": {
       "version": "11.1.2",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-11.1.2.tgz",
@@ -1601,6 +2637,18 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/foundation-sites": {
       "version": "6.8.1",
       "resolved": "https://registry.npmjs.org/foundation-sites/-/foundation-sites-6.8.1.tgz",
@@ -1612,6 +2660,34 @@
         "jquery": ">=3.6.0",
         "motion-ui": "latest",
         "what-input": ">=5.2.10"
+      }
+    },
+    "node_modules/gaxios": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.3.0.tgz",
+      "integrity": "sha512-RB5vLV+vvQeoFPCX4QMK6/hjVkbIamPp1QSUD0CiZcnj12qbpiL+pLbYtgD+oZkWl0tl9z+o2Utp+MpM3QRhBA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/gcp-metadata": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+      "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/get-east-asian-width": {
@@ -1716,6 +2792,32 @@
       "integrity": "sha512-xYfnw62CKG8nLkZBfWbhWwDw02CHty86jfPcc2cr3ZfeuK9ysoVPPEUxf21bAD/rWAgk52SuBrLJlefNy8mvFg==",
       "dev": true
     },
+    "node_modules/google-auth-library": {
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.9.1.tgz",
+      "integrity": "sha512-i1ydyHrqcIxXkWh/uBmVkzCvIuq5yiK2ATndIe5XxKholrG/MTYP9xGYka4sQhrbIAgGjL2B6NOE7rFaiF3fXw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^7.1.4",
+        "gcp-metadata": "8.1.2",
+        "google-logging-utils": "1.1.3",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-logging-utils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/has-flag": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-5.0.1.tgz",
@@ -1760,6 +2862,38 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/htmlparser2": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-9.1.0.tgz",
+      "integrity": "sha512-5zfg6mHUoaer/97TxnGpxmbR7zJtPwIYFMZ/H5ucTlPZhKvtum05yiPK3Mgai3a0DyVxv7qYqoweaEd2nrYQzQ==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.1.0",
+        "entities": "^4.5.0"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/iconv-lite": {
@@ -1832,6 +2966,22 @@
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "dev": true
+    },
+    "node_modules/inline-source": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/inline-source/-/inline-source-8.0.3.tgz",
+      "integrity": "sha512-2k0V+qA8buiBSfchYGg6KgugU/YFboGRZyRWQS0AC1wPBIwehi63KVTKLuk7grnqtneafktIxMUn/nhCDCkW5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "csso": "^5.0.5",
+        "htmlparser2": "^9.0.0",
+        "node-fetch": "^3.3.2",
+        "svgo": "^3.0.0",
+        "terser": "^5.24.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
     },
     "node_modules/internmap": {
       "version": "2.0.3",
@@ -1960,6 +3110,15 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
     "node_modules/json-buffer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
@@ -1987,6 +3146,27 @@
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
     },
     "node_modules/keyv": {
       "version": "4.5.4",
@@ -2097,6 +3277,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "license": "ISC"
+    },
     "node_modules/markdown-it": {
       "version": "14.3.0",
       "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.3.0.tgz",
@@ -2122,6 +3314,18 @@
       },
       "bin": {
         "markdown-it": "bin/markdown-it.mjs"
+      }
+    },
+    "node_modules/marked": {
+      "version": "15.0.12",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
+      "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/mathml-tag-names": {
@@ -2210,8 +3414,16 @@
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
+    "node_modules/mustache": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
+      "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
+      "license": "MIT",
+      "bin": {
+        "mustache": "bin/mustache"
+      }
     },
     "node_modules/nanoid": {
       "version": "3.3.11",
@@ -2239,6 +3451,44 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
     "node_modules/normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -2246,6 +3496,18 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
       }
     },
     "node_modules/optionator": {
@@ -2270,7 +3532,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
       "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "yocto-queue": "^0.1.0"
@@ -2296,6 +3557,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-retry": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+      "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/retry": "0.12.0",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/parent-module": {
@@ -2353,7 +3627,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
@@ -2503,6 +3776,29 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/protobufjs": {
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+      "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
+        "@types/node": ">=13.7.0",
+        "long": "^5.3.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -2572,6 +3868,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/reusify": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
@@ -2582,6 +3887,13 @@
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/robust-predicates": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.3.tgz",
+      "integrity": "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==",
+      "license": "Unlicense",
+      "peer": true
     },
     "node_modules/run-parallel": {
       "version": "1.2.0",
@@ -2612,10 +3924,39 @@
       "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
       "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ=="
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "node_modules/sax": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.1.tgz",
+      "integrity": "sha512-42tBVwLWnaQvW5zc4HbZrTuWccECCZfBi92FDuwtqxasH+JbPB3/FOKb1m222K42R4WxuxzzMsTswfzgtSu64Q==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=11.0.0"
+      }
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -2720,13 +4061,31 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
       }
     },
     "node_modules/string-width": {
@@ -2993,6 +4352,50 @@
       "integrity": "sha512-ovssysQTa+luh7A5Weu3Rta6FJlFBBbInjOh722LIt6klpU2/HtdUbszju/G4devcvk8PGt7FCLv5wftu3THUA==",
       "dev": true
     },
+    "node_modules/svgo": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-3.3.4.tgz",
+      "integrity": "sha512-GsNRis4e8jxn2Y9ENz/8lbJ93CstG8svtMnuRaHbiF2LTJ5tK0/q3t/URPq9Zc7zVWBJnNnJMIp6bevK7bSmNg==",
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^7.2.0",
+        "css-select": "^5.1.0",
+        "css-tree": "^2.3.1",
+        "css-what": "^6.1.0",
+        "csso": "^5.0.5",
+        "picocolors": "^1.0.0",
+        "sax": "^1.5.0"
+      },
+      "bin": {
+        "svgo": "bin/svgo"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/svgo"
+      }
+    },
+    "node_modules/svgo/node_modules/css-tree": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.3.1.tgz",
+      "integrity": "sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==",
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.0.30",
+        "source-map-js": "^1.0.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/svgo/node_modules/mdn-data": {
+      "version": "2.0.30",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.30.tgz",
+      "integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==",
+      "license": "CC0-1.0"
+    },
     "node_modules/table": {
       "version": "6.9.0",
       "resolved": "https://registry.npmjs.org/table/-/table-6.9.0.tgz",
@@ -3010,6 +4413,30 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/terser": {
+      "version": "5.49.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.49.0.tgz",
+      "integrity": "sha512-SNiDnXyHSrxVcIOtVbULzcTmniUiwcV7Nwdyj1twVubeTmbjoa8p69KKDpfkdoOavuM4/GRm1+ykI8qqnavHoA==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@jridgewell/source-map": "^0.3.3",
+        "acorn": "^8.15.0",
+        "commander": "^2.20.0",
+        "source-map-support": "~0.5.20"
+      },
+      "bin": {
+        "terser": "bin/terser"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/terser/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -3021,6 +4448,49 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
       }
     },
     "node_modules/tslib": {
@@ -3041,10 +4511,51 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/typescript": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-7.0.2.tgz",
+      "integrity": "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc"
+      },
+      "engines": {
+        "node": ">=16.20.0"
+      },
+      "optionalDependencies": {
+        "@typescript/typescript-aix-ppc64": "7.0.2",
+        "@typescript/typescript-darwin-arm64": "7.0.2",
+        "@typescript/typescript-darwin-x64": "7.0.2",
+        "@typescript/typescript-freebsd-arm64": "7.0.2",
+        "@typescript/typescript-freebsd-x64": "7.0.2",
+        "@typescript/typescript-linux-arm": "7.0.2",
+        "@typescript/typescript-linux-arm64": "7.0.2",
+        "@typescript/typescript-linux-loong64": "7.0.2",
+        "@typescript/typescript-linux-mips64el": "7.0.2",
+        "@typescript/typescript-linux-ppc64": "7.0.2",
+        "@typescript/typescript-linux-riscv64": "7.0.2",
+        "@typescript/typescript-linux-s390x": "7.0.2",
+        "@typescript/typescript-linux-x64": "7.0.2",
+        "@typescript/typescript-netbsd-arm64": "7.0.2",
+        "@typescript/typescript-netbsd-x64": "7.0.2",
+        "@typescript/typescript-openbsd-arm64": "7.0.2",
+        "@typescript/typescript-openbsd-x64": "7.0.2",
+        "@typescript/typescript-sunos-x64": "7.0.2",
+        "@typescript/typescript-win32-arm64": "7.0.2",
+        "@typescript/typescript-win32-x64": "7.0.2"
+      }
+    },
     "node_modules/uc.micro": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
       "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "license": "MIT"
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
       "license": "MIT"
     },
     "node_modules/unicorn-magic": {
@@ -3074,6 +4585,21 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "license": "MIT"
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
     },
     "node_modules/what-input": {
       "version": "5.2.12",
@@ -3116,11 +4642,40 @@
         "node": "^20.17.0 || >=22.9.0"
       }
     },
+    "node_modules/ws": {
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,6 +6,8 @@
     "": {
       "name": "consuldemocracy",
       "dependencies": {
+        "@cosla/sensemaking-report-ui": "^0.1.2",
+        "@cosla/sensemaking-tools": "^1.1.6",
         "@deltablot/dropzone": "^7.4.3",
         "@fortawesome/fontawesome-free": "^6.7.2",
         "@rails/ujs": "^7.1.3-4",
@@ -110,6 +112,90 @@
       "license": "MIT",
       "dependencies": {
         "@keyv/serialize": "^1.1.1"
+      }
+    },
+    "node_modules/@cosla/sensemaker-visualizations": {
+      "version": "1.0.48",
+      "resolved": "https://registry.npmjs.org/@cosla/sensemaker-visualizations/-/sensemaker-visualizations-1.0.48.tgz",
+      "integrity": "sha512-95ELNz5sfgMEzymS/L6As4D1uONof8HxHtc0SJxWebMO2eF0Cu0THuwso5X2QXQr7dvicPQcn4fKRyO0cqhxaA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "d3": "^7.0.0"
+      }
+    },
+    "node_modules/@cosla/sensemaking-report-ui": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@cosla/sensemaking-report-ui/-/sensemaking-report-ui-0.1.2.tgz",
+      "integrity": "sha512-jInbFGgi2FYNcK0Jp52PSfGY8DPdECI4G1+N76GE89u5IhC/qKQ8rDjfoRLFMDvl2LU+d6BwDyzRFQ90cdELvg==",
+      "license": "ISC",
+      "dependencies": {
+        "@cosla/sensemaker-visualizations": "^1.0.48",
+        "inline-source": "^8.0.3",
+        "marked": "^15.0.3",
+        "mustache": "^4.2.0"
+      },
+      "bin": {
+        "sensemaking-report-ui": "bin/cli.js"
+      }
+    },
+    "node_modules/@cosla/sensemaking-tools": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@cosla/sensemaking-tools/-/sensemaking-tools-1.1.6.tgz",
+      "integrity": "sha512-AHLyquSSPADY40h9rxSj38ngRDTAuhsKlJxIKItXfF5KtWM1DbKSEqd+BfWKXHCoNsDRjdrRWs45yU2PcmN9nw==",
+      "license": "ISC",
+      "dependencies": {
+        "@google/genai": "^1.52.0",
+        "@sinclair/typebox": "^0.34.3",
+        "commander": "^13.1.0",
+        "csv-parse": "^5.6.0",
+        "csv-writer": "^1.6.0",
+        "marked": "^15.0.3",
+        "ts-node": "^10.9.2",
+        "typescript": "^5.5.4"
+      }
+    },
+    "node_modules/@cosla/sensemaking-tools/node_modules/commander": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
+      "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cosla/sensemaking-tools/node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
     "node_modules/@csstools/css-parser-algorithms": {
@@ -435,6 +521,30 @@
         "node": ">=6"
       }
     },
+    "node_modules/@google/genai": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.52.0.tgz",
+      "integrity": "sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "google-auth-library": "^10.3.0",
+        "p-retry": "^4.6.2",
+        "protobufjs": "^7.5.4",
+        "ws": "^8.18.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/sdk": "^1.25.2"
+      },
+      "peerDependenciesMeta": {
+        "@modelcontextprotocol/sdk": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -487,6 +597,51 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/source-map": {
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
+      "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.25"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
     "node_modules/@keyv/serialize": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@keyv/serialize/-/serialize-1.1.1.tgz",
@@ -532,10 +687,73 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.2.tgz",
+      "integrity": "sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/@rails/ujs": {
       "version": "7.1.3-4",
       "resolved": "https://registry.npmjs.org/@rails/ujs/-/ujs-7.1.3-4.tgz",
       "integrity": "sha512-z0ckI5jrAJfImcObjMT1RBz2IxH6I5q6ZTMFex6AfxSQKZuuL8JxAXvg2CvBuodGCxKvybFVolDyMHXlBLeYAA=="
+    },
+    "node_modules/@sinclair/typebox": {
+      "version": "0.34.52",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.52.tgz",
+      "integrity": "sha512-XiMQh7qqVlxZzcVD+kkGMNGMzcTrDMLWI7S4x7z1MkCkbDPrekpZXEUK0eZqZFMuHQg2a2DZOcDIh9o5v3Gonw==",
+      "license": "MIT"
     },
     "node_modules/@sindresorhus/merge-streams": {
       "version": "4.0.0",
@@ -580,6 +798,30 @@
         "tslib": "^2.8.0"
       }
     },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.12.tgz",
+      "integrity": "sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==",
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "license": "MIT"
+    },
     "node_modules/@types/d3-selection": {
       "version": "3.0.11",
       "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
@@ -607,11 +849,365 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/node": {
+      "version": "26.1.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.2.tgz",
+      "integrity": "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
+    "node_modules/@types/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+      "license": "MIT"
+    },
+    "node_modules/@typescript/typescript-aix-ppc64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-aix-ppc64/-/typescript-aix-ppc64-7.0.2.tgz",
+      "integrity": "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-darwin-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-arm64/-/typescript-darwin-arm64-7.0.2.tgz",
+      "integrity": "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-darwin-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-x64/-/typescript-darwin-x64-7.0.2.tgz",
+      "integrity": "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-freebsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-arm64/-/typescript-freebsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-freebsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-x64/-/typescript-freebsd-x64-7.0.2.tgz",
+      "integrity": "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-arm": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm/-/typescript-linux-arm-7.0.2.tgz",
+      "integrity": "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm64/-/typescript-linux-arm64-7.0.2.tgz",
+      "integrity": "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-loong64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-loong64/-/typescript-linux-loong64-7.0.2.tgz",
+      "integrity": "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-mips64el": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-mips64el/-/typescript-linux-mips64el-7.0.2.tgz",
+      "integrity": "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-ppc64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-ppc64/-/typescript-linux-ppc64-7.0.2.tgz",
+      "integrity": "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-riscv64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-riscv64/-/typescript-linux-riscv64-7.0.2.tgz",
+      "integrity": "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-s390x": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-s390x/-/typescript-linux-s390x-7.0.2.tgz",
+      "integrity": "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-x64/-/typescript-linux-x64-7.0.2.tgz",
+      "integrity": "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-netbsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-arm64/-/typescript-netbsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-netbsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-x64/-/typescript-netbsd-x64-7.0.2.tgz",
+      "integrity": "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-openbsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-arm64/-/typescript-openbsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-openbsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-x64/-/typescript-openbsd-x64-7.0.2.tgz",
+      "integrity": "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-sunos-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-sunos-x64/-/typescript-sunos-x64-7.0.2.tgz",
+      "integrity": "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-win32-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-arm64/-/typescript-win32-arm64-7.0.2.tgz",
+      "integrity": "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-win32-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-x64/-/typescript-win32-x64-7.0.2.tgz",
+      "integrity": "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -628,6 +1224,27 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
+      "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/ajv": {
@@ -657,6 +1274,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "license": "MIT"
+    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -670,6 +1293,35 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/billboard.js": {
@@ -693,6 +1345,12 @@
         "d3-transition": "^3.0.1",
         "d3-zoom": "^3.0.0"
       }
+    },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+      "license": "ISC"
     },
     "node_modules/brace-expansion": {
       "version": "1.1.13",
@@ -724,6 +1382,18 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "license": "MIT"
     },
     "node_modules/cacheable": {
       "version": "2.3.4",
@@ -806,6 +1476,12 @@
         }
       }
     },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "license": "MIT"
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -846,6 +1522,22 @@
         "node": ">=12"
       }
     },
+    "node_modules/css-select": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
     "node_modules/css-tree": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
@@ -860,6 +1552,18 @@
         "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
       }
     },
+    "node_modules/css-what": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -870,6 +1574,93 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/csso": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/csso/-/csso-5.0.5.tgz",
+      "integrity": "sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "~2.2.0"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/csso/node_modules/css-tree": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.2.1.tgz",
+      "integrity": "sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA==",
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.0.28",
+        "source-map-js": "^1.0.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/csso/node_modules/mdn-data": {
+      "version": "2.0.28",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.28.tgz",
+      "integrity": "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g==",
+      "license": "CC0-1.0"
+    },
+    "node_modules/csv-parse": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-5.6.0.tgz",
+      "integrity": "sha512-l3nz3euub2QMg5ouu5U09Ew9Wf6/wQ8I++ch1loQ0ljmzhmfZYrH9fflS22i/PQEvsPvxCwxgz5q7UB8K1JO4Q==",
+      "license": "MIT"
+    },
+    "node_modules/csv-writer": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/csv-writer/-/csv-writer-1.6.0.tgz",
+      "integrity": "sha512-NOx7YDFWEsM/fTRAJjRpPp8t+MKRVvniAg9wQlUKx20MFrPs73WLJhFf5iteqrxNYnsy924K3Iroh3yNHeYd2g==",
+      "license": "MIT"
+    },
+    "node_modules/d3": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/d3/-/d3-7.9.0.tgz",
+      "integrity": "sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==",
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "d3-array": "3",
+        "d3-axis": "3",
+        "d3-brush": "3",
+        "d3-chord": "3",
+        "d3-color": "3",
+        "d3-contour": "4",
+        "d3-delaunay": "6",
+        "d3-dispatch": "3",
+        "d3-drag": "3",
+        "d3-dsv": "3",
+        "d3-ease": "3",
+        "d3-fetch": "3",
+        "d3-force": "3",
+        "d3-format": "3",
+        "d3-geo": "3",
+        "d3-hierarchy": "3",
+        "d3-interpolate": "3",
+        "d3-path": "3",
+        "d3-polygon": "3",
+        "d3-quadtree": "3",
+        "d3-random": "3",
+        "d3-scale": "4",
+        "d3-scale-chromatic": "3",
+        "d3-selection": "3",
+        "d3-shape": "3",
+        "d3-time": "3",
+        "d3-time-format": "4",
+        "d3-timer": "3",
+        "d3-transition": "3",
+        "d3-zoom": "3"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/d3-array": {
@@ -906,10 +1697,49 @@
         "node": ">=12"
       }
     },
+    "node_modules/d3-chord": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-3.0.1.tgz",
+      "integrity": "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==",
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "d3-path": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/d3-color": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
       "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-contour": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-4.0.2.tgz",
+      "integrity": "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==",
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "d3-array": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "delaunator": "5"
+      },
       "engines": {
         "node": ">=12"
       }
@@ -966,10 +1796,51 @@
         "node": ">=12"
       }
     },
+    "node_modules/d3-fetch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-3.0.1.tgz",
+      "integrity": "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==",
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "d3-dsv": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-force": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
+      "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-quadtree": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/d3-format": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
       "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-geo": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.1.tgz",
+      "integrity": "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==",
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "d3-array": "2.5.0 - 3"
+      },
       "engines": {
         "node": ">=12"
       }
@@ -1001,6 +1872,36 @@
         "node": ">=12"
       }
     },
+    "node_modules/d3-polygon": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-3.0.1.tgz",
+      "integrity": "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==",
+      "license": "ISC",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-quadtree": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
+      "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
+      "license": "ISC",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-random": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-3.0.1.tgz",
+      "integrity": "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==",
+      "license": "ISC",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/d3-scale": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
@@ -1011,6 +1912,20 @@
         "d3-interpolate": "1.2.0 - 3",
         "d3-time": "2.1.1 - 3",
         "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-interpolate": "1 - 3"
       },
       "engines": {
         "node": ">=12"
@@ -1098,11 +2013,19 @@
         "node": ">=12"
       }
     },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -1122,6 +2045,89 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/delaunator": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.1.0.tgz",
+      "integrity": "sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==",
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "robust-predicates": "^3.0.2"
+      }
+    },
+    "node_modules/diff": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
+      "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
@@ -1469,6 +2475,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -1542,6 +2554,29 @@
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
     "node_modules/file-entry-cache": {
       "version": "11.1.2",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-11.1.2.tgz",
@@ -1601,6 +2636,18 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/foundation-sites": {
       "version": "6.8.1",
       "resolved": "https://registry.npmjs.org/foundation-sites/-/foundation-sites-6.8.1.tgz",
@@ -1612,6 +2659,34 @@
         "jquery": ">=3.6.0",
         "motion-ui": "latest",
         "what-input": ">=5.2.10"
+      }
+    },
+    "node_modules/gaxios": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.3.0.tgz",
+      "integrity": "sha512-RB5vLV+vvQeoFPCX4QMK6/hjVkbIamPp1QSUD0CiZcnj12qbpiL+pLbYtgD+oZkWl0tl9z+o2Utp+MpM3QRhBA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/gcp-metadata": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+      "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/get-east-asian-width": {
@@ -1716,6 +2791,32 @@
       "integrity": "sha512-xYfnw62CKG8nLkZBfWbhWwDw02CHty86jfPcc2cr3ZfeuK9ysoVPPEUxf21bAD/rWAgk52SuBrLJlefNy8mvFg==",
       "dev": true
     },
+    "node_modules/google-auth-library": {
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.9.1.tgz",
+      "integrity": "sha512-i1ydyHrqcIxXkWh/uBmVkzCvIuq5yiK2ATndIe5XxKholrG/MTYP9xGYka4sQhrbIAgGjL2B6NOE7rFaiF3fXw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^7.1.4",
+        "gcp-metadata": "8.1.2",
+        "google-logging-utils": "1.1.3",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-logging-utils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/has-flag": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-5.0.1.tgz",
@@ -1760,6 +2861,38 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/htmlparser2": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-9.1.0.tgz",
+      "integrity": "sha512-5zfg6mHUoaer/97TxnGpxmbR7zJtPwIYFMZ/H5ucTlPZhKvtum05yiPK3Mgai3a0DyVxv7qYqoweaEd2nrYQzQ==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.1.0",
+        "entities": "^4.5.0"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/iconv-lite": {
@@ -1832,6 +2965,22 @@
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "dev": true
+    },
+    "node_modules/inline-source": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/inline-source/-/inline-source-8.0.3.tgz",
+      "integrity": "sha512-2k0V+qA8buiBSfchYGg6KgugU/YFboGRZyRWQS0AC1wPBIwehi63KVTKLuk7grnqtneafktIxMUn/nhCDCkW5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "csso": "^5.0.5",
+        "htmlparser2": "^9.0.0",
+        "node-fetch": "^3.3.2",
+        "svgo": "^3.0.0",
+        "terser": "^5.24.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
     },
     "node_modules/internmap": {
       "version": "2.0.3",
@@ -1960,6 +3109,15 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
     "node_modules/json-buffer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
@@ -1987,6 +3145,27 @@
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
     },
     "node_modules/keyv": {
       "version": "4.5.4",
@@ -2097,6 +3276,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "license": "ISC"
+    },
     "node_modules/markdown-it": {
       "version": "14.3.0",
       "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.3.0.tgz",
@@ -2122,6 +3313,18 @@
       },
       "bin": {
         "markdown-it": "bin/markdown-it.mjs"
+      }
+    },
+    "node_modules/marked": {
+      "version": "15.0.12",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
+      "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/mathml-tag-names": {
@@ -2210,8 +3413,16 @@
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
+    "node_modules/mustache": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
+      "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
+      "license": "MIT",
+      "bin": {
+        "mustache": "bin/mustache"
+      }
     },
     "node_modules/nanoid": {
       "version": "3.3.11",
@@ -2239,6 +3450,44 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
     "node_modules/normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -2246,6 +3495,18 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
       }
     },
     "node_modules/optionator": {
@@ -2296,6 +3557,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-retry": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+      "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/retry": "0.12.0",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/parent-module": {
@@ -2353,7 +3627,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
@@ -2503,6 +3776,29 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/protobufjs": {
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+      "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
+        "@types/node": ">=13.7.0",
+        "long": "^5.3.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -2572,6 +3868,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/reusify": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
@@ -2582,6 +3887,13 @@
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/robust-predicates": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.3.tgz",
+      "integrity": "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==",
+      "license": "Unlicense",
+      "peer": true
     },
     "node_modules/run-parallel": {
       "version": "1.2.0",
@@ -2612,10 +3924,39 @@
       "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
       "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ=="
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "node_modules/sax": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.1.tgz",
+      "integrity": "sha512-42tBVwLWnaQvW5zc4HbZrTuWccECCZfBi92FDuwtqxasH+JbPB3/FOKb1m222K42R4WxuxzzMsTswfzgtSu64Q==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=11.0.0"
+      }
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -2720,13 +4061,31 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
       }
     },
     "node_modules/string-width": {
@@ -2993,6 +4352,50 @@
       "integrity": "sha512-ovssysQTa+luh7A5Weu3Rta6FJlFBBbInjOh722LIt6klpU2/HtdUbszju/G4devcvk8PGt7FCLv5wftu3THUA==",
       "dev": true
     },
+    "node_modules/svgo": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-3.3.4.tgz",
+      "integrity": "sha512-GsNRis4e8jxn2Y9ENz/8lbJ93CstG8svtMnuRaHbiF2LTJ5tK0/q3t/URPq9Zc7zVWBJnNnJMIp6bevK7bSmNg==",
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^7.2.0",
+        "css-select": "^5.1.0",
+        "css-tree": "^2.3.1",
+        "css-what": "^6.1.0",
+        "csso": "^5.0.5",
+        "picocolors": "^1.0.0",
+        "sax": "^1.5.0"
+      },
+      "bin": {
+        "svgo": "bin/svgo"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/svgo"
+      }
+    },
+    "node_modules/svgo/node_modules/css-tree": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.3.1.tgz",
+      "integrity": "sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==",
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.0.30",
+        "source-map-js": "^1.0.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/svgo/node_modules/mdn-data": {
+      "version": "2.0.30",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.30.tgz",
+      "integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==",
+      "license": "CC0-1.0"
+    },
     "node_modules/table": {
       "version": "6.9.0",
       "resolved": "https://registry.npmjs.org/table/-/table-6.9.0.tgz",
@@ -3010,6 +4413,30 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/terser": {
+      "version": "5.49.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.49.0.tgz",
+      "integrity": "sha512-SNiDnXyHSrxVcIOtVbULzcTmniUiwcV7Nwdyj1twVubeTmbjoa8p69KKDpfkdoOavuM4/GRm1+ykI8qqnavHoA==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@jridgewell/source-map": "^0.3.3",
+        "acorn": "^8.15.0",
+        "commander": "^2.20.0",
+        "source-map-support": "~0.5.20"
+      },
+      "bin": {
+        "terser": "bin/terser"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/terser/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -3021,6 +4448,49 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
       }
     },
     "node_modules/tslib": {
@@ -3041,10 +4511,51 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/typescript": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-7.0.2.tgz",
+      "integrity": "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc"
+      },
+      "engines": {
+        "node": ">=16.20.0"
+      },
+      "optionalDependencies": {
+        "@typescript/typescript-aix-ppc64": "7.0.2",
+        "@typescript/typescript-darwin-arm64": "7.0.2",
+        "@typescript/typescript-darwin-x64": "7.0.2",
+        "@typescript/typescript-freebsd-arm64": "7.0.2",
+        "@typescript/typescript-freebsd-x64": "7.0.2",
+        "@typescript/typescript-linux-arm": "7.0.2",
+        "@typescript/typescript-linux-arm64": "7.0.2",
+        "@typescript/typescript-linux-loong64": "7.0.2",
+        "@typescript/typescript-linux-mips64el": "7.0.2",
+        "@typescript/typescript-linux-ppc64": "7.0.2",
+        "@typescript/typescript-linux-riscv64": "7.0.2",
+        "@typescript/typescript-linux-s390x": "7.0.2",
+        "@typescript/typescript-linux-x64": "7.0.2",
+        "@typescript/typescript-netbsd-arm64": "7.0.2",
+        "@typescript/typescript-netbsd-x64": "7.0.2",
+        "@typescript/typescript-openbsd-arm64": "7.0.2",
+        "@typescript/typescript-openbsd-x64": "7.0.2",
+        "@typescript/typescript-sunos-x64": "7.0.2",
+        "@typescript/typescript-win32-arm64": "7.0.2",
+        "@typescript/typescript-win32-x64": "7.0.2"
+      }
+    },
     "node_modules/uc.micro": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
       "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "license": "MIT"
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
       "license": "MIT"
     },
     "node_modules/unicorn-magic": {
@@ -3074,6 +4585,21 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "license": "MIT"
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
     },
     "node_modules/what-input": {
       "version": "5.2.12",
@@ -3114,6 +4640,36 @@
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,8 @@
 {
   "name": "consuldemocracy",
   "dependencies": {
+    "@cosla/sensemaking-tools": "^1.2.0",
+    "@cosla/sensemaking-report-ui": "^0.1.2",
     "@deltablot/dropzone": "^7.4.3",
     "@fortawesome/fontawesome-free": "^6.7.2",
     "@rails/ujs": "^7.1.3-4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,8 @@
 {
   "name": "consuldemocracy",
   "dependencies": {
+    "@cosla/sensemaking-tools": "^1.1.6",
+    "@cosla/sensemaking-report-ui": "^0.1.2",
     "@deltablot/dropzone": "^7.4.3",
     "@fortawesome/fontawesome-free": "^6.7.2",
     "@rails/ujs": "^7.1.3-4",

--- a/spec/components/admin/settings/llm_configuration_tab_component_spec.rb
+++ b/spec/components/admin/settings/llm_configuration_tab_component_spec.rb
@@ -18,9 +18,11 @@ describe Admin::Settings::LlmConfigurationTabComponent do
   let(:provider_setting) { Setting.find_by!(key: "llm.provider") }
   let(:model_setting) { Setting.find_by!(key: "llm.model") }
   let(:feature_setting) { Setting.find_by!(key: "llm.use_llm_for_translations") }
+  let(:sensemaker_setting) { Setting.find_by!(key: "llm.use_sensemaker") }
   let(:provider_select_selector) { "#value_setting_#{provider_setting.id}" }
   let(:model_select_selector) { "#value_setting_#{model_setting.id}" }
   let(:feature_button_selector) { "button[aria-labelledby='title_setting_#{feature_setting.id}']" }
+  let(:sensemaker_button_selector) { "button[aria-labelledby='title_setting_#{sensemaker_setting.id}']" }
 
   before do
     Setting["llm.provider"] = nil
@@ -55,6 +57,12 @@ describe Admin::Settings::LlmConfigurationTabComponent do
         expect(page).to have_content "Content Translation"
         expect(page).to have_content "Use LLM for content translations and take precedence over " \
                                      "Microsoft translation services."
+        expect(page).to have_button "No", disabled: true
+      end
+
+      stub_secrets(sensemaker_data_folder: "vendor/sensemaking-tools/data")
+
+      page.find(sensemaker_button_selector) do
         expect(page).to have_button "No", disabled: true
       end
     end
@@ -101,6 +109,35 @@ describe Admin::Settings::LlmConfigurationTabComponent do
       end
 
       page.find(feature_button_selector) do
+        expect(page).to have_button "No", disabled: false
+      end
+    end
+  end
+
+  describe "sensemaker toggle" do
+    before do
+      Setting["llm.provider"] = "OpenAI"
+      Setting["llm.model"] = "gpt-4o"
+      Setting["llm.use_sensemaker"] = false
+    end
+
+    it "is disabled when sensemaker_data_folder is not configured" do
+      stub_secrets(sensemaker_data_folder: "")
+
+      render_inline component
+
+      page.find(sensemaker_button_selector) do
+        expect(page).to have_content "Sensemaker"
+        expect(page).to have_button "No", disabled: true
+      end
+    end
+
+    it "is enabled when LLM and sensemaker_data_folder are configured" do
+      stub_secrets(sensemaker_data_folder: "vendor/sensemaking-tools/data")
+
+      render_inline component
+
+      page.find(sensemaker_button_selector) do
         expect(page).to have_button "No", disabled: false
       end
     end

--- a/spec/factories/sensemaker/jobs.rb
+++ b/spec/factories/sensemaker/jobs.rb
@@ -1,0 +1,21 @@
+FactoryBot.define do
+  factory :sensemaker_job, class: "Sensemaker::Job" do
+    user
+    script { "categorization_runner.ts" }
+    started_at { Time.current }
+    finished_at { nil }
+    error { nil }
+    analysable_type { "Debate" }
+    analysable_id { create(:debate).id }
+    additional_context { "Test context" }
+    published { true }
+
+    trait :unpublished do
+      published { false }
+    end
+
+    trait :published do
+      published { true }
+    end
+  end
+end

--- a/spec/factories/sensemaker/jobs.rb
+++ b/spec/factories/sensemaker/jobs.rb
@@ -17,5 +17,9 @@ FactoryBot.define do
     trait :published do
       published { true }
     end
+
+    trait :report do
+      script { "sensemaking-report-ui" }
+    end
   end
 end

--- a/spec/lib/conversation_spec.rb
+++ b/spec/lib/conversation_spec.rb
@@ -1,0 +1,513 @@
+require "rails_helper"
+
+HTML_TAGS = %w[<p> <strong> <em> </p>].freeze
+
+describe Conversation do
+  let(:user) { create(:user) }
+
+  def expect_no_html_tags(content, tags = HTML_TAGS)
+    tags.each { |tag| expect(content).not_to include(tag) }
+  end
+
+  shared_examples "rejects non-open-ended Poll::Question" do |method_name|
+    it "raises ArgumentError" do
+      conversation = Conversation.new("Poll::Question", question.id)
+      expect { conversation.send(method_name) }.to raise_error(
+        ArgumentError,
+        /only supported for open-ended Poll::Question/
+      )
+    end
+  end
+
+  describe "#compile_context" do
+    it "can compile context for Poll" do
+      poll = create(:poll)
+
+      3.times do
+        create(:comment, commentable: poll, user: user)
+      end
+
+      conversation = Conversation.new("Poll", poll.id)
+      context_result = conversation.compile_context
+
+      expect(context_result).to be_present
+      expect(context_result).to include("- Comments: #{conversation.comments.size}")
+      expect(conversation.comments.size).to eq(3)
+    end
+
+    it "can compile context for Proposal" do
+      proposal = create(:proposal)
+
+      conversation = Conversation.new("Proposal", proposal.id)
+      context_result = conversation.compile_context
+      expect(context_result).to be_present
+      expect(context_result).to include(
+        "This proposal has #{proposal.total_votes} votes out of #{Proposal.votes_needed_for_success} required"
+      )
+    end
+
+    it "sanitizes HTML from Proposal description and summary" do
+      proposal = create(:proposal,
+                        description: "<p>This is a <strong>description</strong> with <em>HTML</em> tags.</p>",
+                        summary: "<p>This is a <strong>summary</strong>.</p>")
+      conversation = Conversation.new("Proposal", proposal.id)
+      context_result = conversation.compile_context
+
+      expect(context_result).to include("This is a description with HTML tags.")
+      expect(context_result).to include("This is a summary.")
+      expect_no_html_tags(context_result)
+    end
+
+    it "decodes HTML entities like &nbsp; and &#39; from Proposal description" do
+      proposal = create(:proposal,
+                        description: "<p>Tell us what matters to you and share your&nbsp;ideas. " \
+                                     "You&#39;ve seen this before.</p>")
+      conversation = Conversation.new("Proposal", proposal.id)
+      context_result = conversation.compile_context
+
+      expected_text = "Tell us what matters to you and share your ideas. You've seen this before."
+      expect(context_result).to include(expected_text)
+      expect(context_result).not_to include("&nbsp;")
+      expect(context_result).not_to include("&#39;")
+    end
+
+    it "can compile context for Debate" do
+      debate = create(:debate)
+
+      conversation = Conversation.new("Debate", debate.id)
+      context_result = conversation.compile_context
+      expect(context_result).to be_present
+      expect(context_result).to include(
+        "This debate has #{debate.cached_votes_up} votes for and #{debate.cached_votes_down} votes against"
+      )
+    end
+
+    it "sanitizes HTML from Debate description" do
+      debate = create(:debate, description: "<p><strong>How do you feel</strong> about <em>safety</em>?</p>")
+      conversation = Conversation.new("Debate", debate.id)
+      context_result = conversation.compile_context
+
+      expect(context_result).to include("How do you feel about safety?")
+      expect_no_html_tags(context_result)
+    end
+
+    it "decodes HTML entities like &nbsp; from Debate description" do
+      debate = create(:debate,
+                      description: "<p>How do you feel about the overall safety of our community&nbsp; " \
+                                   "and what are your biggest concerns?</p>")
+      conversation = Conversation.new("Debate", debate.id)
+      context_result = conversation.compile_context
+
+      expected_text = "How do you feel about the overall safety of our community and " \
+                      "what are your biggest concerns?"
+      expect(context_result).to include(expected_text)
+      expect(context_result).not_to include("&nbsp;")
+      expect(context_result).not_to include("<p>")
+    end
+
+    it "can compile context for Legislation::Proposal" do
+      proposal = create(:legislation_proposal)
+
+      conversation = Conversation.new("Legislation::Proposal", proposal.id)
+      context_result = conversation.compile_context
+      expect(context_result).to be_present
+      expect(context_result).to include(
+        "This proposal is part of the legislation process, \"#{proposal.process.title}\""
+      )
+    end
+
+    it "can compile context for Legislation::QuestionOption and include filter note" do
+      process = create(:legislation_process)
+      question = create(:legislation_question, process: process)
+      option = create(:legislation_question_option, question: question, value: "Option A")
+
+      conversation = Conversation.new("Legislation::QuestionOption", option.id)
+      context_result = conversation.compile_context
+
+      expect(context_result).to be_present
+      expect(context_result).to include(
+        "This debate is part of the legislation process, \"#{process.title}\""
+      )
+      expect(context_result).to include(
+        "Note: Comments in this analysis are filtered to only include comments from users " \
+        "who selected the option \"Option A\""
+      )
+    end
+
+    it "sanitizes HTML from Legislation::Proposal description and summary" do
+      proposal = create(:legislation_proposal,
+                        description: "<p>Legislation <strong>description</strong> with HTML.</p>",
+                        summary: "<p>Legislation <em>summary</em>.</p>")
+      conversation = Conversation.new("Legislation::Proposal", proposal.id)
+      context_result = conversation.compile_context
+
+      expect(context_result).to include("Legislation description with HTML.")
+      expect(context_result).to include("Legislation summary.")
+      expect_no_html_tags(context_result, %w[<p> <strong> <em>])
+    end
+
+    it "can compile context for Legislation::Question without question options" do
+      question = create(:legislation_question)
+
+      conversation = Conversation.new("Legislation::Question", question.id)
+      context_result = conversation.compile_context
+      expect(context_result).to be_present
+      expect(context_result).to include(
+        "This debate is part of the legislation process, \"#{question.process.title}\""
+      )
+      expect(context_result).not_to include("### Debate Responses")
+    end
+
+    it "sanitizes HTML from Legislation::Question description" do
+      question = create(:legislation_question,
+                        description: "<p>Question <strong>description</strong> with <em>HTML</em>.</p>")
+      conversation = Conversation.new("Legislation::Question", question.id)
+      context_result = conversation.compile_context
+
+      expect(context_result).to include("Question description with HTML.")
+      expect_no_html_tags(context_result, %w[<p> <strong> <em>])
+    end
+
+    it "can compile context for Legislation::Question with question options" do
+      question = create(:legislation_question)
+      2.times do
+        create(:legislation_question_option, question: question)
+      end
+      3.times do
+        create(:legislation_answer, question: question, question_option: question.question_options.sample)
+      end
+
+      conversation = Conversation.new("Legislation::Question", question.id)
+      context_result = conversation.compile_context
+      expect(context_result).to be_present
+      expect(context_result).to include("### Debate Responses")
+      expect(context_result).to include("- #{question.question_options.first.value}")
+      expect(context_result).to include("- #{question.question_options.last.value}")
+    end
+
+    it "can compile context for Budget with investments" do
+      budget = create(:budget)
+
+      3.times do
+        create(:budget_investment, budget: budget)
+      end
+
+      conversation = Conversation.new("Budget", budget.id)
+      context_result = conversation.compile_context
+
+      expect(context_result).to be_present
+      expect(context_result).to include("- Comments: #{conversation.comments.size}")
+      expect(conversation.comments.size).to eq(3)
+    end
+
+    it "can compile context for Budget::Group with investments" do
+      budget = create(:budget)
+      group = create(:budget_group, budget: budget)
+      heading = create(:budget_heading, group: group)
+
+      3.times do
+        create(:budget_investment, heading: heading)
+      end
+
+      conversation = Conversation.new("Budget::Group", group.id)
+      context_result = conversation.compile_context
+
+      expect(context_result).to be_present
+      expect(context_result).to include("- Comments: #{conversation.comments.size}")
+      expect(conversation.comments.size).to eq(3)
+    end
+
+    it "can compile context for all Proposals (collection conversation)" do
+      conversation = Conversation.new("Proposal", nil)
+      context_result = conversation.compile_context
+
+      expect(context_result).to be_present
+      expect(context_result).to include("These are the proposals that have been submitted")
+    end
+
+    it_behaves_like "rejects non-open-ended Poll::Question", :compile_context do
+      let(:poll) { create(:poll) }
+      let(:question) do
+        q = create(:poll_question_unique, poll: poll, title: "Test Question")
+        create(:poll_question_option, question: q, title: "Option 1")
+        create(:poll_question_option, question: q, title: "Option 2")
+        q
+      end
+    end
+
+    it "can compile context for Poll::Question with open-ended question" do
+      poll = create(:poll)
+      question = create(:poll_question_open, poll: poll, title: "Open Question")
+      create(:poll_answer, question: question, answer: "First answer", option: nil)
+      create(:poll_answer, question: question, answer: "Second answer", option: nil)
+
+      conversation = Conversation.new("Poll::Question", question.id)
+      context_result = conversation.compile_context
+
+      expect(context_result).to be_present
+      expect(context_result).to include(
+        "This Poll is composed of 1 question(s). The questions are as follows:"
+      )
+      expect(context_result).to include("Q1 (Open ended): Open Question")
+    end
+  end
+
+  describe "#comments" do
+    describe "avoids filtering out in job run by vote padding" do
+      shared_examples "pads votes by 1" do |expected_votes|
+        it "pads so cached_votes_up and cached_votes_total are #{expected_votes}" do
+          comments = conversation.comments
+          expect(comments.size).to eq(1)
+          expect(comments.first.cached_votes_up).to eq(expected_votes)
+          expect(comments.first.cached_votes_total).to eq(expected_votes)
+        end
+      end
+
+      context "Budget" do
+        let(:budget) { create(:budget) }
+        let(:conversation) { Conversation.new("Budget", budget.id) }
+
+        it_behaves_like "pads votes by 1", 1 do
+          before { create(:budget_investment, budget: budget, cached_votes_up: 0) }
+        end
+
+        it_behaves_like "pads votes by 1", 6 do
+          before { create(:budget_investment, budget: budget, cached_votes_up: 5) }
+        end
+      end
+
+      context "Budget::Group" do
+        let(:budget) { create(:budget) }
+        let(:group) { create(:budget_group, budget: budget) }
+        let(:heading) { create(:budget_heading, group: group) }
+        let(:conversation) { Conversation.new("Budget::Group", group.id) }
+
+        it_behaves_like "pads votes by 1", 1 do
+          before { create(:budget_investment, heading: heading, cached_votes_up: 0) }
+        end
+
+        it_behaves_like "pads votes by 1", 4 do
+          before { create(:budget_investment, heading: heading, cached_votes_up: 3) }
+        end
+      end
+
+      context "Proposal" do
+        let(:conversation) { Conversation.new("Proposal", nil) }
+
+        it_behaves_like "pads votes by 1", 1 do
+          before { create(:proposal, cached_votes_up: 0) }
+        end
+
+        it_behaves_like "pads votes by 1", 11 do
+          before { create(:proposal, cached_votes_up: 10) }
+        end
+      end
+    end
+
+    describe "sanitizes HTML from comment-like items" do
+      it "sanitizes HTML from Budget::Investment description in comments" do
+        budget = create(:budget)
+        create(:budget_investment,
+               budget: budget,
+               title: "Test Investment",
+               description: "<p>Investment <strong>description</strong> with <em>HTML</em> tags.</p>")
+
+        conversation = Conversation.new("Budget", budget.id)
+        comments = conversation.comments
+
+        expect(comments.size).to eq(1)
+        expect(comments.first.body).to include("Test Investment")
+        expect(comments.first.body).to include("Investment description with HTML tags.")
+        expect_no_html_tags(comments.first.body)
+      end
+
+      it "sanitizes HTML from Proposal description in comments" do
+        create(:proposal,
+               title: "Test Proposal",
+               description: "<p>Proposal <strong>description</strong> with <em>HTML</em> tags.</p>")
+
+        conversation = Conversation.new("Proposal", nil)
+        comments = conversation.comments
+
+        expect(comments.size).to eq(1)
+        expect(comments.first.body).to include("Test Proposal")
+        expect(comments.first.body).to include("Proposal description with HTML tags.")
+        expect_no_html_tags(comments.first.body)
+      end
+
+      it "sanitizes HTML from Budget::Group investment description" do
+        budget = create(:budget)
+        group = create(:budget_group, budget: budget)
+        heading = create(:budget_heading, group: group)
+        create(:budget_investment,
+               heading: heading,
+               title: "Group Investment",
+               description: "<p>Group <strong>investment</strong> description.</p>")
+
+        conversation = Conversation.new("Budget::Group", group.id)
+        comments = conversation.comments
+
+        expect(comments.size).to eq(1)
+        expect(comments.first.body).to include("Group Investment")
+        expect(comments.first.body).to include("Group investment description.")
+        expect_no_html_tags(comments.first.body, %w[<p> <strong>])
+      end
+    end
+
+    describe "handles Poll with standard comments" do
+      it "collects standard comments on the poll when poll has only multi-choice questions" do
+        poll = create(:poll)
+        question = create(:poll_question_unique, poll: poll)
+        create(:poll_question_option, question: question)
+        comment1 = create(:comment, commentable: poll, user: user)
+        comment2 = create(:comment, commentable: poll, user: user)
+
+        conversation = Conversation.new("Poll", poll.id)
+        comments = conversation.comments
+
+        expect(comments.size).to eq(2)
+        expect(comments.map(&:id)).to contain_exactly(comment1.id, comment2.id)
+        expect(comments.map(&:body)).to contain_exactly(comment1.body, comment2.body)
+      end
+
+      it "excludes hidden comments" do
+        poll = create(:poll)
+        question = create(:poll_question_unique, poll: poll)
+        create(:poll_question_option, question: question)
+        visible_comment = create(:comment, commentable: poll, user: user)
+        create(:comment, commentable: poll, user: user, hidden_at: Time.current)
+
+        conversation = Conversation.new("Poll", poll.id)
+        comments = conversation.comments
+
+        expect(comments.size).to eq(1)
+        expect(comments.first.id).to eq(visible_comment.id)
+      end
+    end
+
+    describe "handles Poll with open-ended questions (combined answers)" do
+      it "combines all answers from a user across all questions" do
+        poll = create(:poll)
+        user1 = create(:user)
+        user2 = create(:user)
+
+        question1 = create(:poll_question_unique, poll: poll, title: "What is your favourite cake?")
+        option1a = create(:poll_question_option, question: question1, title: "Chocolate")
+        option1b = create(:poll_question_option, question: question1, title: "Vanilla")
+        create(:poll_answer, question: question1, option: option1a, author: user1)
+        create(:poll_answer, question: question1, option: option1b, author: user2)
+
+        question2 = create(:poll_question_open, poll: poll, title: "What occasion should we have cake?")
+        create(:poll_answer, question: question2, answer: "Christmas and birthdays", option: nil,
+                             author: user1)
+        create(:poll_answer, question: question2, answer: "Every day", option: nil, author: user2)
+
+        conversation = Conversation.new("Poll", poll.id)
+        comments = conversation.comments
+
+        expect(comments.size).to eq(2)
+        user1_comment = comments.find { |c| c.user_id == user1.id }
+        user2_comment = comments.find { |c| c.user_id == user2.id }
+
+        expect(user1_comment.body).to eq("Q1: Chocolate | Q2: Christmas and birthdays")
+        expect(user2_comment.body).to eq("Q1: Vanilla | Q2: Every day")
+        expect(user1_comment.cached_votes_up).to eq(1)
+        expect(user1_comment.cached_votes_total).to eq(1)
+      end
+
+      it "handles multiple choice questions with multiple selections" do
+        poll = create(:poll)
+        user1 = create(:user)
+
+        question1 = create(:poll_question_multiple, poll: poll, title: "What times should we have cake?")
+        option1a = create(:poll_question_option, question: question1, title: "Morning")
+        option1b = create(:poll_question_option, question: question1, title: "Afternoon")
+        create(:poll_question_option, question: question1, title: "Evening")
+        create(:poll_answer, question: question1, option: option1a, author: user1)
+        create(:poll_answer, question: question1, option: option1b, author: user1)
+
+        question2 = create(:poll_question_open, poll: poll, title: "What other feedback?")
+        create(:poll_answer, question: question2, answer: "More cake please", option: nil, author: user1)
+
+        conversation = Conversation.new("Poll", poll.id)
+        comments = conversation.comments
+
+        expect(comments.size).to eq(1)
+        expect(comments.first.body).to eq("Q1: Morning, Afternoon | Q2: More cake please")
+      end
+
+      it "handles users who haven't answered all questions" do
+        poll = create(:poll)
+        user1 = create(:user)
+        user2 = create(:user)
+
+        question1 = create(:poll_question_unique, poll: poll, title: "Question 1")
+        option1 = create(:poll_question_option, question: question1, title: "Option A")
+        create(:poll_answer, question: question1, option: option1, author: user1)
+        create(:poll_answer, question: question1, option: option1, author: user2)
+
+        question2 = create(:poll_question_open, poll: poll, title: "Question 2")
+        create(:poll_answer, question: question2, answer: "Answer from user1", option: nil, author: user1)
+
+        conversation = Conversation.new("Poll", poll.id)
+        comments = conversation.comments
+
+        expect(comments.size).to eq(2)
+        user1_comment = comments.find { |c| c.user_id == user1.id }
+        user2_comment = comments.find { |c| c.user_id == user2.id }
+
+        expect(user1_comment.body).to eq("Q1: Option A | Q2: Answer from user1")
+        expect(user2_comment.body).to eq("Q1: Option A")
+      end
+
+      it "only includes users who have at least one answer" do
+        poll = create(:poll)
+        user_with_answer = create(:user)
+        create(:user)
+
+        question1 = create(:poll_question_open, poll: poll, title: "Question 1")
+        create(:poll_answer, question: question1, answer: "Some answer", option: nil,
+                             author: user_with_answer)
+
+        conversation = Conversation.new("Poll", poll.id)
+        comments = conversation.comments
+
+        expect(comments.size).to eq(1)
+        expect(comments.first.user_id).to eq(user_with_answer.id)
+      end
+    end
+
+    describe "handles Poll::Question directly" do
+      it_behaves_like "rejects non-open-ended Poll::Question", :comments do
+        let(:poll) { create(:poll) }
+        let(:question) do
+          q = create(:poll_question_unique, poll: poll, title: "Single Question")
+          create(:poll_question_option, question: q, title: "Yes")
+          q
+        end
+      end
+
+      it_behaves_like "rejects non-open-ended Poll::Question", :comments do
+        let(:poll) { create(:poll) }
+        let(:question) do
+          q = create(:poll_question_multiple, poll: poll, title: "Multiple Question")
+          create(:poll_question_option, question: q, title: "Option A")
+          q
+        end
+      end
+
+      it "handles single open-ended question" do
+        poll = create(:poll)
+        question = create(:poll_question_open, poll: poll, title: "Open Question")
+        answer = create(:poll_answer, question: question, answer: "My answer", option: nil)
+
+        conversation = Conversation.new("Poll::Question", question.id)
+        comments = conversation.comments
+
+        expect(comments.size).to eq(1)
+        expect(comments.first.id).to eq("a_#{answer.id}")
+        expect(comments.first.body).to eq("My answer")
+      end
+    end
+  end
+end

--- a/spec/lib/sensemaker/backend/node_spec.rb
+++ b/spec/lib/sensemaker/backend/node_spec.rb
@@ -1,0 +1,267 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe Sensemaker::Backend::Node do
+  include_context "sensemaker llm config"
+
+  let(:user) { create(:user) }
+  let(:runtime_config) do
+    Sensemaker::RuntimeConfig.new(setting: Setting, llm_context: Llm::Config.context)
+  end
+  let(:backend) do
+    Sensemaker::Backend::Node.new(job, runtime_config: runtime_config)
+  end
+  let(:debate) { create(:debate) }
+  let(:job) do
+    create(:sensemaker_job,
+           analysable_type: "Debate",
+           analysable_id: debate.id,
+           script: "categorization_runner.ts",
+           user: user,
+           started_at: Time.current,
+           additional_context: "")
+  end
+
+  describe "#build_command" do
+    before do
+      allow(Llm::Config).to receive(:context).and_return(llm_context)
+      allow(Setting).to receive(:[]).and_call_original
+      allow(Setting).to receive(:[]).with("llm.provider").and_return("VertexAI")
+      allow(Setting).to receive(:[]).with("llm.model").and_return("gemini-2.5-flash-lite")
+    end
+
+    shared_examples "runner command with common flags" do |script_name, use_output_file_flag: true|
+      it "returns the correct command for #{script_name}" do
+        job.script = script_name
+        command = backend.build_command
+        expect(command).to include("npx ts-node #{backend.script_path}")
+        expect(command).to include("--adapter vertex")
+        expect(command).to include("--vertexProject sensemaker-466109")
+        expect(command).to include("--vertexLocation global")
+        expect(command).to include("--modelName gemini-2.5-flash-lite")
+        expect(command).not_to include("--keyFilename")
+        expect(command).not_to include("--baseUrl")
+        expect(command).to include("--inputFile #{job.artefacts.input_path}")
+        if use_output_file_flag
+          expect(command).to include("--outputFile #{backend.send(:output_file)}")
+        else
+          expect(command).not_to include("--outputFile")
+          expect(command).to include("--outputBasename #{backend.send(:output_file)}")
+        end
+      end
+    end
+
+    it_behaves_like "runner command with common flags", "categorization_runner.ts", use_output_file_flag: true
+    it_behaves_like "runner command with common flags", "advanced_runner.ts", use_output_file_flag: false
+    it_behaves_like "runner command with common flags", "runner.ts", use_output_file_flag: false
+
+    it "returns the correct command for OpenAI-compatible providers" do
+      allow(Setting).to receive(:[]).with("llm.provider").and_return("OpenAI")
+
+      command = backend.build_command
+      expect(command).to include("--adapter openai-compatible")
+      expect(command).to include("--provider openai")
+      expect(command).to include("--apiKey openai-secret")
+      expect(command).to include("--baseUrl https://openai-proxy.example.com/v1")
+      expect(command).not_to include("--vertexProject")
+      expect(command).not_to include("--vertexLocation")
+    end
+
+    it "omits baseUrl for OpenAI-compatible providers when not configured" do
+      allow(Setting).to receive(:[]).with("llm.provider").and_return("OpenAI")
+      allow(llm_config).to receive(:openai_api_base).and_return(nil)
+
+      command = backend.build_command
+      expect(command).not_to include("--baseUrl")
+    end
+
+    it "returns the correct command for ollama provider" do
+      allow(Setting).to receive(:[]).with("llm.provider").and_return("ollama")
+
+      command = backend.build_command
+      expect(command).to include("--adapter ollama")
+      expect(command).to include("--baseUrl http://localhost:11434")
+      expect(command).not_to include("--provider")
+      expect(command).not_to include("--apiKey")
+      expect(command).not_to include("--vertexProject")
+    end
+
+    it "returns the correct command for the sensemaking-report-ui script" do
+      job.update!(script: "sensemaking-report-ui")
+      conversation = instance_double(Sensemaker::Conversation)
+      allow(job).to receive(:conversation).and_return(conversation)
+      allow(conversation).to receive(:target_label).with(format: :full).and_return("Test Label")
+
+      command = backend.build_command
+      input_path = job.artefacts.input_path
+
+      expect(command).to include("npx sensemaking-report-ui inline")
+      expect(command).to include("--topics")
+      expect(command).to include("#{input_path}-topic-stats.json")
+      expect(command).to include("--summary")
+      expect(command).to include("#{input_path}-summary.json")
+      expect(command).to include("--comments")
+      expect(command).to include("#{input_path}-comments-with-scores.json")
+      expect(command).to include("--metadata")
+      expect(command).to include(job.artefacts.metadata_path)
+      expect(command).to include(Shellwords.escape("Report for Test Label"))
+      expect(command).to include("--outputDir #{Shellwords.escape(job.artefacts.job_directory.to_s)}")
+      expect(command).to include("--outputFile")
+      expect(command).to include("report.html")
+      expect(backend.output_file_name).to eq("report.html")
+    end
+  end
+
+  describe "#script_path" do
+    package_folder = Sensemaker::Paths.sensemaker_package_folder
+    runner_cli = "#{package_folder}/runner-cli"
+    report_ui = "/tmp/sensemaker_test_folder/report-ui"
+
+    before do
+      allow(Sensemaker::Paths).to receive(:report_ui_folder).and_return(report_ui)
+    end
+
+    {
+      "categorization_runner.ts" => "#{runner_cli}/categorization_runner.ts",
+      "runner.ts" => "#{runner_cli}/runner.ts",
+      "advanced_runner.ts" => "#{runner_cli}/advanced_runner.ts",
+      "health_check_runner.ts" => "#{runner_cli}/health_check_runner.ts",
+      "sensemaking-report-ui" => "#{report_ui}/bin/cli.js"
+    }.each do |script, expected_path|
+      it "returns the correct path for #{script}" do
+        job.script = script
+        expect(backend.script_path).to eq(expected_path)
+      end
+    end
+  end
+
+  describe "#check_runtime_dependencies?" do
+    before do
+      allow(backend).to receive(:system).with("which node > /dev/null 2>&1").and_return(true)
+      allow(backend).to receive(:system).with("which npx > /dev/null 2>&1").and_return(true)
+      allow(File).to receive(:exist?).and_return(true)
+    end
+
+    it "returns true when all runtime dependencies are available" do
+      expect(backend.check_runtime_dependencies?).to be true
+    end
+
+    {
+      "Node.js is not available" => [
+        -> { allow(backend).to receive(:system).with("which node > /dev/null 2>&1").and_return(false) },
+        "Node.js not found"
+      ],
+      "NPX is not available" => [
+        -> { allow(backend).to receive(:system).with("which npx > /dev/null 2>&1").and_return(false) },
+        "NPX not found"
+      ],
+      "the sensemaking-tools package folder does not exist" => [
+        -> {
+          allow(File).to receive(:exist?).with(Sensemaker::Paths.sensemaker_package_folder).and_return(false)
+        },
+        "sensemaking-tools package folder not found"
+      ],
+      "the sensemaking data folder does not exist" => [
+        -> {
+          allow(File).to receive(:exist?).with(Sensemaker::Paths.sensemaker_data_folder).and_return(false)
+        },
+        "Sensemaker data folder not found"
+      ],
+      "the input file does not exist" => [
+        -> {
+          allow(File).to receive(:exist?).with(Sensemaker::Paths.sensemaker_package_folder).and_return(true)
+          allow(File).to receive(:exist?).with(job.artefacts.input_path).and_return(false)
+        },
+        "Input file not found"
+      ],
+      "the script file does not exist" => [
+        -> {
+          allow(File).to receive(:exist?).with(Sensemaker::Paths.sensemaker_package_folder).and_return(true)
+          allow(File).to receive(:exist?).with(job.artefacts.input_path).and_return(true)
+          allow(File).to receive(:exist?).with(backend.script_path).and_return(false)
+        },
+        "Script file not found"
+      ]
+    }.each do |description, (setup, error_substring)|
+      it "returns false when #{description}" do
+        instance_exec(&setup)
+        result = backend.check_runtime_dependencies?
+        expect(result).to be false
+        job.reload
+        expect(job.finished_at).to be_present
+        expect(job.error).to include(error_substring)
+      end
+    end
+  end
+
+  describe "#working_directory" do
+    it "returns the sensemaker package folder for runner scripts" do
+      expect(backend.working_directory).to eq(Sensemaker::Paths.sensemaker_package_folder)
+    end
+
+    it "returns Rails.root for the report-ui script" do
+      job.update!(script: "sensemaking-report-ui")
+      expect(backend.working_directory).to eq(Rails.root)
+    end
+  end
+
+  describe "#after_input_prepared" do
+    it "returns nil for standard runner scripts" do
+      job.script = "categorization_runner.ts"
+      expect(backend.after_input_prepared).to be(nil)
+    end
+
+    context "when script is advanced_runner.ts" do
+      before do
+        job.script = "advanced_runner.ts"
+        job.input_file = "/tmp/categorization-output.csv"
+        allow(File).to receive(:exist?).and_call_original
+        allow(File).to receive(:exist?).with(job.artefacts.input_path).and_return(true)
+      end
+
+      it "calls provide_defaults_for_zero_vote_comments" do
+        expect(Sensemaker::CsvExporter).to receive(:provide_defaults_for_zero_vote_comments)
+          .with(job.artefacts.input_path).and_return(3)
+        expect(backend.after_input_prepared).to eq(3)
+      end
+    end
+
+    context "when script is sensemaking-report-ui" do
+      before do
+        job.update!(script: "sensemaking-report-ui")
+        conversation = instance_double(Sensemaker::Conversation)
+        allow(job).to receive(:conversation).and_return(conversation)
+        allow(conversation).to receive(:target_label).with(format: :full).and_return("Test Label")
+      end
+
+      it "writes report metadata when file does not exist" do
+        allow(File).to receive(:exist?).and_call_original
+        allow(File).to receive(:exist?).with(job.artefacts.metadata_path).and_return(false)
+        allow(File).to receive(:write)
+
+        backend.after_input_prepared
+
+        expect(File).to have_received(:write).with(job.artefacts.metadata_path, anything)
+      end
+
+      it "skips writing metadata when file already exists" do
+        allow(File).to receive(:exist?).and_call_original
+        allow(File).to receive(:exist?).with(job.artefacts.metadata_path).and_return(true)
+        allow(File).to receive(:write)
+
+        backend.after_input_prepared
+
+        expect(File).not_to have_received(:write)
+      end
+    end
+  end
+
+  describe "#redact_command" do
+    it "redacts api keys in commands" do
+      command = "npx ts-node script.ts --apiKey super-secret-key"
+      expect(backend.redact_command(command)).to include("--apiKey [REDACTED]")
+      expect(backend.redact_command(command)).not_to include("super-secret-key")
+    end
+  end
+end

--- a/spec/lib/sensemaker/csv_exporter_spec.rb
+++ b/spec/lib/sensemaker/csv_exporter_spec.rb
@@ -1,0 +1,181 @@
+require "rails_helper"
+
+describe Sensemaker::CsvExporter do
+  let(:commentable) { create(:debate) }
+  let(:conversation) { Sensemaker::Conversation.new("Debate", commentable.id) }
+  let(:csv_exporter) { Sensemaker::CsvExporter.new(conversation) }
+
+  describe "#export_to_csv" do
+    it "exports the comments to a CSV file" do
+      expect(csv_exporter.export_to_csv).to be_present
+    end
+
+    it "exports to the specified file path" do
+      file_path = "/tmp/test-export.csv"
+      result = csv_exporter.export_to_csv(file_path)
+      expect(result).to eq(file_path)
+      expect(File.exist?(file_path)).to be true
+    end
+
+    it "includes comment data in the CSV" do
+      create(:comment, commentable: commentable, body: "Test comment")
+      file_path = "/tmp/test-export.csv"
+
+      csv_exporter.export_to_csv(file_path)
+      csv_content = File.read(file_path)
+
+      expect(csv_content).to include("Test comment")
+      expect(csv_content).to include(Sensemaker::CsvExporter::EXPORT_HEADERS.to_csv.chomp)
+    end
+  end
+
+  describe "#export_to_string" do
+    it "exports the comments to a CSV string" do
+      create(:comment, commentable: commentable, body: "Test comment")
+      result = csv_exporter.export_to_string
+
+      expect(result).to include("Test comment")
+      expect(result).to include(Sensemaker::CsvExporter::EXPORT_HEADERS.to_csv.chomp)
+    end
+  end
+
+  describe ".provide_defaults_for_zero_vote_comments" do
+    let(:csv_file_path) { "/tmp/test-categorization-output.csv" }
+    let(:temp_csv_file) { Tempfile.new(["test-categorization-output", ".csv"]) }
+    let(:csv_header) { "comment-id,comment_text,agrees,disagrees,passes,author-id,topics\n" }
+    let(:expected_headers) { %w[comment-id comment_text agrees disagrees passes author-id topics] }
+
+    def with_temp_csv(*lines)
+      temp = Tempfile.new(["test-csv", ".csv"])
+      lines.each { |line| temp.write(line) }
+      temp.close
+      FileUtils.cp(temp.path, csv_file_path)
+      yield
+    ensure
+      temp&.unlink
+    end
+
+    def read_csv
+      CSV.read(csv_file_path, headers: true)
+    end
+
+    before do
+      temp_csv_file.write(csv_header)
+      temp_csv_file.write("comment_1,First comment,5,2,1,user_1,Transportation:PublicTransit\n")
+      temp_csv_file.write("comment_2,Second comment,0,0,0,user_2,Transportation:Parking\n")
+      temp_csv_file.write("comment_3,Third comment,3,0,0,user_3,Technology:Internet\n")
+      temp_csv_file.write("comment_4,Fourth comment,0,4,0,user_4,Transportation:Cycling\n")
+      temp_csv_file.write("comment_5,Fifth comment,0,0,2,user_5,Technology:Mobile\n")
+      temp_csv_file.write("comment_6,Sixth comment,0,0,0,user_6,Transportation:Walking\n")
+      temp_csv_file.close
+
+      FileUtils.cp(temp_csv_file.path, csv_file_path)
+    end
+
+    after do
+      temp_csv_file.unlink
+      FileUtils.rm_f(csv_file_path)
+      FileUtils.rm_f("#{csv_file_path}.unfiltered")
+    end
+
+    it "preserves all columns" do
+      Sensemaker::CsvExporter.provide_defaults_for_zero_vote_comments(csv_file_path)
+
+      expect(read_csv.first.headers).to include(*expected_headers)
+    end
+
+    it "preserves the topics column from categorization" do
+      Sensemaker::CsvExporter.provide_defaults_for_zero_vote_comments(csv_file_path)
+
+      topics = read_csv.map { |row| row["topics"] }
+
+      expect(topics).to include("Transportation:PublicTransit", "Technology:Internet",
+                                "Transportation:Cycling", "Technology:Mobile")
+    end
+
+    it "keeps all rows and sets passes to 1 for zero-vote rows" do
+      with_temp_csv(
+        csv_header,
+        "comment_pass,Pass only,0,0,1,user_1,Transportation:PublicTransit\n",
+        "comment_disagree,Disagree only,0,2,0,user_1,Transportation:PublicTransit\n",
+        "comment_zero,Zero votes,0,0,0,user_2,Transportation:Parking\n"
+      ) do
+        comments_count = Sensemaker::CsvExporter.provide_defaults_for_zero_vote_comments(csv_file_path)
+
+        data = read_csv
+        expect(data.length).to eq(3)
+        expect(comments_count).to eq(3)
+
+        zero_row = data.find { |row| row["comment-id"] == "comment_zero" }
+        expect(zero_row["passes"]).to eq("1")
+        expect(zero_row["agrees"]).to eq("0")
+        expect(zero_row["disagrees"]).to eq("0")
+
+        pass_row = data.find { |row| row["comment-id"] == "comment_pass" }
+        expect(pass_row["passes"]).to eq("1")
+      end
+    end
+
+    it "handles empty CSV files gracefully" do
+      with_temp_csv(csv_header) do
+        expect do
+          Sensemaker::CsvExporter.provide_defaults_for_zero_vote_comments(csv_file_path)
+        end.not_to raise_error
+
+        expect(read_csv.length).to eq(0)
+      end
+    end
+
+    it "returns early if the CSV file does not exist" do
+      non_existent_file = "/tmp/non-existent-file.csv"
+
+      expect(File).to receive(:exist?).with(non_existent_file).and_return(false)
+      expect(CSV).not_to receive(:foreach)
+
+      Sensemaker::CsvExporter.provide_defaults_for_zero_vote_comments(non_existent_file)
+    end
+
+    it "creates an unfiltered backup when defaults are applied" do
+      Sensemaker::CsvExporter.provide_defaults_for_zero_vote_comments(csv_file_path)
+
+      expect(File.exist?("#{csv_file_path}.unfiltered")).to be true
+
+      unfiltered_data = CSV.read("#{csv_file_path}.unfiltered", headers: true)
+      expect(unfiltered_data.length).to eq(6)
+
+      data = read_csv
+      expect(data.length).to eq(6)
+      zero_vote_passes = data.select { |row| %w[comment_2 comment_6].include?(row["comment-id"]) }
+                             .map { |row| row["passes"] }
+      expect(zero_vote_passes).to all(eq("1"))
+    end
+
+    it "does not create an unfiltered backup when no defaults are required" do
+      with_temp_csv(
+        csv_header,
+        "comment_1,First comment,5,2,1,user_1,Transportation:PublicTransit\n",
+        "comment_2,Second comment,0,3,0,user_2,Transportation:Parking\n",
+        "comment_3,Third comment,3,0,0,user_3,Technology:Internet\n"
+      ) do
+        Sensemaker::CsvExporter.provide_defaults_for_zero_vote_comments(csv_file_path)
+
+        expect(File.exist?("#{csv_file_path}.unfiltered")).to be false
+      end
+    end
+
+    it "handles missing vote columns by defaulting passes to 1" do
+      with_temp_csv(
+        "comment-id,comment_text,author-id,topics\n",
+        "comment_1,First comment,user_1,Transportation:PublicTransit\n",
+        "comment_2,Second comment,user_2,Transportation:Parking\n"
+      ) do
+        comments_count = Sensemaker::CsvExporter.provide_defaults_for_zero_vote_comments(csv_file_path)
+
+        data = read_csv
+        expect(comments_count).to eq(2)
+        expect(data.length).to eq(2)
+        expect(data.map { |row| row["passes"] }).to all(eq("1"))
+      end
+    end
+  end
+end

--- a/spec/lib/sensemaker/csv_exporter_spec.rb
+++ b/spec/lib/sensemaker/csv_exporter_spec.rb
@@ -1,0 +1,181 @@
+require "rails_helper"
+
+describe Sensemaker::CsvExporter do
+  let(:commentable) { create(:debate) }
+  let(:conversation) { Sensemaker::Conversation.new("Debate", commentable.id) }
+  let(:csv_exporter) { Sensemaker::CsvExporter.new(conversation) }
+
+  describe "#export_to_csv" do
+    it "exports the comments to a CSV file" do
+      expect(csv_exporter.export_to_csv).to be_present
+    end
+
+    it "exports to the specified file path" do
+      file_path = "/tmp/test-export.csv"
+      result = csv_exporter.export_to_csv(file_path)
+      expect(result).to eq(file_path)
+      expect(File.exist?(file_path)).to be true
+    end
+
+    it "includes comment data in the CSV" do
+      create(:comment, commentable: commentable, body: "Test comment")
+      file_path = "/tmp/test-export.csv"
+
+      csv_exporter.export_to_csv(file_path)
+      csv_content = File.read(file_path)
+
+      expect(csv_content).to include("Test comment")
+      expect(csv_content).to include(Sensemaker::CsvExporter::EXPORT_HEADERS.to_csv.chomp)
+    end
+  end
+
+  describe "#export_to_string" do
+    it "exports the comments to a CSV string" do
+      create(:comment, commentable: commentable, body: "Test comment")
+      result = csv_exporter.export_to_string
+
+      expect(result).to include("Test comment")
+      expect(result).to include(Sensemaker::CsvExporter::EXPORT_HEADERS.to_csv.chomp)
+    end
+  end
+
+  describe ".provide_defaults_for_zero_vote_comments" do
+    let(:csv_file_path) { "/tmp/test-categorization-output.csv" }
+    let(:temp_csv_file) { Tempfile.new(["test-categorization-output", ".csv"]) }
+    let(:csv_header) { "participant_id,survey_text,agrees,disagrees,passes,author-id,topics\n" }
+    let(:expected_headers) { %w[participant_id survey_text agrees disagrees passes author-id topics] }
+
+    def with_temp_csv(*lines)
+      temp = Tempfile.new(["test-csv", ".csv"])
+      lines.each { |line| temp.write(line) }
+      temp.close
+      FileUtils.cp(temp.path, csv_file_path)
+      yield
+    ensure
+      temp&.unlink
+    end
+
+    def read_csv
+      CSV.read(csv_file_path, headers: true)
+    end
+
+    before do
+      temp_csv_file.write(csv_header)
+      temp_csv_file.write("comment_1,First comment,5,2,1,user_1,Transportation:PublicTransit\n")
+      temp_csv_file.write("comment_2,Second comment,0,0,0,user_2,Transportation:Parking\n")
+      temp_csv_file.write("comment_3,Third comment,3,0,0,user_3,Technology:Internet\n")
+      temp_csv_file.write("comment_4,Fourth comment,0,4,0,user_4,Transportation:Cycling\n")
+      temp_csv_file.write("comment_5,Fifth comment,0,0,2,user_5,Technology:Mobile\n")
+      temp_csv_file.write("comment_6,Sixth comment,0,0,0,user_6,Transportation:Walking\n")
+      temp_csv_file.close
+
+      FileUtils.cp(temp_csv_file.path, csv_file_path)
+    end
+
+    after do
+      temp_csv_file.unlink
+      FileUtils.rm_f(csv_file_path)
+      FileUtils.rm_f("#{csv_file_path}.unfiltered")
+    end
+
+    it "preserves all columns" do
+      Sensemaker::CsvExporter.provide_defaults_for_zero_vote_comments(csv_file_path)
+
+      expect(read_csv.first.headers).to include(*expected_headers)
+    end
+
+    it "preserves the topics column from categorization" do
+      Sensemaker::CsvExporter.provide_defaults_for_zero_vote_comments(csv_file_path)
+
+      topics = read_csv.map { |row| row["topics"] }
+
+      expect(topics).to include("Transportation:PublicTransit", "Technology:Internet",
+                                "Transportation:Cycling", "Technology:Mobile")
+    end
+
+    it "keeps all rows and sets passes to 1 for zero-vote rows" do
+      with_temp_csv(
+        csv_header,
+        "comment_pass,Pass only,0,0,1,user_1,Transportation:PublicTransit\n",
+        "comment_disagree,Disagree only,0,2,0,user_1,Transportation:PublicTransit\n",
+        "comment_zero,Zero votes,0,0,0,user_2,Transportation:Parking\n"
+      ) do
+        comments_count = Sensemaker::CsvExporter.provide_defaults_for_zero_vote_comments(csv_file_path)
+
+        data = read_csv
+        expect(data.length).to eq(3)
+        expect(comments_count).to eq(3)
+
+        zero_row = data.find { |row| row["participant_id"] == "comment_zero" }
+        expect(zero_row["passes"]).to eq("1")
+        expect(zero_row["agrees"]).to eq("0")
+        expect(zero_row["disagrees"]).to eq("0")
+
+        pass_row = data.find { |row| row["participant_id"] == "comment_pass" }
+        expect(pass_row["passes"]).to eq("1")
+      end
+    end
+
+    it "handles empty CSV files gracefully" do
+      with_temp_csv(csv_header) do
+        expect do
+          Sensemaker::CsvExporter.provide_defaults_for_zero_vote_comments(csv_file_path)
+        end.not_to raise_error
+
+        expect(read_csv.length).to eq(0)
+      end
+    end
+
+    it "returns early if the CSV file does not exist" do
+      non_existent_file = "/tmp/non-existent-file.csv"
+
+      expect(File).to receive(:exist?).with(non_existent_file).and_return(false)
+      expect(CSV).not_to receive(:foreach)
+
+      Sensemaker::CsvExporter.provide_defaults_for_zero_vote_comments(non_existent_file)
+    end
+
+    it "creates an unfiltered backup when defaults are applied" do
+      Sensemaker::CsvExporter.provide_defaults_for_zero_vote_comments(csv_file_path)
+
+      expect(File.exist?("#{csv_file_path}.unfiltered")).to be true
+
+      unfiltered_data = CSV.read("#{csv_file_path}.unfiltered", headers: true)
+      expect(unfiltered_data.length).to eq(6)
+
+      data = read_csv
+      expect(data.length).to eq(6)
+      zero_vote_passes = data.select { |row| %w[comment_2 comment_6].include?(row["participant_id"]) }
+                             .map { |row| row["passes"] }
+      expect(zero_vote_passes).to all(eq("1"))
+    end
+
+    it "does not create an unfiltered backup when no defaults are required" do
+      with_temp_csv(
+        csv_header,
+        "comment_1,First comment,5,2,1,user_1,Transportation:PublicTransit\n",
+        "comment_2,Second comment,0,3,0,user_2,Transportation:Parking\n",
+        "comment_3,Third comment,3,0,0,user_3,Technology:Internet\n"
+      ) do
+        Sensemaker::CsvExporter.provide_defaults_for_zero_vote_comments(csv_file_path)
+
+        expect(File.exist?("#{csv_file_path}.unfiltered")).to be false
+      end
+    end
+
+    it "handles missing vote columns by defaulting passes to 1" do
+      with_temp_csv(
+        "participant_id,survey_text,author-id,topics\n",
+        "comment_1,First comment,user_1,Transportation:PublicTransit\n",
+        "comment_2,Second comment,user_2,Transportation:Parking\n"
+      ) do
+        comments_count = Sensemaker::CsvExporter.provide_defaults_for_zero_vote_comments(csv_file_path)
+
+        data = read_csv
+        expect(comments_count).to eq(2)
+        expect(data.length).to eq(2)
+        expect(data.map { |row| row["passes"] }).to all(eq("1"))
+      end
+    end
+  end
+end

--- a/spec/lib/sensemaker/job_artefacts_spec.rb
+++ b/spec/lib/sensemaker/job_artefacts_spec.rb
@@ -1,0 +1,445 @@
+require "rails_helper"
+
+describe Sensemaker::JobArtefacts do
+  let(:user) { create(:user) }
+  let(:debate) { create(:debate) }
+  let(:job) do
+    create(:sensemaker_job,
+           analysable_type: "Debate",
+           analysable_id: debate.id,
+           script: "categorization_runner.ts",
+           user: user,
+           started_at: Time.current,
+           additional_context: "Test context")
+  end
+  let(:artefacts) { Sensemaker::JobArtefacts.new(job) }
+
+  shared_context "sensemaker paths stubbed" do
+    let(:data_folder) { "/tmp/sensemaker_test_folder/data" }
+
+    before do
+      allow(Sensemaker::Paths).to receive(:sensemaker_data_folder).and_return(data_folder)
+    end
+  end
+
+  describe "#output_file_name" do
+    {
+      "categorization_runner.ts" => ->(j) { "categorization-output-#{j.id}.csv" },
+      "advanced_runner.ts" => ->(j) { "output-#{j.id}" },
+      "runner.ts" => ->(j) { "output-#{j.id}" },
+      "health_check_runner.ts" => ->(j) { "health-check-#{j.id}.txt" },
+      "sensemaking-report-ui" => ->(j) { "report-#{j.id}.html" }
+    }.each do |script, expected_fn|
+      it "returns the correct output file name for #{script}" do
+        job.script = script
+        expect(artefacts.output_file_name).to eq(expected_fn.call(job))
+      end
+    end
+
+    it "falls back for unknown scripts" do
+      job.script = "unknown_runner.ts"
+      expect(artefacts.output_file_name).to eq("output-#{job.id}.csv")
+    end
+  end
+
+  describe "#multiple_outputs?" do
+    it "returns true for advanced_runner.ts and runner.ts" do
+      job.script = "advanced_runner.ts"
+      expect(artefacts.multiple_outputs?).to be true
+      job.script = "runner.ts"
+      expect(artefacts.multiple_outputs?).to be true
+    end
+
+    it "returns false for single output scripts" do
+      job.script = "categorization_runner.ts"
+      expect(artefacts.multiple_outputs?).to be false
+      job.script = "health_check_runner.ts"
+      expect(artefacts.multiple_outputs?).to be false
+      job.script = "sensemaking-report-ui"
+      expect(artefacts.multiple_outputs?).to be false
+    end
+  end
+
+  describe "#default_output_path" do
+    include_context "sensemaker paths stubbed"
+
+    {
+      "categorization_runner.ts" => ->(j, df) { "#{df}/categorization-output-#{j.id}.csv" },
+      "advanced_runner.ts" => ->(j, df) { "#{df}/output-#{j.id}" },
+      "runner.ts" => ->(j, df) { "#{df}/output-#{j.id}" }
+    }.each do |script, expected_path_fn|
+      it "returns the correct path for #{script}" do
+        job.script = script
+        expect(artefacts.default_output_path).to eq(expected_path_fn.call(job, data_folder))
+      end
+    end
+  end
+
+  describe "#relative_output_path" do
+    let(:relative_data_folder) { "tmp/sensemaker_test_folder/data" }
+
+    before do
+      allow(Sensemaker::Paths).to receive(:sensemaker_relative_data_folder).and_return(relative_data_folder)
+    end
+
+    it "returns a path relative to Rails.root (no leading slash)" do
+      job.script = "categorization_runner.ts"
+      path = artefacts.relative_output_path
+      expect(path).to eq("#{relative_data_folder}/categorization-output-#{job.id}.csv")
+      expect(path).not_to start_with("/")
+    end
+
+    {
+      "advanced_runner.ts" => ->(j, rel_df) { "#{rel_df}/output-#{j.id}" },
+      "sensemaking-report-ui" => ->(j, rel_df) { "#{rel_df}/report-#{j.id}.html" }
+    }.each do |script, expected_path_fn|
+      it "returns the correct relative path for #{script}" do
+        job.script = script
+        expect(artefacts.relative_output_path).to eq(expected_path_fn.call(job, relative_data_folder))
+      end
+    end
+  end
+
+  describe "#persisted_output_path" do
+    [nil, ""].each do |blank_value|
+      it "returns nil when persisted_output is #{blank_value.inspect}" do
+        job.persisted_output = blank_value
+        expect(artefacts.persisted_output_path).to be(nil)
+      end
+    end
+
+    it "resolves relative persisted_output against Rails.root so path survives deploys" do
+      relative_path = "tmp/sensemaker_test_folder/data/output-60"
+      job.persisted_output = relative_path
+      expect(artefacts.persisted_output_path).to eq(Rails.root.join(relative_path))
+      expect(artefacts.persisted_output_path.to_s).to include(Rails.root.to_s)
+    end
+  end
+
+  describe "#output_artefact_paths" do
+    include_context "sensemaker paths stubbed"
+    let(:base_path) { "#{data_folder}/output-#{job.id}" }
+
+    context "when persisted_output is not set" do
+      it "uses default_output_path for single output scripts" do
+        job.script = "categorization_runner.ts"
+        expected_path = "#{data_folder}/categorization-output-#{job.id}.csv"
+        expect(artefacts.output_artefact_paths).to eq([expected_path])
+      end
+
+      it "uses default_output_path for advanced_runner.ts" do
+        job.script = "advanced_runner.ts"
+        expect(artefacts.output_artefact_paths).to eq([
+          "#{base_path}-summary.json",
+          "#{base_path}-topic-stats.json",
+          "#{base_path}-comments-with-scores.json"
+        ])
+      end
+
+      it "uses default_output_path for runner.ts" do
+        job.script = "runner.ts"
+        expect(artefacts.output_artefact_paths).to eq([
+          "#{base_path}-summary.json",
+          "#{base_path}-summary.html",
+          "#{base_path}-summary.md",
+          "#{base_path}-summaryAndSource.csv"
+        ])
+      end
+    end
+
+    context "when persisted_output is set" do
+      let(:persisted_path) { "/historical/path/output-#{job.id}" }
+
+      before do
+        job.persisted_output = persisted_path
+      end
+
+      it "uses resolved persisted_output_path (absolute) so File.exist? works after deploys" do
+        job.script = "categorization_runner.ts"
+        expect(artefacts.output_artefact_paths).to eq([persisted_path])
+      end
+
+      it "uses persisted_output for advanced_runner.ts" do
+        job.script = "advanced_runner.ts"
+        expect(artefacts.output_artefact_paths).to eq([
+          "#{persisted_path}-summary.json",
+          "#{persisted_path}-topic-stats.json",
+          "#{persisted_path}-comments-with-scores.json"
+        ])
+      end
+
+      it "uses persisted_output for runner.ts" do
+        job.script = "runner.ts"
+        expect(artefacts.output_artefact_paths).to eq([
+          "#{persisted_path}-summary.json",
+          "#{persisted_path}-summary.html",
+          "#{persisted_path}-summary.md",
+          "#{persisted_path}-summaryAndSource.csv"
+        ])
+      end
+
+      context "when persisted_output is a relative path (post-deploy safe)" do
+        let(:relative_path) { "vendor/sensemaking-tools/data/output-#{job.id}" }
+
+        before do
+          job.persisted_output = relative_path
+        end
+
+        it "returns absolute paths via persisted_output_path so complete? can find files" do
+          job.script = "categorization_runner.ts"
+          expected = Rails.root.join(relative_path).to_s
+          expect(artefacts.output_artefact_paths).to eq([expected])
+        end
+      end
+    end
+  end
+
+  describe "#complete?" do
+    include_context "sensemaker paths stubbed"
+
+    before do
+      allow(File).to receive(:exist?).and_return(false)
+    end
+
+    context "when script has single output" do
+      before do
+        job.script = "categorization_runner.ts"
+      end
+
+      it "returns true when the output file exists" do
+        output_path = "#{data_folder}/categorization-output-#{job.id}.csv"
+        allow(File).to receive(:exist?).with(output_path).and_return(true)
+        expect(artefacts.complete?).to be true
+      end
+
+      it "returns false when the output file does not exist" do
+        expect(artefacts.complete?).to be false
+      end
+    end
+
+    shared_examples "complete for multi-output script" do |script_name, path_suffixes|
+      before { job.script = script_name }
+
+      it "returns true when all output files exist" do
+        base_path = "#{data_folder}/output-#{job.id}"
+        path_suffixes.each do |suffix|
+          allow(File).to receive(:exist?).with("#{base_path}#{suffix}").and_return(true)
+        end
+        expect(artefacts.complete?).to be true
+      end
+
+      it "returns false when not all output files exist" do
+        base_path = "#{data_folder}/output-#{job.id}"
+        path_suffixes[0..-2].each do |suffix|
+          allow(File).to receive(:exist?).with("#{base_path}#{suffix}").and_return(true)
+        end
+        allow(File).to receive(:exist?).with("#{base_path}#{path_suffixes.last}").and_return(false)
+        expect(artefacts.complete?).to be false
+      end
+    end
+
+    it_behaves_like "complete for multi-output script",
+                    "advanced_runner.ts",
+                    %w[-summary.json -topic-stats.json -comments-with-scores.json]
+
+    it_behaves_like "complete for multi-output script",
+                    "runner.ts",
+                    %w[-summary.json -summary.html -summary.md -summaryAndSource.csv]
+  end
+
+  describe "#input_path" do
+    include_context "sensemaker paths stubbed"
+
+    it "returns the stored input_file when set" do
+      job[:input_file] = "/custom/input.csv"
+      expect(artefacts.input_path).to eq("/custom/input.csv")
+    end
+
+    it "defaults to categorization output for advanced_runner.ts when input_file is not set" do
+      job.script = "advanced_runner.ts"
+      job[:input_file] = nil
+      expect(artefacts.input_path).to eq("#{data_folder}/categorization-output-#{job.id}.csv")
+    end
+
+    it "defaults to advanced-output for report script when input_file is not set" do
+      job.script = "sensemaking-report-ui"
+      job[:input_file] = nil
+      expect(artefacts.input_path).to eq("#{data_folder}/advanced-output")
+    end
+
+    it "defaults to input csv for other scripts when input_file is not set" do
+      job.script = "runner.ts"
+      job[:input_file] = nil
+      expect(artefacts.input_path).to eq("#{data_folder}/input-#{job.id}.csv")
+    end
+  end
+
+  describe "#input_artefact_paths" do
+    include_context "sensemaker paths stubbed"
+
+    it "returns an empty array when input_path is blank" do
+      job.script = "health_check_runner.ts"
+      job[:input_file] = nil
+      expect(artefacts.input_artefact_paths).to eq([])
+    end
+
+    it "returns a single path for single-input scripts" do
+      job.script = "runner.ts"
+      job[:input_file] = "/tmp/input-#{job.id}.csv"
+      expect(artefacts.input_artefact_paths).to eq([job[:input_file]])
+    end
+
+    it "returns derived JSON artefacts for sensemaking-report-ui" do
+      job.script = "sensemaking-report-ui"
+      job[:input_file] = "/tmp/output-#{job.id}"
+
+      expect(artefacts.input_artefact_paths).to eq([
+        "#{job[:input_file]}-topic-stats.json",
+        "#{job[:input_file]}-summary.json",
+        "#{job[:input_file]}-comments-with-scores.json",
+        "#{job[:input_file]}-metadata.json"
+      ])
+    end
+  end
+
+  describe "#metadata_path" do
+    it "returns nil when input_path is blank" do
+      job.script = "health_check_runner.ts"
+      job[:input_file] = nil
+      expect(artefacts.metadata_path).to be(nil)
+    end
+
+    it "returns the metadata json path derived from input_path" do
+      job[:input_file] = "/tmp/output-#{job.id}"
+      expect(artefacts.metadata_path).to eq("/tmp/output-#{job.id}-metadata.json")
+    end
+  end
+
+  describe "#existing_output_artefact_paths" do
+    include_context "sensemaker paths stubbed"
+    let(:base_path) { "#{data_folder}/output-#{job.id}" }
+
+    before do
+      allow(File).to receive(:exist?).and_return(false)
+    end
+
+    it "returns only paths for which the file exists" do
+      job.script = "runner.ts"
+      existing_path = "#{base_path}-summary.json"
+      allow(File).to receive(:exist?).with(existing_path).and_return(true)
+
+      expect(artefacts.existing_output_artefact_paths).to eq([existing_path])
+    end
+
+    it "excludes paths for which the file does not exist" do
+      job.script = "runner.ts"
+      path1 = "#{base_path}-summary.json"
+      path2 = "#{base_path}-summary.html"
+      allow(File).to receive(:exist?).with(path1).and_return(true)
+      allow(File).to receive(:exist?).with(path2).and_return(false)
+
+      expect(artefacts.existing_output_artefact_paths).to eq([path1])
+    end
+  end
+
+  describe "#existing_input_artefact_paths" do
+    before do
+      allow(File).to receive(:exist?).and_return(false)
+    end
+
+    it "returns only input artefacts that exist" do
+      existing_path = "/tmp/input-existing-#{job.id}.csv"
+      allow(File).to receive(:exist?).with(existing_path).and_return(true)
+      job.script = "runner.ts"
+      job[:input_file] = existing_path
+
+      expect(artefacts.existing_input_artefact_paths).to eq([existing_path])
+    end
+
+    it "returns only existing derived input artefacts for sensemaking-report-ui" do
+      job.script = "sensemaking-report-ui"
+      job[:input_file] = "/tmp/output-#{job.id}"
+      existing = "#{job[:input_file]}-summary.json"
+      missing_1 = "#{job[:input_file]}-topic-stats.json"
+      missing_2 = "#{job[:input_file]}-comments-with-scores.json"
+      missing_3 = "#{job[:input_file]}-metadata.json"
+
+      allow(File).to receive(:exist?).with(existing).and_return(true)
+      allow(File).to receive(:exist?).with(missing_1).and_return(false)
+      allow(File).to receive(:exist?).with(missing_2).and_return(false)
+      allow(File).to receive(:exist?).with(missing_3).and_return(false)
+
+      expect(artefacts.existing_input_artefact_paths).to eq([existing])
+    end
+  end
+
+  describe "#cleanup" do
+    include_context "sensemaker paths stubbed"
+
+    before do
+      allow(FileUtils).to receive(:rm_f).and_return(true)
+    end
+
+    it "cleans up default input csv and unfiltered sidecar" do
+      expect(FileUtils).to receive(:rm_f).with("#{data_folder}/input-#{job.id}.csv").at_least(:once)
+      expect(FileUtils).to receive(:rm_f).with("#{data_folder}/input-#{job.id}.csv.unfiltered")
+
+      artefacts.cleanup
+    end
+
+    {
+      "health_check_runner.ts" => ->(j, df) { ["#{df}/health-check-#{j.id}.txt"] },
+      "advanced_runner.ts" => ->(j, df) {
+        ["#{df}/output-#{j.id}-summary.json", "#{df}/output-#{j.id}-topic-stats.json",
+         "#{df}/output-#{j.id}-comments-with-scores.json"]
+      },
+      "categorization_runner.ts" => ->(j, df) { ["#{df}/categorization-output-#{j.id}.csv"] },
+      "sensemaking-report-ui" => ->(j, df) { ["#{df}/report-#{j.id}.html"] },
+      "runner.ts" => ->(j, df) {
+        ["#{df}/output-#{j.id}-summary.json", "#{df}/output-#{j.id}-summary.html",
+         "#{df}/output-#{j.id}-summary.md", "#{df}/output-#{j.id}-summaryAndSource.csv"]
+      }
+    }.each do |script, paths_fn|
+      context "when script is #{script}" do
+        it "cleans up output files" do
+          job.script = script
+          paths = paths_fn.call(job, data_folder)
+          paths.each { |p| expect(FileUtils).to receive(:rm_f).with(p) }
+          artefacts.cleanup
+        end
+      end
+    end
+
+    context "when persisted_output is present and file exists" do
+      before do
+        job.persisted_output = "/path/to/output.txt"
+        allow(File).to receive(:exist?).and_return(false)
+        allow(File).to receive(:exist?).with(Rails.root.join("/path/to/output.txt")).and_return(true)
+      end
+
+      it "removes the persisted output file using resolved path (persisted_output_path)" do
+        resolved = Rails.root.join("/path/to/output.txt")
+        expect(FileUtils).to receive(:rm_f).with(resolved)
+
+        artefacts.cleanup
+      end
+    end
+
+    context "when persisted_output is nil" do
+      before do
+        job.persisted_output = nil
+      end
+
+      it "does not attempt to remove a persisted output file" do
+        expect(FileUtils).not_to receive(:rm_f).with("/path/to/output.txt")
+        artefacts.cleanup
+      end
+    end
+
+    it "handles errors gracefully" do
+      allow(FileUtils).to receive(:rm_f).and_raise(StandardError.new("File system error"))
+
+      expect(artefacts.cleanup).to be(nil)
+    end
+  end
+end

--- a/spec/lib/sensemaker/job_artefacts_spec.rb
+++ b/spec/lib/sensemaker/job_artefacts_spec.rb
@@ -1,0 +1,453 @@
+require "rails_helper"
+
+describe Sensemaker::JobArtefacts do
+  let(:user) { create(:user) }
+  let(:debate) { create(:debate) }
+  let(:job) do
+    create(:sensemaker_job,
+           analysable_type: "Debate",
+           analysable_id: debate.id,
+           script: "categorization_runner.ts",
+           user: user,
+           started_at: Time.current,
+           additional_context: "Test context")
+  end
+  let(:artefacts) { Sensemaker::JobArtefacts.new(job) }
+
+  shared_context "sensemaker paths stubbed" do
+    let(:data_folder) { "/tmp/sensemaker_test_folder/data" }
+    let(:job_dir) { "#{data_folder}/job-#{job.id}" }
+
+    before do
+      allow(Sensemaker::Paths).to receive(:sensemaker_data_folder).and_return(data_folder)
+    end
+  end
+
+  describe "#output_file_name" do
+    {
+      "categorization_runner.ts" => "categorization-output.csv",
+      "advanced_runner.ts" => "output",
+      "runner.ts" => "output",
+      "health_check_runner.ts" => "health-check.txt",
+      "sensemaking-report-ui" => "report.html"
+    }.each do |script, expected_name|
+      it "returns the correct output file name for #{script}" do
+        job.script = script
+        expect(artefacts.output_file_name).to eq(expected_name)
+      end
+    end
+
+    it "falls back for unknown scripts" do
+      job.script = "unknown_runner.ts"
+      expect(artefacts.output_file_name).to eq("output.csv")
+    end
+  end
+
+  describe "#multiple_outputs?" do
+    it "returns true for advanced_runner.ts and runner.ts" do
+      job.script = "advanced_runner.ts"
+      expect(artefacts.multiple_outputs?).to be true
+      job.script = "runner.ts"
+      expect(artefacts.multiple_outputs?).to be true
+    end
+
+    it "returns false for single output scripts" do
+      job.script = "categorization_runner.ts"
+      expect(artefacts.multiple_outputs?).to be false
+      job.script = "health_check_runner.ts"
+      expect(artefacts.multiple_outputs?).to be false
+      job.script = "sensemaking-report-ui"
+      expect(artefacts.multiple_outputs?).to be false
+    end
+  end
+
+  describe "#job_directory" do
+    include_context "sensemaker paths stubbed"
+
+    it "returns the per-job directory under the data folder" do
+      expect(artefacts.job_directory).to eq(job_dir)
+    end
+  end
+
+  describe "#ensure_directory!" do
+    include_context "sensemaker paths stubbed"
+
+    it "creates the job directory" do
+      expect(FileUtils).to receive(:mkdir_p).with(job_dir)
+      artefacts.ensure_directory!
+    end
+  end
+
+  describe "#default_output_path" do
+    include_context "sensemaker paths stubbed"
+
+    {
+      "categorization_runner.ts" => ->(jd) { "#{jd}/categorization-output.csv" },
+      "advanced_runner.ts" => ->(jd) { "#{jd}/output" },
+      "runner.ts" => ->(jd) { "#{jd}/output" }
+    }.each do |script, expected_path_fn|
+      it "returns the correct path for #{script}" do
+        job.script = script
+        expect(artefacts.default_output_path).to eq(expected_path_fn.call(job_dir))
+      end
+    end
+  end
+
+  describe "#relative_output_path" do
+    let(:relative_data_folder) { "tmp/sensemaker_test_folder/data" }
+    let(:relative_job_dir) { "#{relative_data_folder}/job-#{job.id}" }
+
+    before do
+      allow(Sensemaker::Paths).to receive(:sensemaker_relative_data_folder).and_return(relative_data_folder)
+    end
+
+    it "returns a path relative to Rails.root (no leading slash)" do
+      job.script = "categorization_runner.ts"
+      path = artefacts.relative_output_path
+      expect(path).to eq("#{relative_job_dir}/categorization-output.csv")
+      expect(path).not_to start_with("/")
+    end
+
+    {
+      "advanced_runner.ts" => ->(rjd) { "#{rjd}/output" },
+      "sensemaking-report-ui" => ->(rjd) { "#{rjd}/report.html" }
+    }.each do |script, expected_path_fn|
+      it "returns the correct relative path for #{script}" do
+        job.script = script
+        expect(artefacts.relative_output_path).to eq(expected_path_fn.call(relative_job_dir))
+      end
+    end
+  end
+
+  describe "#persisted_output_path" do
+    [nil, ""].each do |blank_value|
+      it "returns nil when persisted_output is #{blank_value.inspect}" do
+        job.persisted_output = blank_value
+        expect(artefacts.persisted_output_path).to be(nil)
+      end
+    end
+
+    it "resolves relative persisted_output against Rails.root so path survives deploys" do
+      relative_path = "tmp/sensemaker_test_folder/data/job-60/output"
+      job.persisted_output = relative_path
+      expect(artefacts.persisted_output_path).to eq(Rails.root.join(relative_path))
+      expect(artefacts.persisted_output_path.to_s).to include(Rails.root.to_s)
+    end
+  end
+
+  describe "#output_artefact_paths" do
+    include_context "sensemaker paths stubbed"
+    let(:base_path) { "#{job_dir}/output" }
+
+    context "when persisted_output is not set" do
+      it "uses default_output_path for single output scripts" do
+        job.script = "categorization_runner.ts"
+        expected_path = "#{job_dir}/categorization-output.csv"
+        expect(artefacts.output_artefact_paths).to eq([expected_path])
+      end
+
+      it "uses default_output_path for advanced_runner.ts" do
+        job.script = "advanced_runner.ts"
+        expect(artefacts.output_artefact_paths).to eq([
+          "#{base_path}-summary.json",
+          "#{base_path}-topic-stats.json",
+          "#{base_path}-comments-with-scores.json"
+        ])
+      end
+
+      it "uses default_output_path for runner.ts" do
+        job.script = "runner.ts"
+        expect(artefacts.output_artefact_paths).to eq([
+          "#{base_path}-summary.json",
+          "#{base_path}-summary.html",
+          "#{base_path}-summary.md",
+          "#{base_path}-summaryAndSource.csv"
+        ])
+      end
+    end
+
+    context "when persisted_output is set" do
+      let(:persisted_path) { "/historical/path/output" }
+
+      before do
+        job.persisted_output = persisted_path
+      end
+
+      it "uses resolved persisted_output_path (absolute) so File.exist? works after deploys" do
+        job.script = "categorization_runner.ts"
+        expect(artefacts.output_artefact_paths).to eq([persisted_path])
+      end
+
+      it "uses persisted_output for advanced_runner.ts" do
+        job.script = "advanced_runner.ts"
+        expect(artefacts.output_artefact_paths).to eq([
+          "#{persisted_path}-summary.json",
+          "#{persisted_path}-topic-stats.json",
+          "#{persisted_path}-comments-with-scores.json"
+        ])
+      end
+
+      it "uses persisted_output for runner.ts" do
+        job.script = "runner.ts"
+        expect(artefacts.output_artefact_paths).to eq([
+          "#{persisted_path}-summary.json",
+          "#{persisted_path}-summary.html",
+          "#{persisted_path}-summary.md",
+          "#{persisted_path}-summaryAndSource.csv"
+        ])
+      end
+
+      context "when persisted_output is a relative path (post-deploy safe)" do
+        let(:relative_path) { "vendor/sensemaking-tools/data/job-#{job.id}/output" }
+
+        before do
+          job.persisted_output = relative_path
+        end
+
+        it "returns absolute paths via persisted_output_path so complete? can find files" do
+          job.script = "categorization_runner.ts"
+          expected = Rails.root.join(relative_path).to_s
+          expect(artefacts.output_artefact_paths).to eq([expected])
+        end
+      end
+    end
+  end
+
+  describe "#complete?" do
+    include_context "sensemaker paths stubbed"
+
+    before do
+      allow(File).to receive(:exist?).and_return(false)
+    end
+
+    context "when script has single output" do
+      before do
+        job.script = "categorization_runner.ts"
+      end
+
+      it "returns true when the output file exists" do
+        output_path = "#{job_dir}/categorization-output.csv"
+        allow(File).to receive(:exist?).with(output_path).and_return(true)
+        expect(artefacts.complete?).to be true
+      end
+
+      it "returns false when the output file does not exist" do
+        expect(artefacts.complete?).to be false
+      end
+    end
+
+    shared_examples "complete for multi-output script" do |script_name, path_suffixes|
+      before { job.script = script_name }
+
+      it "returns true when all output files exist" do
+        base_path = "#{job_dir}/output"
+        path_suffixes.each do |suffix|
+          allow(File).to receive(:exist?).with("#{base_path}#{suffix}").and_return(true)
+        end
+        expect(artefacts.complete?).to be true
+      end
+
+      it "returns false when not all output files exist" do
+        base_path = "#{job_dir}/output"
+        path_suffixes[0..-2].each do |suffix|
+          allow(File).to receive(:exist?).with("#{base_path}#{suffix}").and_return(true)
+        end
+        allow(File).to receive(:exist?).with("#{base_path}#{path_suffixes.last}").and_return(false)
+        expect(artefacts.complete?).to be false
+      end
+    end
+
+    it_behaves_like "complete for multi-output script",
+                    "advanced_runner.ts",
+                    %w[-summary.json -topic-stats.json -comments-with-scores.json]
+
+    it_behaves_like "complete for multi-output script",
+                    "runner.ts",
+                    %w[-summary.json -summary.html -summary.md -summaryAndSource.csv]
+  end
+
+  describe "#input_path" do
+    include_context "sensemaker paths stubbed"
+
+    it "returns the stored input_file when set" do
+      job[:input_file] = "/custom/input.csv"
+      expect(artefacts.input_path).to eq("/custom/input.csv")
+    end
+
+    it "defaults to categorization output for advanced_runner.ts when input_file is not set" do
+      job.script = "advanced_runner.ts"
+      job[:input_file] = nil
+      expect(artefacts.input_path).to eq("#{job_dir}/categorization-output.csv")
+    end
+
+    it "defaults to advanced-output for report script when input_file is not set" do
+      job.script = "sensemaking-report-ui"
+      job[:input_file] = nil
+      expect(artefacts.input_path).to eq("#{job_dir}/advanced-output")
+    end
+
+    it "defaults to input csv for other scripts when input_file is not set" do
+      job.script = "runner.ts"
+      job[:input_file] = nil
+      expect(artefacts.input_path).to eq("#{job_dir}/input.csv")
+    end
+  end
+
+  describe "#input_artefact_paths" do
+    include_context "sensemaker paths stubbed"
+
+    it "returns an empty array when input_path is blank" do
+      job.script = "health_check_runner.ts"
+      job[:input_file] = nil
+      expect(artefacts.input_artefact_paths).to eq([])
+    end
+
+    it "returns a single path for single-input scripts" do
+      job.script = "runner.ts"
+      job[:input_file] = "/tmp/input.csv"
+      expect(artefacts.input_artefact_paths).to eq([job[:input_file]])
+    end
+
+    it "returns derived JSON artefacts for sensemaking-report-ui" do
+      job.script = "sensemaking-report-ui"
+      job[:input_file] = "/tmp/output"
+
+      expect(artefacts.input_artefact_paths).to eq([
+        "#{job[:input_file]}-topic-stats.json",
+        "#{job[:input_file]}-summary.json",
+        "#{job[:input_file]}-comments-with-scores.json",
+        "#{job[:input_file]}-metadata.json"
+      ])
+    end
+  end
+
+  describe "#metadata_path" do
+    it "returns nil when input_path is blank" do
+      job.script = "health_check_runner.ts"
+      job[:input_file] = nil
+      expect(artefacts.metadata_path).to be(nil)
+    end
+
+    it "returns the metadata json path derived from input_path" do
+      job[:input_file] = "/tmp/output"
+      expect(artefacts.metadata_path).to eq("/tmp/output-metadata.json")
+    end
+  end
+
+  describe "#existing_output_artefact_paths" do
+    include_context "sensemaker paths stubbed"
+    let(:base_path) { "#{job_dir}/output" }
+
+    before do
+      allow(File).to receive(:exist?).and_return(false)
+    end
+
+    it "returns only paths for which the file exists" do
+      job.script = "runner.ts"
+      existing_path = "#{base_path}-summary.json"
+      allow(File).to receive(:exist?).with(existing_path).and_return(true)
+
+      expect(artefacts.existing_output_artefact_paths).to eq([existing_path])
+    end
+
+    it "excludes paths for which the file does not exist" do
+      job.script = "runner.ts"
+      path1 = "#{base_path}-summary.json"
+      path2 = "#{base_path}-summary.html"
+      allow(File).to receive(:exist?).with(path1).and_return(true)
+      allow(File).to receive(:exist?).with(path2).and_return(false)
+
+      expect(artefacts.existing_output_artefact_paths).to eq([path1])
+    end
+  end
+
+  describe "#existing_input_artefact_paths" do
+    before do
+      allow(File).to receive(:exist?).and_return(false)
+    end
+
+    it "returns only input artefacts that exist" do
+      existing_path = "/tmp/input-existing.csv"
+      allow(File).to receive(:exist?).with(existing_path).and_return(true)
+      job.script = "runner.ts"
+      job[:input_file] = existing_path
+
+      expect(artefacts.existing_input_artefact_paths).to eq([existing_path])
+    end
+
+    it "returns only existing derived input artefacts for sensemaking-report-ui" do
+      job.script = "sensemaking-report-ui"
+      job[:input_file] = "/tmp/output"
+      existing = "#{job[:input_file]}-summary.json"
+      missing_1 = "#{job[:input_file]}-topic-stats.json"
+      missing_2 = "#{job[:input_file]}-comments-with-scores.json"
+      missing_3 = "#{job[:input_file]}-metadata.json"
+
+      allow(File).to receive(:exist?).with(existing).and_return(true)
+      allow(File).to receive(:exist?).with(missing_1).and_return(false)
+      allow(File).to receive(:exist?).with(missing_2).and_return(false)
+      allow(File).to receive(:exist?).with(missing_3).and_return(false)
+
+      expect(artefacts.existing_input_artefact_paths).to eq([existing])
+    end
+  end
+
+  describe "#cleanup" do
+    include_context "sensemaker paths stubbed"
+
+    before do
+      allow(FileUtils).to receive_messages(rm_rf: [job_dir], rm_f: true)
+      allow(Dir).to receive(:exist?).and_call_original
+      allow(Dir).to receive(:exist?).with(job_dir).and_return(true)
+    end
+
+    it "removes the job directory" do
+      expect(FileUtils).to receive(:rm_rf).with(job_dir)
+      artefacts.cleanup
+    end
+
+    context "when persisted_output is present outside the job directory and file exists" do
+      before do
+        job.persisted_output = "/path/to/output.txt"
+        allow(File).to receive(:exist?).and_return(false)
+        allow(File).to receive(:exist?).with(Rails.root.join("/path/to/output.txt")).and_return(true)
+      end
+
+      it "removes the persisted output file using resolved path (persisted_output_path)" do
+        resolved = Rails.root.join("/path/to/output.txt")
+        expect(FileUtils).to receive(:rm_f).with(resolved)
+
+        artefacts.cleanup
+      end
+    end
+
+    context "when persisted_output is inside the job directory" do
+      before do
+        job.persisted_output = "#{job_dir}/report.html"
+        allow(File).to receive(:exist?).and_return(true)
+      end
+
+      it "does not separately remove persisted output already covered by rm_rf" do
+        expect(FileUtils).not_to receive(:rm_f)
+        artefacts.cleanup
+      end
+    end
+
+    context "when persisted_output is nil" do
+      before do
+        job.persisted_output = nil
+      end
+
+      it "does not attempt to remove a persisted output file" do
+        expect(FileUtils).not_to receive(:rm_f).with("/path/to/output.txt")
+        artefacts.cleanup
+      end
+    end
+
+    it "handles errors gracefully" do
+      allow(FileUtils).to receive(:rm_rf).and_raise(StandardError.new("File system error"))
+
+      expect(artefacts.cleanup).to be(nil)
+    end
+  end
+end

--- a/spec/lib/sensemaker/job_runner_spec.rb
+++ b/spec/lib/sensemaker/job_runner_spec.rb
@@ -1,0 +1,395 @@
+require "rails_helper"
+
+describe Sensemaker::JobRunner do
+  include_context "sensemaker llm config"
+
+  let(:user) { create(:user) }
+  let(:debate) { create(:debate) }
+  let(:job) do
+    create(:sensemaker_job,
+           analysable_type: "Debate",
+           analysable_id: debate.id,
+           script: "categorization_runner.ts",
+           user: user,
+           started_at: Time.current,
+           additional_context: "")
+  end
+
+  describe "#initialize" do
+    it "initializes with the provided job" do
+      service = Sensemaker::JobRunner.new(job)
+      expect(service.job).to eq(job)
+      expect(service.backend).to be_a(Sensemaker::Backend::Node)
+    end
+  end
+
+  describe "#run" do
+    let(:service) { Sensemaker::JobRunner.new(job) }
+
+    before do
+      FileUtils.mkdir_p(Sensemaker::Paths.sensemaker_package_folder)
+      allow(File).to receive(:exist?).and_return(true)
+      allow(service.backend).to receive(:check_runtime_dependencies?).and_return(true)
+      allow(service).to receive_messages(check_dependencies?: true, prepare_input_data: 0)
+    end
+
+    it "runs the complete workflow successfully" do
+      allow(File).to receive(:exist?).and_return(true)
+      allow(service).to receive(:system).and_return(true)
+
+      service.run_synchronously
+
+      job.reload
+      expect(job.started_at).to be_present
+      expect(job.finished_at).to be_present
+    end
+
+    it "stops if check_dependencies? returns false" do
+      allow(service).to receive(:check_dependencies?).and_return(false)
+      expect(service).not_to receive(:execute_script)
+
+      service.run_synchronously
+    end
+
+    it "stops if execute_script returns false" do
+      expect(service).to receive(:execute_script).and_return(false)
+
+      service.run_synchronously
+    end
+
+    it "handles errors and updates the job" do
+      expect(service).to receive(:execute_script).and_raise(StandardError.new("Test error"))
+
+      expect { service.run_synchronously }.to raise_error(StandardError)
+
+      job.reload
+      expect(job.finished_at).to be_present
+      expect(job.error).to include("Test error")
+    end
+  end
+
+  describe "#check_dependencies?" do
+    let(:service) { Sensemaker::JobRunner.new(job) }
+
+    before do
+      allow(Llm::Config).to receive(:context).and_return(llm_context)
+      allow(Setting).to receive(:[]).and_call_original
+      allow(Setting).to receive(:[]).with("llm.provider").and_return("VertexAI")
+      allow(Setting).to receive(:[]).with("llm.model").and_return("gemini-2.5-flash-lite")
+      allow(service.backend).to receive(:check_runtime_dependencies?).and_return(true)
+      allow(File).to receive(:exist?).and_return(true)
+    end
+
+    it "returns true when all dependencies are available" do
+      result = service.send(:check_dependencies?)
+      expect(result).to be true
+    end
+
+    {
+      "sensemaker_data_folder is not configured" => [
+        -> { allow(Tenant.current_secrets).to receive(:sensemaker_data_folder).and_return(nil) },
+        "Sensemaker data folder not configured"
+      ],
+      "Vertex AI project_id is not configured" => [
+        -> { allow(llm_config).to receive(:vertexai_project_id).and_return(nil) },
+        "Vertex AI is not configured"
+      ],
+      "LLM provider is unsupported" => [
+        -> { allow(Setting).to receive(:[]).with("llm.provider").and_return("Unsupported") },
+        "Sensemaker LLM provider is not supported"
+      ],
+      "LLM model is not selected" => [
+        -> { allow(Setting).to receive(:[]).with("llm.model").and_return(nil) },
+        "Sensemaker requires an LLM model to be selected"
+      ],
+      "apis.google_application_credentials is set but key file does not exist" => [
+        -> {
+          allow(Rails.application.secrets).to receive(:google_application_credentials)
+          .and_return("/nonexistent/key.json")
+          allow(File).to receive(:exist?).with("/nonexistent/key.json").and_return(false)
+        },
+        "Key file (apis.google_application_credentials) not found"
+      ],
+      "runtime dependencies check fails" => [
+        -> {
+          allow(service.backend).to receive(:check_runtime_dependencies?).and_return(false)
+        },
+        nil
+      ]
+    }.each do |description, (setup, error_substring)|
+      it "returns false when #{description}" do
+        instance_exec(&setup)
+        result = service.send(:check_dependencies?)
+        expect(result).to be false
+        next if error_substring.nil?
+
+        job.reload
+        expect(job.finished_at).to be_present
+        expect(job.error).to include(error_substring)
+      end
+    end
+
+    it "returns true for OpenAI-compatible provider with API key" do
+      allow(Setting).to receive(:[]).with("llm.provider").and_return("OpenAI")
+      allow(llm_config).to receive(:openai_api_key).and_return("tenant-openai-key")
+
+      result = service.send(:check_dependencies?)
+      expect(result).to be true
+    end
+
+    it "returns false for OpenAI-compatible provider without API key" do
+      allow(Setting).to receive(:[]).with("llm.provider").and_return("OpenAI")
+      allow(llm_config).to receive(:openai_api_key).and_return(nil)
+
+      result = service.send(:check_dependencies?)
+      expect(result).to be false
+      job.reload
+      expect(job.error).to include("Sensemaker requires an API key for provider 'openai'")
+    end
+  end
+
+  describe "#execute_script" do
+    let(:service) { Sensemaker::JobRunner.new(job) }
+
+    before do
+      allow(File).to receive(:exist?).and_return(true)
+      allow(Setting).to receive(:[]).and_call_original
+      allow(Setting).to receive(:[]).with("llm.provider").and_return("VertexAI")
+      allow(Setting).to receive(:[]).with("llm.model").and_return("gemini-2.5-flash-lite")
+    end
+
+    it "returns value when the script executes successfully" do
+      timeout = Sensemaker::JobRunner::TIMEOUT
+      expected_command = %r{cd .* && timeout #{timeout} .*}
+      expect(service).to receive(:`).with(expected_command).and_return("Success output")
+
+      allow(service).to receive(:process_exit_status).and_return(0)
+
+      result = service.send(:execute_script)
+
+      expect(result).to be_present
+    end
+
+    it "returns nil and updates the job when the script fails" do
+      timeout = Sensemaker::JobRunner::TIMEOUT
+      expected_command = %r{cd .* && timeout #{timeout} .*}
+      expect(service).to receive(:`).with(expected_command).and_return("Error output")
+
+      allow(service).to receive(:process_exit_status).and_return(1)
+
+      result = service.send(:execute_script)
+
+      expect(result).to be nil
+
+      job.reload
+      expect(job.finished_at).to be_present
+      expect(job.error).to include("Command:")
+      expect(job.error).to include("Error output")
+    end
+
+    it "redacts api keys in stored command errors" do
+      allow(Llm::Config).to receive(:context).and_return(llm_context)
+      allow(llm_config).to receive(:openai_api_key).and_return("super-secret-key")
+      allow(Setting).to receive(:[]).with("llm.provider").and_return("OpenAI")
+      allow(Setting).to receive(:[]).with("llm.model").and_return("gpt-4o")
+
+      timeout = Sensemaker::JobRunner::TIMEOUT
+      expected_command = %r{cd .* && timeout #{timeout} .*--apiKey super-secret-key.*}
+      expect(service).to receive(:`).with(expected_command).and_return("Error output")
+      allow(service).to receive(:process_exit_status).and_return(1)
+
+      service.send(:execute_script)
+      job.reload
+      expect(job.error).to include("--apiKey [REDACTED]")
+      expect(job.error).not_to include("super-secret-key")
+    end
+  end
+
+  describe "#execute_job_workflow" do
+    let(:service) { Sensemaker::JobRunner.new(job) }
+
+    before do
+      allow(File).to receive(:exist?).and_return(true)
+      allow(service.backend).to receive(:check_runtime_dependencies?).and_return(true)
+      allow(service).to receive_messages(check_dependencies?: true, execute_script: "success")
+      allow(service).to receive(:prepare_input_data)
+    end
+
+    context "when artefacts are complete" do
+      it "sets finished_at and does not set error" do
+        allow(job.artefacts).to receive(:complete?).and_return(true)
+
+        service.send(:execute_job_workflow)
+
+        job.reload
+        expect(job.finished_at).to be_present
+        expect(job.error).to be(nil)
+      end
+
+      it "sets comments_analysed count when job finishes successfully" do
+        allow(job.artefacts).to receive(:complete?).and_return(true)
+        allow(service).to receive(:prepare_input_data).and_return(5)
+
+        service.send(:execute_job_workflow)
+
+        job.reload
+        expect(job.comments_analysed).to eq(5)
+      end
+    end
+
+    context "when artefacts are incomplete" do
+      it "sets finished_at and error message" do
+        allow(job.artefacts).to receive(:complete?).and_return(false)
+
+        service.send(:execute_job_workflow)
+
+        job.reload
+        expect(job.finished_at).to be_present
+        expect(job.error).to eq("Output file(s) not found")
+      end
+    end
+  end
+
+  describe "#prepare_input_data" do
+    let(:service) { Sensemaker::JobRunner.new(job) }
+    let(:mock_exporter) { instance_double(Sensemaker::CsvExporter) }
+    let(:input_file_path) { "#{Sensemaker::Paths.sensemaker_data_folder}/job-#{job.id}/input.csv" }
+    let(:mock_conversation) { instance_double(Sensemaker::Conversation) }
+    let(:mock_comments) { Array.new(7) { double("comment") } }
+
+    before do
+      allow(Sensemaker::CsvExporter).to receive(:new).and_return(mock_exporter)
+      allow(mock_exporter).to receive(:export_to_csv)
+      allow(job).to receive(:conversation).and_return(mock_conversation)
+      allow(mock_conversation).to receive_messages(
+        comments: mock_comments,
+        compile_context: "Test context"
+      )
+      allow(service.backend).to receive(:after_input_prepared).and_return(nil)
+    end
+
+    it "creates a CsvExporter with the job's conversation" do
+      service.send(:prepare_input_data)
+
+      expect(Sensemaker::CsvExporter).to have_received(:new).with(mock_conversation)
+    end
+
+    it "exports CSV data to the input file" do
+      service.send(:prepare_input_data)
+
+      expect(mock_exporter).to have_received(:export_to_csv).with(input_file_path)
+    end
+
+    it "persists input_file after exporting CSV when input_file is blank" do
+      expect(job.read_attribute(:input_file)).to be(nil)
+
+      service.send(:prepare_input_data)
+
+      expect(job.reload.input_file).to eq(input_file_path)
+    end
+
+    it "updates the job with additional context" do
+      allow(job).to receive(:conversation).and_return(
+        Sensemaker::Conversation.new(job.analysable_type, job.analysable_id)
+      )
+
+      service.send(:prepare_input_data)
+
+      job.reload
+      expect(job.additional_context).to be_present
+      expect(job.additional_context).to include("Analysing Citizen debate")
+      expect(job.additional_context).to include(debate.title)
+    end
+
+    it "returns the count of comments from conversation when input_file is blank" do
+      job.input_file = nil
+      result = service.send(:prepare_input_data)
+
+      expect(result).to eq(7)
+    end
+
+    context "when script is advanced_runner.ts" do
+      before do
+        job.script = "advanced_runner.ts"
+        job.input_file = "/tmp/categorization-output.csv"
+        allow(File).to receive(:exist?).with(job.artefacts.input_path).and_return(true)
+        allow(service.backend).to receive(:after_input_prepared).and_call_original
+      end
+
+      it "calls CsvExporter.provide_defaults_for_zero_vote_comments via backend" do
+        expect(Sensemaker::CsvExporter).to receive(:provide_defaults_for_zero_vote_comments)
+          .with(job.artefacts.input_path).and_return(3)
+        service.send(:prepare_input_data)
+      end
+
+      it "returns the comments count from provide_defaults_for_zero_vote_comments" do
+        allow(Sensemaker::CsvExporter).to receive(:provide_defaults_for_zero_vote_comments)
+          .with(job.artefacts.input_path).and_return(3)
+        result = service.send(:prepare_input_data)
+
+        expect(result).to eq(3)
+      end
+    end
+
+    context "when script is advanced_runner.ts with blank input_file" do
+      before do
+        job.script = "advanced_runner.ts"
+        job.input_file = nil
+        allow(File).to receive(:exist?).with(job.artefacts.input_path).and_return(true)
+        allow(service.backend).to receive(:after_input_prepared).and_call_original
+      end
+
+      it "calls prepare_with_prep_job and then applies zero-vote defaults" do
+        allow(service).to receive(:prepare_with_prep_job).and_return(10)
+        allow(Sensemaker::CsvExporter).to receive(:provide_defaults_for_zero_vote_comments)
+          .with(job.artefacts.input_path).and_return(10)
+
+        result = service.send(:prepare_input_data)
+
+        expect(result).to eq(10)
+        expect(Sensemaker::CsvExporter).to have_received(:provide_defaults_for_zero_vote_comments)
+          .with(job.artefacts.input_path)
+      end
+    end
+
+    context "when script is sensemaking-report-ui with blank input_file" do
+      before do
+        job.script = "sensemaking-report-ui"
+        job.input_file = nil
+        allow(mock_conversation).to receive(:target_label).with(format: :full).and_return("Test Report")
+        allow(service.backend).to receive(:after_input_prepared).and_call_original
+      end
+
+      it "calls prepare_with_prep_job and writes report metadata" do
+        allow(service).to receive(:prepare_with_prep_job).and_return(15)
+        metadata_path = job.artefacts.metadata_path
+        allow(File).to receive(:exist?).with(metadata_path).and_return(false)
+        allow(File).to receive(:write)
+
+        result = service.send(:prepare_input_data)
+
+        expect(result).to eq(15)
+        expect(File).to have_received(:write).with(metadata_path, anything)
+      end
+    end
+
+    context "when input_file is already set for non-advanced_runner script" do
+      before do
+        job.script = "categorization_runner.ts"
+        job.input_file = "/existing/input.csv"
+      end
+
+      it "returns 0 when input_file is already set" do
+        result = service.send(:prepare_input_data)
+
+        expect(result).to eq(0)
+      end
+
+      it "does not export CSV when input_file is already set" do
+        service.send(:prepare_input_data)
+
+        expect(mock_exporter).not_to have_received(:export_to_csv)
+      end
+    end
+  end
+end

--- a/spec/lib/sensemaker/job_runner_spec.rb
+++ b/spec/lib/sensemaker/job_runner_spec.rb
@@ -1,0 +1,568 @@
+require "rails_helper"
+
+describe Sensemaker::JobRunner do
+  let(:user) { create(:user) }
+  let(:debate) { create(:debate) }
+  let(:job) do
+    create(:sensemaker_job,
+           analysable_type: "Debate",
+           analysable_id: debate.id,
+           script: "categorization_runner.ts",
+           user: user,
+           started_at: Time.current,
+           additional_context: "")
+  end
+
+  describe "#initialize" do
+    it "initializes with the provided job" do
+      service = Sensemaker::JobRunner.new(job)
+      expect(service.job).to eq(job)
+    end
+  end
+
+  describe "#run" do
+    let(:service) { Sensemaker::JobRunner.new(job) }
+
+    before do
+      FileUtils.mkdir_p(Sensemaker::Paths.sensemaker_package_folder)
+      allow(File).to receive(:exist?).and_return(true)
+      allow(service).to receive(:system).with("which node > /dev/null 2>&1").and_return(true)
+      allow(service).to receive(:system).with("which npx > /dev/null 2>&1").and_return(true)
+      allow(service).to receive_messages(check_dependencies?: true, prepare_input_data: 0)
+    end
+
+    it "runs the complete workflow successfully" do
+      allow(File).to receive(:exist?).and_return(true)
+      allow(service).to receive(:system).and_return(true)
+
+      service.run_synchronously
+
+      job.reload
+      expect(job.started_at).to be_present
+      expect(job.finished_at).to be_present
+    end
+
+    it "stops if check_dependencies? returns false" do
+      allow(service).to receive(:check_dependencies?).and_return(false)
+      expect(service).not_to receive(:execute_script)
+
+      service.run_synchronously
+    end
+
+    it "stops if execute_script returns false" do
+      expect(service).to receive(:execute_script).and_return(false)
+
+      service.run_synchronously
+    end
+
+    it "handles errors and updates the job" do
+      expect(service).to receive(:execute_script).and_raise(StandardError.new("Test error"))
+
+      expect { service.run_synchronously }.to raise_error(StandardError)
+
+      job.reload
+      expect(job.finished_at).to be_present
+      expect(job.error).to include("Test error")
+    end
+  end
+
+  describe "#check_dependencies?" do
+    let(:service) { Sensemaker::JobRunner.new(job) }
+    let(:llm_config) do
+      double(
+        "LLM config",
+        vertexai_project_id: "sensemaker-466109",
+        vertexai_location: "global",
+        openai_api_key: "openai-secret",
+        openai_api_base: "https://openai-proxy.example.com/v1",
+        together_api_base: "https://api.together.xyz/v1",
+        mistral_api_base: "https://api.mistral.ai/v1",
+        ollama_api_base: "http://localhost:11434",
+        together_api_key: "together-secret",
+        mistral_api_key: "mistral-secret"
+      )
+    end
+    let(:llm_context) { double("LLM context", config: llm_config) }
+
+    before do
+      allow(service).to receive(:system).with("which node > /dev/null 2>&1").and_return(true)
+      allow(service).to receive(:system).with("which npx > /dev/null 2>&1").and_return(true)
+      allow(File).to receive(:exist?).and_return(true)
+      allow(Llm::Config).to receive(:context).and_return(llm_context)
+      allow(Setting).to receive(:[]).and_call_original
+      allow(Setting).to receive(:[]).with("llm.provider").and_return("VertexAI")
+      allow(Setting).to receive(:[]).with("llm.model").and_return("gemini-2.5-flash-lite")
+    end
+
+    it "returns true when all dependencies are available" do
+      result = service.send(:check_dependencies?)
+      expect(result).to be true
+    end
+
+    {
+      "sensemaker_data_folder is not configured" => [
+        -> { allow(Tenant.current_secrets).to receive(:sensemaker_data_folder).and_return(nil) },
+        "Sensemaker data folder not configured"
+      ],
+      "Vertex AI project_id is not configured" => [
+        -> { allow(llm_config).to receive(:vertexai_project_id).and_return(nil) },
+        "Vertex AI is not configured"
+      ],
+      "LLM provider is unsupported" => [
+        -> { allow(Setting).to receive(:[]).with("llm.provider").and_return("Unsupported") },
+        "Sensemaker LLM provider is not supported"
+      ],
+      "LLM model is not selected" => [
+        -> { allow(Setting).to receive(:[]).with("llm.model").and_return(nil) },
+        "Sensemaker requires an LLM model to be selected"
+      ],
+      "Node.js is not available" => [
+        -> { allow(service).to receive(:system).with("which node > /dev/null 2>&1").and_return(false) },
+        "Node.js not found"
+      ],
+      "NPX is not available" => [
+        -> { allow(service).to receive(:system).with("which npx > /dev/null 2>&1").and_return(false) },
+        "NPX not found"
+      ],
+      "the sensemaking-tools package folder does not exist" => [
+        -> {
+          allow(File).to receive(:exist?).with(Sensemaker::Paths.sensemaker_package_folder).and_return(false)
+        },
+        "sensemaking-tools package folder not found"
+      ],
+      "the sensemaking data folder does not exist" => [
+        -> {
+          allow(File).to receive(:exist?).with(Sensemaker::Paths.sensemaker_data_folder).and_return(false)
+        },
+        "Sensemaker data folder not found"
+      ],
+      "the input file does not exist" => [
+        -> {
+          allow(File).to receive(:exist?).with(Sensemaker::Paths.sensemaker_package_folder).and_return(true)
+          allow(File).to receive(:exist?).with(job.artefacts.input_path).and_return(false)
+        },
+        "Input file not found"
+      ],
+      "apis.google_application_credentials is set but key file does not exist" => [
+        -> {
+          allow(Rails.application.secrets).to receive(:google_application_credentials)
+          .and_return("/nonexistent/key.json")
+          allow(File).to receive(:exist?).with("/nonexistent/key.json").and_return(false)
+          allow(File).to receive(:exist?).with(Sensemaker::Paths.sensemaker_package_folder).and_return(true)
+          allow(File).to receive(:exist?).with(job.artefacts.input_path).and_return(true)
+        },
+        "Key file (apis.google_application_credentials) not found"
+      ],
+      "the script file does not exist" => [
+        -> {
+          allow(File).to receive(:exist?).with(Sensemaker::Paths.sensemaker_package_folder).and_return(true)
+          allow(File).to receive(:exist?).with(job.artefacts.input_path).and_return(true)
+          allow(File).to receive(:exist?).with(service.script_file).and_return(false)
+        },
+        "Script file not found"
+      ]
+    }.each do |description, (setup, error_substring)|
+      it "returns false when #{description}" do
+        instance_exec(&setup)
+        result = service.send(:check_dependencies?)
+        expect(result).to be false
+        job.reload
+        expect(job.finished_at).to be_present
+        expect(job.error).to include(error_substring)
+      end
+    end
+
+    it "returns true for OpenAI-compatible provider with API key" do
+      allow(Setting).to receive(:[]).with("llm.provider").and_return("OpenAI")
+      allow(llm_config).to receive(:openai_api_key).and_return("tenant-openai-key")
+
+      result = service.send(:check_dependencies?)
+      expect(result).to be true
+    end
+
+    it "returns false for OpenAI-compatible provider without API key" do
+      allow(Setting).to receive(:[]).with("llm.provider").and_return("OpenAI")
+      allow(llm_config).to receive(:openai_api_key).and_return(nil)
+
+      result = service.send(:check_dependencies?)
+      expect(result).to be false
+      job.reload
+      expect(job.error).to include("Sensemaker requires an API key for provider 'openai'")
+    end
+  end
+
+  describe "#execute_script" do
+    let(:service) { Sensemaker::JobRunner.new(job) }
+
+    before do
+      allow(File).to receive(:exist?).and_return(true)
+      allow(Setting).to receive(:[]).and_call_original
+      allow(Setting).to receive(:[]).with("llm.provider").and_return("VertexAI")
+      allow(Setting).to receive(:[]).with("llm.model").and_return("gemini-2.5-flash-lite")
+    end
+
+    it "returns value when the script executes successfully" do
+      timeout = Sensemaker::JobRunner::TIMEOUT
+      expected_command = %r{cd .* && timeout #{timeout} .*}
+      expect(service).to receive(:`).with(expected_command).and_return("Success output")
+
+      allow(service).to receive(:process_exit_status).and_return(0)
+
+      result = service.send(:execute_script)
+
+      expect(result).to be_present
+    end
+
+    it "returns nil and updates the job when the script fails" do
+      timeout = Sensemaker::JobRunner::TIMEOUT
+      expected_command = %r{cd .* && timeout #{timeout} .*}
+      expect(service).to receive(:`).with(expected_command).and_return("Error output")
+
+      allow(service).to receive(:process_exit_status).and_return(1)
+
+      result = service.send(:execute_script)
+
+      expect(result).to be nil
+
+      job.reload
+      expect(job.finished_at).to be_present
+      expect(job.error).to include("Command:")
+      expect(job.error).to include("Error output")
+    end
+
+    it "redacts api keys in stored command errors" do
+      timeout = Sensemaker::JobRunner::TIMEOUT
+      expected_command = %r{cd .* && timeout #{timeout} .*--apiKey super-secret-key.*}
+      expect(service).to receive(:`).with(expected_command).and_return("Error output")
+      allow(service).to receive_messages(
+        sensemaker_adapter: "openai-compatible",
+        sensemaker_provider: "openai",
+        sensemaker_api_key: "super-secret-key",
+        process_exit_status: 1
+      )
+
+      service.send(:execute_script)
+      job.reload
+      expect(job.error).to include("--apiKey [REDACTED]")
+      expect(job.error).not_to include("super-secret-key")
+    end
+  end
+
+  describe "#build_command" do
+    let(:service) { Sensemaker::JobRunner.new(job) }
+    let(:llm_config) do
+      double(
+        "LLM config",
+        vertexai_project_id: "sensemaker-466109",
+        vertexai_location: "global",
+        openai_api_key: "openai-secret",
+        openai_api_base: "https://openai-proxy.example.com/v1",
+        together_api_base: "https://api.together.xyz/v1",
+        mistral_api_base: "https://api.mistral.ai/v1",
+        ollama_api_base: "http://localhost:11434",
+        together_api_key: "together-secret",
+        mistral_api_key: "mistral-secret"
+      )
+    end
+    let(:llm_context) { double("LLM context", config: llm_config) }
+
+    before do
+      allow(Llm::Config).to receive(:context).and_return(llm_context)
+      allow(Setting).to receive(:[]).and_call_original
+      allow(Setting).to receive(:[]).with("llm.provider").and_return("VertexAI")
+      allow(Setting).to receive(:[]).with("llm.model").and_return("gemini-2.5-flash-lite")
+    end
+
+    shared_examples "runner command with common flags" do |script_name, use_output_file_flag: true|
+      it "returns the correct command for #{script_name}" do
+        service.job.script = script_name
+        command = service.build_command
+        expect(command).to include("npx ts-node #{service.script_file}")
+        expect(command).to include("--adapter vertex")
+        expect(command).to include("--vertexProject sensemaker-466109")
+        expect(command).to include("--vertexLocation global")
+        expect(command).to include("--modelName gemini-2.5-flash-lite")
+        expect(command).not_to include("--keyFilename")
+        expect(command).not_to include("--baseUrl")
+        expect(command).to include("--inputFile #{job.artefacts.input_path}")
+        if use_output_file_flag
+          expect(command).to include("--outputFile #{service.output_file}")
+        else
+          expect(command).not_to include("--outputFile")
+          expect(command).to include("--outputBasename #{service.output_file}")
+        end
+      end
+    end
+
+    it_behaves_like "runner command with common flags", "categorization_runner.ts", use_output_file_flag: true
+    it_behaves_like "runner command with common flags", "advanced_runner.ts", use_output_file_flag: false
+    it_behaves_like "runner command with common flags", "runner.ts", use_output_file_flag: false
+
+    it "returns the correct command for OpenAI-compatible providers" do
+      allow(Setting).to receive(:[]).with("llm.provider").and_return("OpenAI")
+
+      command = service.build_command
+      expect(command).to include("--adapter openai-compatible")
+      expect(command).to include("--provider openai")
+      expect(command).to include("--apiKey openai-secret")
+      expect(command).to include("--baseUrl https://openai-proxy.example.com/v1")
+      expect(command).not_to include("--vertexProject")
+      expect(command).not_to include("--vertexLocation")
+    end
+
+    it "omits baseUrl for OpenAI-compatible providers when not configured" do
+      allow(Setting).to receive(:[]).with("llm.provider").and_return("OpenAI")
+      allow(llm_config).to receive(:openai_api_base).and_return(nil)
+
+      command = service.build_command
+      expect(command).not_to include("--baseUrl")
+    end
+
+    it "returns the correct command for ollama provider" do
+      allow(Setting).to receive(:[]).with("llm.provider").and_return("ollama")
+
+      command = service.build_command
+      expect(command).to include("--adapter ollama")
+      expect(command).to include("--baseUrl http://localhost:11434")
+      expect(command).not_to include("--provider")
+      expect(command).not_to include("--apiKey")
+      expect(command).not_to include("--vertexProject")
+    end
+
+    it "returns the correct command for the sensemaking-report-ui script" do
+      service.job.update!(script: "sensemaking-report-ui")
+      conversation = instance_double(Sensemaker::Conversation)
+      allow(service.job).to receive(:conversation).and_return(conversation)
+      allow(conversation).to receive(:target_label).with(format: :full).and_return("Test Label")
+
+      command = service.build_command
+      input_path = job.artefacts.input_path
+
+      expect(command).to include("npx sensemaking-report-ui inline")
+      expect(command).to include("--topics")
+      expect(command).to include("#{input_path}-topic-stats.json")
+      expect(command).to include("--summary")
+      expect(command).to include("#{input_path}-summary.json")
+      expect(command).to include("--comments")
+      expect(command).to include("#{input_path}-comments-with-scores.json")
+      expect(command).to include("--metadata")
+      expect(command).to include(job.artefacts.metadata_path)
+      expect(command).to include(Shellwords.escape("Report for Test Label"))
+      expect(command).to include("--outputDir")
+      expect(command).to include("--outputFile")
+      expect(command).to include(service.output_file_name)
+    end
+  end
+
+  describe "#script_file" do
+    let(:service) { Sensemaker::JobRunner.new(job) }
+
+    package_folder = Sensemaker::Paths.sensemaker_package_folder
+    runner_cli = "#{package_folder}/runner-cli"
+    report_ui = "/tmp/sensemaker_test_folder/report-ui"
+
+    before do
+      allow(Sensemaker::Paths).to receive(:report_ui_folder).and_return(report_ui)
+    end
+
+    {
+      "categorization_runner.ts" => "#{runner_cli}/categorization_runner.ts",
+      "runner.ts" => "#{runner_cli}/runner.ts",
+      "advanced_runner.ts" => "#{runner_cli}/advanced_runner.ts",
+      "health_check_runner.ts" => "#{runner_cli}/health_check_runner.ts",
+      "sensemaking-report-ui" => "#{report_ui}/bin/cli.js"
+    }.each do |script, expected_path|
+      it "returns the correct path for #{script}" do
+        job.script = script
+        expect(service.script_file).to eq(expected_path)
+      end
+    end
+  end
+
+  describe "#execute_job_workflow" do
+    let(:service) { Sensemaker::JobRunner.new(job) }
+
+    before do
+      allow(File).to receive(:exist?).and_return(true)
+      allow(service).to receive(:system).with("which node > /dev/null 2>&1").and_return(true)
+      allow(service).to receive(:system).with("which npx > /dev/null 2>&1").and_return(true)
+      allow(service).to receive_messages(check_dependencies?: true, execute_script: "success")
+      allow(service).to receive(:prepare_input_data)
+    end
+
+    context "when artefacts are complete" do
+      it "sets finished_at and does not set error" do
+        allow(job.artefacts).to receive(:complete?).and_return(true)
+
+        service.send(:execute_job_workflow)
+
+        job.reload
+        expect(job.finished_at).to be_present
+        expect(job.error).to be(nil)
+      end
+
+      it "sets comments_analysed count when job finishes successfully" do
+        allow(job.artefacts).to receive(:complete?).and_return(true)
+        allow(service).to receive(:prepare_input_data).and_return(5)
+
+        service.send(:execute_job_workflow)
+
+        job.reload
+        expect(job.comments_analysed).to eq(5)
+      end
+    end
+
+    context "when artefacts are incomplete" do
+      it "sets finished_at and error message" do
+        allow(job.artefacts).to receive(:complete?).and_return(false)
+
+        service.send(:execute_job_workflow)
+
+        job.reload
+        expect(job.finished_at).to be_present
+        expect(job.error).to eq("Output file(s) not found")
+      end
+    end
+  end
+
+  describe "#prepare_input_data" do
+    let(:service) { Sensemaker::JobRunner.new(job) }
+    let(:mock_exporter) { instance_double(Sensemaker::CsvExporter) }
+    let(:input_file_path) { "#{Sensemaker::Paths.sensemaker_data_folder}/input-#{job.id}.csv" }
+    let(:mock_conversation) { instance_double(Sensemaker::Conversation) }
+    let(:mock_comments) { Array.new(7) { double("comment") } }
+
+    before do
+      allow(Sensemaker::CsvExporter).to receive(:new).and_return(mock_exporter)
+      allow(mock_exporter).to receive(:export_to_csv)
+      allow(job).to receive(:conversation).and_return(mock_conversation)
+      allow(mock_conversation).to receive_messages(
+        comments: mock_comments,
+        compile_context: "Test context"
+      )
+    end
+
+    it "creates a CsvExporter with the job's conversation" do
+      service.send(:prepare_input_data)
+
+      expect(Sensemaker::CsvExporter).to have_received(:new).with(mock_conversation)
+    end
+
+    it "exports CSV data to the input file" do
+      service.send(:prepare_input_data)
+
+      expect(mock_exporter).to have_received(:export_to_csv).with(input_file_path)
+    end
+
+    it "persists input_file after exporting CSV when input_file is blank" do
+      expect(job.read_attribute(:input_file)).to be(nil)
+
+      service.send(:prepare_input_data)
+
+      expect(job.reload.input_file).to eq(input_file_path)
+    end
+
+    it "updates the job with additional context" do
+      allow(job).to receive(:conversation).and_return(
+        Sensemaker::Conversation.new(job.analysable_type, job.analysable_id)
+      )
+
+      service.send(:prepare_input_data)
+
+      job.reload
+      expect(job.additional_context).to be_present
+      expect(job.additional_context).to include("Analysing Citizen debate")
+      expect(job.additional_context).to include(debate.title)
+    end
+
+    it "returns the count of comments from conversation when input_file is blank" do
+      job.input_file = nil
+      result = service.send(:prepare_input_data)
+
+      expect(result).to eq(7)
+    end
+
+    context "when script is advanced_runner.ts" do
+      before do
+        job.script = "advanced_runner.ts"
+        job.input_file = "/tmp/categorization-output.csv"
+        allow(File).to receive(:exist?).with(job.artefacts.input_path).and_return(true)
+      end
+
+      it "calls CsvExporter.provide_defaults_for_zero_vote_comments" do
+        expect(Sensemaker::CsvExporter).to receive(:provide_defaults_for_zero_vote_comments)
+          .with(job.artefacts.input_path).and_return(3)
+        service.send(:prepare_input_data)
+      end
+
+      it "returns the comments count from provide_defaults_for_zero_vote_comments" do
+        allow(Sensemaker::CsvExporter).to receive(:provide_defaults_for_zero_vote_comments)
+          .with(job.artefacts.input_path).and_return(3)
+        result = service.send(:prepare_input_data)
+
+        expect(result).to eq(3)
+      end
+    end
+
+    context "when script is advanced_runner.ts with blank input_file" do
+      let(:categorization_job) { create(:sensemaker_job, comments_analysed: 10) }
+      let(:categorization_runner) { instance_double(Sensemaker::JobRunner) }
+
+      before do
+        job.script = "advanced_runner.ts"
+        job.input_file = nil
+        allow(File).to receive(:exist?).with(job.artefacts.input_path).and_return(true)
+      end
+
+      it "calls prepare_with_categorization_job and then applies zero-vote defaults" do
+        allow(service).to receive(:prepare_with_categorization_job).and_return(10)
+        allow(Sensemaker::CsvExporter).to receive(:provide_defaults_for_zero_vote_comments)
+          .with(job.artefacts.input_path).and_return(10)
+
+        result = service.send(:prepare_input_data)
+
+        expect(result).to eq(10)
+        expect(Sensemaker::CsvExporter).to have_received(:provide_defaults_for_zero_vote_comments)
+          .with(job.artefacts.input_path)
+      end
+    end
+
+    context "when script is sensemaking-report-ui with blank input_file" do
+      let(:advanced_job) { create(:sensemaker_job, comments_analysed: 15) }
+
+      before do
+        job.script = "sensemaking-report-ui"
+        job.input_file = nil
+      end
+
+      it "calls prepare_with_advanced_runner_job and returns its comments_analysed count" do
+        allow(service).to receive(:prepare_with_advanced_runner_job).and_return(15)
+        allow(service).to receive(:write_report_metadata)
+
+        result = service.send(:prepare_input_data)
+
+        expect(result).to eq(15)
+        expect(service).to have_received(:write_report_metadata)
+      end
+    end
+
+    context "when input_file is already set for non-advanced_runner script" do
+      before do
+        job.script = "categorization_runner.ts"
+        job.input_file = "/existing/input.csv"
+      end
+
+      it "returns 0 when input_file is already set" do
+        result = service.send(:prepare_input_data)
+
+        expect(result).to eq(0)
+      end
+
+      it "does not export CSV when input_file is already set" do
+        service.send(:prepare_input_data)
+
+        expect(mock_exporter).not_to have_received(:export_to_csv)
+      end
+    end
+  end
+end

--- a/spec/lib/sensemaker/runtime_config_spec.rb
+++ b/spec/lib/sensemaker/runtime_config_spec.rb
@@ -1,0 +1,107 @@
+require "rails_helper"
+
+describe Sensemaker::RuntimeConfig do
+  let(:setting) { class_double(Setting) }
+  let(:llm_config) do
+    double(
+      "LLM config",
+      vertexai_project_id: "sensemaker-466109",
+      vertexai_location: "global",
+      openai_api_key: "openai-secret",
+      openai_api_base: "https://openai-proxy.example.com/v1",
+      openrouter_api_key: "openrouter-secret",
+      openrouter_api_base: "https://openrouter.ai/api/v1",
+      mistral_api_key: "mistral-secret",
+      mistral_api_base: "https://api.mistral.ai/v1",
+      ollama_api_base: "http://localhost:11434"
+    )
+  end
+  let(:llm_context) { double("LLM context", config: llm_config) }
+  let(:runtime_config) { Sensemaker::RuntimeConfig.new(setting: setting, llm_context: llm_context) }
+
+  before do
+    allow(setting).to receive(:[]).and_return(nil)
+  end
+
+  describe "#provider and #model" do
+    it "normalizes provider and returns selected model" do
+      allow(setting).to receive(:[]).with("llm.provider").and_return(" OpenAI ")
+      allow(setting).to receive(:[]).with("llm.model").and_return("gpt-4.1-mini")
+
+      expect(runtime_config.provider).to eq("openai")
+      expect(runtime_config.model).to eq("gpt-4.1-mini")
+    end
+  end
+
+  describe "#adapter" do
+    it "maps vertex provider to vertex adapter" do
+      allow(setting).to receive(:[]).with("llm.provider").and_return("VertexAI")
+      expect(runtime_config.adapter).to eq("vertex")
+    end
+
+    it "maps openai provider to openai-compatible adapter" do
+      allow(setting).to receive(:[]).with("llm.provider").and_return("OpenAI")
+      expect(runtime_config.adapter).to eq("openai-compatible")
+    end
+
+    it "maps ollama provider to ollama adapter" do
+      allow(setting).to receive(:[]).with("llm.provider").and_return("ollama")
+      expect(runtime_config.adapter).to eq("ollama")
+    end
+
+    it "returns nil for unsupported provider" do
+      allow(setting).to receive(:[]).with("llm.provider").and_return("unsupported")
+      expect(runtime_config.adapter).to be(nil)
+      expect(runtime_config.supported?).to be(false)
+    end
+  end
+
+  describe "#compat_provider, #api_key and #base_url" do
+    it "resolves openai-compatible provider settings" do
+      allow(setting).to receive(:[]).with("llm.provider").and_return("OpenAI")
+
+      expect(runtime_config.compat_provider).to eq("openai")
+      expect(runtime_config.api_key).to eq("openai-secret")
+      expect(runtime_config.base_url).to eq("https://openai-proxy.example.com/v1")
+    end
+
+    it "resolves openrouter provider settings" do
+      allow(setting).to receive(:[]).with("llm.provider").and_return("OpenRouter")
+
+      expect(runtime_config.adapter).to eq("openai-compatible")
+      expect(runtime_config.compat_provider).to eq("openrouter")
+      expect(runtime_config.api_key).to eq("openrouter-secret")
+      expect(runtime_config.base_url).to eq("https://openrouter.ai/api/v1")
+    end
+
+    it "resolves ollama base url" do
+      allow(setting).to receive(:[]).with("llm.provider").and_return("ollama")
+
+      expect(runtime_config.compat_provider).to be(nil)
+      expect(runtime_config.api_key).to be(nil)
+      expect(runtime_config.base_url).to eq("http://localhost:11434")
+    end
+
+    it "returns nil api_key/base_url when config methods are unavailable" do
+      limited_config = double("LLM config", vertexai_project_id: "proj", vertexai_location: nil)
+      limited_context = double("LLM context", config: limited_config)
+      cfg = Sensemaker::RuntimeConfig.new(setting: setting, llm_context: limited_context)
+      allow(setting).to receive(:[]).with("llm.provider").and_return("OpenAI")
+
+      expect(cfg.api_key).to be(nil)
+      expect(cfg.base_url).to be(nil)
+    end
+  end
+
+  describe "#vertex_project_id and #vertex_location" do
+    it "returns vertex project and location" do
+      expect(runtime_config.vertex_project_id).to eq("sensemaker-466109")
+      expect(runtime_config.vertex_location).to eq("global")
+    end
+
+    it "defaults vertex location to global when blank" do
+      allow(llm_config).to receive(:vertexai_location).and_return(nil)
+      expect(runtime_config.vertex_location).to eq("global")
+    end
+  end
+end

--- a/spec/lib/sensemaker/runtime_config_spec.rb
+++ b/spec/lib/sensemaker/runtime_config_spec.rb
@@ -1,0 +1,94 @@
+require "rails_helper"
+
+describe Sensemaker::RuntimeConfig do
+  include_context "sensemaker llm config"
+
+  let(:setting) { class_double(Setting) }
+  let(:runtime_config) { Sensemaker::RuntimeConfig.new(setting: setting, llm_context: llm_context) }
+
+  before do
+    allow(setting).to receive(:[]).and_return(nil)
+  end
+
+  describe "#provider and #model" do
+    it "normalizes provider and returns selected model" do
+      allow(setting).to receive(:[]).with("llm.provider").and_return(" OpenAI ")
+      allow(setting).to receive(:[]).with("llm.model").and_return("gpt-4.1-mini")
+
+      expect(runtime_config.provider).to eq("openai")
+      expect(runtime_config.model).to eq("gpt-4.1-mini")
+    end
+  end
+
+  describe "#adapter" do
+    it "maps vertex provider to vertex adapter" do
+      allow(setting).to receive(:[]).with("llm.provider").and_return("VertexAI")
+      expect(runtime_config.adapter).to eq("vertex")
+    end
+
+    it "maps openai provider to openai-compatible adapter" do
+      allow(setting).to receive(:[]).with("llm.provider").and_return("OpenAI")
+      expect(runtime_config.adapter).to eq("openai-compatible")
+    end
+
+    it "maps ollama provider to ollama adapter" do
+      allow(setting).to receive(:[]).with("llm.provider").and_return("ollama")
+      expect(runtime_config.adapter).to eq("ollama")
+    end
+
+    it "returns nil for unsupported provider" do
+      allow(setting).to receive(:[]).with("llm.provider").and_return("unsupported")
+      expect(runtime_config.adapter).to be(nil)
+      expect(runtime_config.supported?).to be(false)
+    end
+  end
+
+  describe "#compat_provider, #api_key and #base_url" do
+    it "resolves openai-compatible provider settings" do
+      allow(setting).to receive(:[]).with("llm.provider").and_return("OpenAI")
+
+      expect(runtime_config.compat_provider).to eq("openai")
+      expect(runtime_config.api_key).to eq("openai-secret")
+      expect(runtime_config.base_url).to eq("https://openai-proxy.example.com/v1")
+    end
+
+    it "resolves openrouter provider settings" do
+      allow(setting).to receive(:[]).with("llm.provider").and_return("OpenRouter")
+
+      expect(runtime_config.adapter).to eq("openai-compatible")
+      expect(runtime_config.compat_provider).to eq("openrouter")
+      expect(runtime_config.api_key).to eq("openrouter-secret")
+      expect(runtime_config.base_url).to eq("https://openrouter.ai/api/v1")
+    end
+
+    it "resolves ollama base url" do
+      allow(setting).to receive(:[]).with("llm.provider").and_return("ollama")
+
+      expect(runtime_config.compat_provider).to be(nil)
+      expect(runtime_config.api_key).to be(nil)
+      expect(runtime_config.base_url).to eq("http://localhost:11434")
+    end
+
+    it "returns nil api_key/base_url when config methods are unavailable" do
+      limited_config = double("LLM config", vertexai_project_id: "proj", vertexai_location: nil)
+      limited_context = double("LLM context", config: limited_config)
+      cfg = Sensemaker::RuntimeConfig.new(setting: setting, llm_context: limited_context)
+      allow(setting).to receive(:[]).with("llm.provider").and_return("OpenAI")
+
+      expect(cfg.api_key).to be(nil)
+      expect(cfg.base_url).to be(nil)
+    end
+  end
+
+  describe "#vertex_project_id and #vertex_location" do
+    it "returns vertex project and location" do
+      expect(runtime_config.vertex_project_id).to eq("sensemaker-466109")
+      expect(runtime_config.vertex_location).to eq("global")
+    end
+
+    it "defaults vertex location to global when blank" do
+      allow(llm_config).to receive(:vertexai_location).and_return(nil)
+      expect(runtime_config.vertex_location).to eq("global")
+    end
+  end
+end

--- a/spec/lib/sensemaker/script_registry_spec.rb
+++ b/spec/lib/sensemaker/script_registry_spec.rb
@@ -1,0 +1,170 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe Sensemaker::ScriptRegistry do
+  node_script_ids = %w[
+    health_check_runner.ts
+    categorization_runner.ts
+    advanced_runner.ts
+    runner.ts
+    sensemaking-report-ui
+  ].freeze
+
+  describe ".all" do
+    it "includes all Node script ids" do
+      expect(Sensemaker::ScriptRegistry.all).to include(*node_script_ids)
+    end
+
+    it "is a superset of the :node backend scripts" do
+      node = Sensemaker::ScriptRegistry.for_backend(:node)
+      expect(Sensemaker::ScriptRegistry.all).to include(*node)
+
+      extras = Sensemaker::ScriptRegistry.all - node
+      if extras.any?
+        expect(Sensemaker::ScriptRegistry.all.size).to be > node.size
+      end
+    end
+  end
+
+  describe ".known?" do
+    it "returns true for registered scripts" do
+      expect(Sensemaker::ScriptRegistry.known?("categorization_runner.ts")).to be true
+    end
+
+    it "returns false for unknown scripts" do
+      expect(Sensemaker::ScriptRegistry.known?("unknown_runner.ts")).to be false
+    end
+  end
+
+  describe ".for_backend" do
+    it "returns Node scripts for :node" do
+      node = Sensemaker::ScriptRegistry.for_backend(:node)
+      expect(node).to include(*node_script_ids)
+      expect(node).to all(
+        satisfy { |id| Sensemaker::ScriptRegistry.backend_for(id) == :node }
+      )
+    end
+
+    it "returns empty array for unregistered backend" do
+      expect(Sensemaker::ScriptRegistry.for_backend(:unknown)).to eq([])
+    end
+  end
+
+  describe ".user_selectable" do
+    it "excludes internal prep-chain scripts" do
+      expect(Sensemaker::ScriptRegistry.user_selectable).not_to include("advanced_runner.ts")
+    end
+
+    it "includes user-facing scripts" do
+      expect(Sensemaker::ScriptRegistry.user_selectable).to include(
+        "health_check_runner.ts",
+        "categorization_runner.ts",
+        "runner.ts",
+        "sensemaking-report-ui"
+      )
+    end
+  end
+
+  describe ".publishable" do
+    it "includes Node publishable scripts" do
+      expect(Sensemaker::ScriptRegistry.publishable).to include(
+        "runner.ts",
+        "sensemaking-report-ui"
+      )
+    end
+  end
+
+  describe ".backend_for" do
+    it "returns :node for Node scripts" do
+      expect(Sensemaker::ScriptRegistry.backend_for("categorization_runner.ts")).to eq(:node)
+    end
+
+    it "returns nil for unknown scripts" do
+      expect(Sensemaker::ScriptRegistry.backend_for("unknown")).to be(nil)
+    end
+  end
+
+  describe ".logical_name" do
+    it "returns logical names for scripts" do
+      expect(Sensemaker::ScriptRegistry.logical_name("categorization_runner.ts")).to eq(:categorize)
+      expect(Sensemaker::ScriptRegistry.logical_name("sensemaking-report-ui")).to eq(:report)
+    end
+  end
+
+  describe ".prep_steps" do
+    it "returns direct prep step for advanced_runner.ts" do
+      expect(Sensemaker::ScriptRegistry.prep_steps("advanced_runner.ts")).to eq(["categorization_runner.ts"])
+    end
+
+    it "returns direct prep step for sensemaking-report-ui" do
+      expect(Sensemaker::ScriptRegistry.prep_steps("sensemaking-report-ui")).to eq(["advanced_runner.ts"])
+    end
+
+    it "returns empty array for scripts with no prep" do
+      expect(Sensemaker::ScriptRegistry.prep_steps("categorization_runner.ts")).to eq([])
+    end
+
+    it "returns empty array for unknown scripts" do
+      expect(Sensemaker::ScriptRegistry.prep_steps("unknown")).to eq([])
+    end
+  end
+
+  describe ".i18n_key" do
+    it "returns stable locale keys" do
+      expect(Sensemaker::ScriptRegistry.i18n_key("categorization_runner.ts"))
+        .to eq("categorization_runner_ts")
+      expect(Sensemaker::ScriptRegistry.i18n_key("sensemaking-report-ui")).to eq("sensemaking_report_ui")
+    end
+  end
+
+  describe ".artefact_config" do
+    let(:job) { build(:sensemaker_job, id: 42) }
+
+    it "returns config hash for known scripts" do
+      config = Sensemaker::ScriptRegistry.artefact_config("categorization_runner.ts")
+      expect(config[:output_basename].call(job)).to eq("categorization-output.csv")
+    end
+
+    it "returns nil for unknown scripts" do
+      expect(Sensemaker::ScriptRegistry.artefact_config("unknown")).to be(nil)
+    end
+  end
+
+  describe ".scripts_for_logical_name" do
+    it "includes script ids for a logical name" do
+      expect(Sensemaker::ScriptRegistry.scripts_for_logical_name(:report))
+        .to include("sensemaking-report-ui")
+      expect(Sensemaker::ScriptRegistry.scripts_for_logical_name(:summary))
+        .to include("runner.ts")
+    end
+  end
+
+  describe ".output_flag" do
+    it "returns :output_basename for multi-output scripts" do
+      expect(Sensemaker::ScriptRegistry.output_flag("advanced_runner.ts")).to eq(:output_basename)
+      expect(Sensemaker::ScriptRegistry.output_flag("runner.ts")).to eq(:output_basename)
+    end
+
+    it "returns :output_file for single-output scripts" do
+      expect(Sensemaker::ScriptRegistry.output_flag("categorization_runner.ts")).to eq(:output_file)
+      expect(Sensemaker::ScriptRegistry.output_flag("sensemaking-report-ui")).to eq(:output_file)
+      expect(Sensemaker::ScriptRegistry.output_flag("health_check_runner.ts")).to eq(:output_file)
+    end
+
+    it "returns nil for unknown scripts" do
+      expect(Sensemaker::ScriptRegistry.output_flag("unknown")).to be(nil)
+    end
+  end
+
+  describe ".requires_input?" do
+    it "returns false for health check" do
+      expect(Sensemaker::ScriptRegistry.requires_input?("health_check_runner.ts")).to be false
+    end
+
+    it "returns true for scripts that need input" do
+      expect(Sensemaker::ScriptRegistry.requires_input?("categorization_runner.ts")).to be true
+      expect(Sensemaker::ScriptRegistry.requires_input?("sensemaking-report-ui")).to be true
+    end
+  end
+end

--- a/spec/lib/sensemaker/sensemaker_spec.rb
+++ b/spec/lib/sensemaker/sensemaker_spec.rb
@@ -1,0 +1,33 @@
+require "rails_helper"
+
+describe Sensemaker do
+  describe ".enabled?" do
+    before do
+      Setting["llm.provider"] = "OpenAI"
+      Setting["llm.model"] = "gpt-4o"
+      Setting["llm.use_sensemaker"] = true
+    end
+
+    it "is true when LLM is configured and the toggle is on" do
+      expect(Sensemaker.enabled?).to be true
+    end
+
+    it "is false when the toggle is off" do
+      Setting["llm.use_sensemaker"] = false
+
+      expect(Sensemaker.enabled?).to be false
+    end
+
+    it "is false when the provider is missing" do
+      Setting["llm.provider"] = nil
+
+      expect(Sensemaker.enabled?).to be false
+    end
+
+    it "is false when the model is missing" do
+      Setting["llm.model"] = nil
+
+      expect(Sensemaker.enabled?).to be false
+    end
+  end
+end

--- a/spec/models/sensemaker/job_spec.rb
+++ b/spec/models/sensemaker/job_spec.rb
@@ -1,0 +1,88 @@
+require "rails_helper"
+
+describe Sensemaker::Job do
+  let(:user) { create(:user) }
+  let(:debate) { create(:debate) }
+  let(:job) do
+    create(:sensemaker_job,
+           analysable_type: "Debate",
+           analysable_id: debate.id,
+           script: "categorization_runner.ts",
+           user: user,
+           started_at: Time.current,
+           additional_context: "Test context")
+  end
+
+  describe "validations" do
+    it "is valid with valid attributes" do
+      expect(job).to be_valid
+    end
+
+    it "requires analysable_type" do
+      job.analysable_type = nil
+      expect(job).not_to be_valid
+    end
+
+    it "requires analysable_id for non-Proposal types" do
+      job.analysable_id = nil
+      expect(job).not_to be_valid
+    end
+  end
+
+  describe "associations" do
+    it "belongs to a user" do
+      expect(job.user).to eq(user)
+    end
+  end
+
+  describe "instance methods" do
+    describe "#started?" do
+      it "returns true when started_at is present" do
+        expect(job.started?).to be true
+      end
+
+      it "returns false when started_at is nil" do
+        job.started_at = nil
+        expect(job.started?).to be false
+      end
+    end
+
+    describe "#finished?" do
+      it "returns true when finished_at is present" do
+        job.finished_at = Time.current
+        expect(job.finished?).to be true
+      end
+
+      it "returns false when finished_at is nil" do
+        expect(job.finished?).to be false
+      end
+    end
+
+    describe "#cancelled?" do
+      it "returns true when finished_at is present and error is 'Cancelled'" do
+        job.finished_at = Time.current
+        job.error = "Cancelled"
+        expect(job.cancelled?).to be true
+      end
+    end
+
+    describe "cancel!" do
+      it "updates the job with finished_at and error 'Cancelled'" do
+        job.cancel!
+        expect(job.finished_at).to be_present
+        expect(job.error).to eq("Cancelled")
+      end
+    end
+
+    describe "#errored?" do
+      it "returns true when error is present" do
+        job.error = "Some error occurred"
+        expect(job.errored?).to be true
+      end
+
+      it "returns false when error is nil" do
+        expect(job.errored?).to be false
+      end
+    end
+  end
+end

--- a/spec/models/sensemaker/job_spec.rb
+++ b/spec/models/sensemaker/job_spec.rb
@@ -13,6 +13,14 @@ describe Sensemaker::Job do
            additional_context: "Test context")
   end
 
+  shared_context "sensemaker paths stubbed" do
+    let(:data_folder) { "/tmp/sensemaker_test_folder/data" }
+
+    before do
+      allow(Sensemaker::Paths).to receive(:sensemaker_data_folder).and_return(data_folder)
+    end
+  end
+
   describe "validations" do
     it "is valid with valid attributes" do
       expect(job).to be_valid
@@ -42,6 +50,28 @@ describe Sensemaker::Job do
   end
 
   describe "instance methods" do
+    describe "#artefacts" do
+      it "returns a JobArtefacts instance for the job" do
+        expect(job.artefacts).to be_a(Sensemaker::JobArtefacts)
+        expect(job.artefacts.job).to eq(job)
+      end
+
+      it "memoizes the artefacts instance" do
+        expect(job.artefacts).to equal(job.artefacts)
+      end
+    end
+
+    describe "#conversation" do
+      it "returns a Sensemaker::Conversation for the job analysable" do
+        expect(job.conversation).to be_a(Sensemaker::Conversation)
+        expect(job.conversation.target).to eq(debate)
+      end
+
+      it "memoizes the conversation instance" do
+        expect(job.conversation).to equal(job.conversation)
+      end
+    end
+
     describe "#started?" do
       it "returns true when started_at is present" do
         expect(job.started?).to be true
@@ -88,6 +118,134 @@ describe Sensemaker::Job do
 
       it "returns false when error is nil" do
         expect(job.errored?).to be false
+      end
+    end
+  end
+
+  describe "callbacks" do
+    describe "before_save :set_persisted_output_if_successful" do
+      include_context "sensemaker paths stubbed"
+
+      before do
+        allow(File).to receive(:exist?).and_return(false)
+      end
+
+      shared_examples "sets persisted_output when all output files exist" do |script_name, paths_fn|
+        it "sets persisted_output to relative_output_path for #{script_name}" do
+          job.script = script_name
+          paths = paths_fn.call(job, data_folder)
+          paths.each { |p| allow(File).to receive(:exist?).with(p).and_return(true) }
+
+          job.finished_at = Time.current
+          job.error = nil
+          job.save!
+
+          expect(job.persisted_output).to eq(job.artefacts.relative_output_path)
+          expect(job.persisted_output).not_to start_with("/")
+        end
+      end
+
+      context "when job is successful (finished_at present, no error)" do
+        context "when persisted_output is not set" do
+          context "when all output files exist" do
+            it_behaves_like "sets persisted_output when all output files exist",
+                            "categorization_runner.ts",
+                            ->(j, df) { ["#{df}/categorization-output-#{j.id}.csv"] }
+
+            it_behaves_like "sets persisted_output when all output files exist",
+                            "advanced_runner.ts",
+                            ->(j, df) {
+                              ["#{df}/output-#{j.id}-summary.json", "#{df}/output-#{j.id}-topic-stats.json",
+                               "#{df}/output-#{j.id}-comments-with-scores.json"]
+                            }
+
+            it_behaves_like "sets persisted_output when all output files exist",
+                            "runner.ts",
+                            ->(j, df) {
+                              ["#{df}/output-#{j.id}-summary.json", "#{df}/output-#{j.id}-summary.html",
+                               "#{df}/output-#{j.id}-summary.md", "#{df}/output-#{j.id}-summaryAndSource.csv"]
+                            }
+          end
+
+          context "when not all output files exist" do
+            it "does not set persisted_output" do
+              job.script = "advanced_runner.ts"
+              base_path = "#{data_folder}/output-#{job.id}"
+              allow(File).to receive(:exist?).with("#{base_path}-summary.json").and_return(true)
+              allow(File).to receive(:exist?).with("#{base_path}-topic-stats.json").and_return(true)
+              allow(File).to receive(:exist?).with("#{base_path}-comments-with-scores.json").and_return(false)
+
+              job.finished_at = Time.current
+              job.error = nil
+              job.save!
+
+              expect(job.persisted_output).to be(nil)
+            end
+          end
+        end
+
+        context "when persisted_output is already set" do
+          it "does not overwrite existing persisted_output" do
+            existing_path = "vendor/sensemaking-tools/data/output-#{job.id}"
+            job.persisted_output = existing_path
+
+            job.finished_at = Time.current
+            job.error = nil
+            job.save!
+
+            expect(job.persisted_output).to eq(existing_path)
+          end
+        end
+      end
+
+      context "when job is not finished" do
+        it "does not set persisted_output" do
+          job.finished_at = nil
+          job.error = nil
+          job.save!
+
+          expect(job.persisted_output).to be(nil)
+        end
+      end
+
+      context "when job has an error" do
+        it "does not set persisted_output" do
+          job.finished_at = Time.current
+          job.error = "Some error occurred"
+          job.save!
+
+          expect(job.persisted_output).to be(nil)
+        end
+      end
+    end
+
+    describe "after_destroy" do
+      include_context "sensemaker paths stubbed"
+
+      before do
+        allow(FileUtils).to receive(:rm_f).and_return(true)
+        allow(Rails.logger).to receive(:info)
+        allow(Rails.logger).to receive(:warn)
+      end
+
+      it "calls artefacts.cleanup when job is destroyed" do
+        expect(job.artefacts).to receive(:cleanup).and_return([])
+        job.destroy!
+      end
+
+      it "logs cleanup results" do
+        allow(job.artefacts).to receive(:cleanup).and_return(["/tmp/cleaned"])
+        expect(Rails.logger).to receive(:info).with(/Cleaned up files for job #{job.id}/)
+
+        job.destroy!
+      end
+
+      it "continues with destruction even if cleanup fails" do
+        allow(job.artefacts).to receive(:cleanup).and_return(nil)
+        expect(Rails.logger).to receive(:warn).with(/Failed to cleanup files for job #{job.id}/)
+
+        expect { job.destroy }.not_to raise_error
+        expect(Sensemaker::Job.find_by(id: job.id)).to be(nil)
       end
     end
   end

--- a/spec/models/sensemaker/job_spec.rb
+++ b/spec/models/sensemaker/job_spec.rb
@@ -27,6 +27,12 @@ describe Sensemaker::Job do
       job.analysable_id = nil
       expect(job).not_to be_valid
     end
+
+    it "allows nil analysable_id for Proposal type" do
+      job.analysable_type = "Proposal"
+      job.analysable_id = nil
+      expect(job).to be_valid
+    end
   end
 
   describe "associations" do

--- a/spec/models/sensemaker/job_spec.rb
+++ b/spec/models/sensemaker/job_spec.rb
@@ -13,6 +13,15 @@ describe Sensemaker::Job do
            additional_context: "Test context")
   end
 
+  shared_context "sensemaker paths stubbed" do
+    let(:data_folder) { "/tmp/sensemaker_test_folder/data" }
+    let(:job_dir) { "#{data_folder}/job-#{job.id}" }
+
+    before do
+      allow(Sensemaker::Paths).to receive(:sensemaker_data_folder).and_return(data_folder)
+    end
+  end
+
   describe "validations" do
     it "is valid with valid attributes" do
       expect(job).to be_valid
@@ -42,6 +51,28 @@ describe Sensemaker::Job do
   end
 
   describe "instance methods" do
+    describe "#artefacts" do
+      it "returns a JobArtefacts instance for the job" do
+        expect(job.artefacts).to be_a(Sensemaker::JobArtefacts)
+        expect(job.artefacts.job).to eq(job)
+      end
+
+      it "memoizes the artefacts instance" do
+        expect(job.artefacts).to equal(job.artefacts)
+      end
+    end
+
+    describe "#conversation" do
+      it "returns a Sensemaker::Conversation for the job analysable" do
+        expect(job.conversation).to be_a(Sensemaker::Conversation)
+        expect(job.conversation.target).to eq(debate)
+      end
+
+      it "memoizes the conversation instance" do
+        expect(job.conversation).to equal(job.conversation)
+      end
+    end
+
     describe "#started?" do
       it "returns true when started_at is present" do
         expect(job.started?).to be true
@@ -88,6 +119,136 @@ describe Sensemaker::Job do
 
       it "returns false when error is nil" do
         expect(job.errored?).to be false
+      end
+    end
+  end
+
+  describe "callbacks" do
+    describe "before_save :set_persisted_output_if_successful" do
+      include_context "sensemaker paths stubbed"
+
+      before do
+        allow(File).to receive(:exist?).and_return(false)
+      end
+
+      shared_examples "sets persisted_output when all output files exist" do |script_name, paths_fn|
+        it "sets persisted_output to relative_output_path for #{script_name}" do
+          job.script = script_name
+          paths = paths_fn.call(job, data_folder)
+          paths.each { |p| allow(File).to receive(:exist?).with(p).and_return(true) }
+
+          job.finished_at = Time.current
+          job.error = nil
+          job.save!
+
+          expect(job.persisted_output).to eq(job.artefacts.relative_output_path)
+          expect(job.persisted_output).not_to start_with("/")
+        end
+      end
+
+      context "when job is successful (finished_at present, no error)" do
+        context "when persisted_output is not set" do
+          context "when all output files exist" do
+            it_behaves_like "sets persisted_output when all output files exist",
+                            "categorization_runner.ts",
+                            ->(j, df) { ["#{df}/job-#{j.id}/categorization-output.csv"] }
+
+            it_behaves_like "sets persisted_output when all output files exist",
+                            "advanced_runner.ts",
+                            ->(j, df) {
+                              jd = "#{df}/job-#{j.id}"
+                              ["#{jd}/output-summary.json", "#{jd}/output-topic-stats.json",
+                               "#{jd}/output-comments-with-scores.json"]
+                            }
+
+            it_behaves_like "sets persisted_output when all output files exist",
+                            "runner.ts",
+                            ->(j, df) {
+                              jd = "#{df}/job-#{j.id}"
+                              ["#{jd}/output-summary.json", "#{jd}/output-summary.html",
+                               "#{jd}/output-summary.md", "#{jd}/output-summaryAndSource.csv"]
+                            }
+          end
+
+          context "when not all output files exist" do
+            it "does not set persisted_output" do
+              job.script = "advanced_runner.ts"
+              base_path = "#{job_dir}/output"
+              allow(File).to receive(:exist?).with("#{base_path}-summary.json").and_return(true)
+              allow(File).to receive(:exist?).with("#{base_path}-topic-stats.json").and_return(true)
+              allow(File).to receive(:exist?).with("#{base_path}-comments-with-scores.json").and_return(false)
+
+              job.finished_at = Time.current
+              job.error = nil
+              job.save!
+
+              expect(job.persisted_output).to be(nil)
+            end
+          end
+        end
+
+        context "when persisted_output is already set" do
+          it "does not overwrite existing persisted_output" do
+            existing_path = "vendor/sensemaking-tools/data/job-#{job.id}/output"
+            job.persisted_output = existing_path
+
+            job.finished_at = Time.current
+            job.error = nil
+            job.save!
+
+            expect(job.persisted_output).to eq(existing_path)
+          end
+        end
+      end
+
+      context "when job is not finished" do
+        it "does not set persisted_output" do
+          job.finished_at = nil
+          job.error = nil
+          job.save!
+
+          expect(job.persisted_output).to be(nil)
+        end
+      end
+
+      context "when job has an error" do
+        it "does not set persisted_output" do
+          job.finished_at = Time.current
+          job.error = "Some error occurred"
+          job.save!
+
+          expect(job.persisted_output).to be(nil)
+        end
+      end
+    end
+
+    describe "after_destroy" do
+      include_context "sensemaker paths stubbed"
+
+      before do
+        allow(FileUtils).to receive(:rm_f).and_return(true)
+        allow(Rails.logger).to receive(:info)
+        allow(Rails.logger).to receive(:warn)
+      end
+
+      it "calls artefacts.cleanup when job is destroyed" do
+        expect(job.artefacts).to receive(:cleanup).and_return([])
+        job.destroy!
+      end
+
+      it "logs cleanup results" do
+        allow(job.artefacts).to receive(:cleanup).and_return(["/tmp/cleaned"])
+        expect(Rails.logger).to receive(:info).with(/Cleaned up files for job #{job.id}/)
+
+        job.destroy!
+      end
+
+      it "continues with destruction even if cleanup fails" do
+        allow(job.artefacts).to receive(:cleanup).and_return(nil)
+        expect(Rails.logger).to receive(:warn).with(/Failed to cleanup files for job #{job.id}/)
+
+        expect { job.destroy }.not_to raise_error
+        expect(Sensemaker::Job.find_by(id: job.id)).to be(nil)
       end
     end
   end

--- a/spec/support/sensemaker_helpers.rb
+++ b/spec/support/sensemaker_helpers.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+RSpec.shared_context "sensemaker llm config" do
+  let(:llm_config) do
+    double(
+      "LLM config",
+      vertexai_project_id: "sensemaker-466109",
+      vertexai_location: "global",
+      openai_api_key: "openai-secret",
+      openai_api_base: "https://openai-proxy.example.com/v1",
+      openrouter_api_key: "openrouter-secret",
+      openrouter_api_base: "https://openrouter.ai/api/v1",
+      together_api_key: "together-secret",
+      together_api_base: "https://api.together.xyz/v1",
+      mistral_api_key: "mistral-secret",
+      mistral_api_base: "https://api.mistral.ai/v1",
+      ollama_api_base: "http://localhost:11434"
+    )
+  end
+  let(:llm_context) { double("LLM context", config: llm_config) }
+end


### PR DESCRIPTION
## References

Furthers work in PR: https://github.com/consuldemocracy/consuldemocracy/pull/6261

## Objectives

This is [PR 3 of 5](https://github.com/CoslaDigital/consuldemocracyAI/issues/24) that's intended to introduce a Sensemaker integration to Consul.

This adds the main business logic to create Sensemaker analyses using Consul as input. The main logic sits across these classes:

- `Conversation` aggregates comments and votes from various content types and compiles contextual metadata that aids Sensemaker analysis 
- `Sensemaker::CsvExporter` (app/lib/sensemaker/csv_exporter.rb) formats the conversation data into CLI-ready CSV files with comment text, vote counts, and author info ready
- `Sensemaker::JobRunner` (app/lib/sensemaker/job_runner.rb) orchestrates the subprocess workflow by preparing inputs, running sensemaker scripts via Node.js, and managing job lifecycle and error or other state handling

## Visual Changes

None.

## Notes

### Invoking Sensemaker from the console

Creating a Sensemaker run from the console can be achieved like so: 

```ruby
# Choose a target e.g. a debate
debate = Debate.find(123)

# Provide a creator user (usually this is an admin) 
user = User.find_by(email: "admin@consul.dev")

# Create a sensemaker job record
job = Sensemaker::Job.create!(
  user: user,
  analysable_type: "Debate",
  analysable_id: debate.id,
  script: "runner.ts"  # Options: "runner.ts", "advanced_runner.ts", "categorization_runner.ts", "health_check_runner.ts", "single-html-build.js"
)

# Run the job synchronously (for console testing, this will be async in production)
runner = Sensemaker::JobRunner.new(job)
runner.run_synchronously

# Wait, and check the job status
job.reload.status  # => "Completed", "Failed", etc.

# If success, view output file paths
job.output_artefact_paths
```

### Conversation class

The Conversation class is an abstraction over analysable “conversations”: comments, compiled context, and labels for a given target. It currently backs Sensemaker and is designed so other analysis libraries can use it directly. It does no t contain any Sensemaker-specific logic.

Conversation helps analysis libraries by preparing participation data from many Consul targets (Debate, Proposal, Poll, Poll::Question, Legislation::Question, Legislation::QuestionOption, Budget, Budget::Group, etc.): it fetches and normalises comments or pseudo-comments (e.g. poll answers, budget investments) and builds text context that can be used as input.

Sensemaker is one consumer: the integration uses Sensemaker::Conversation (a thin subclass of ::Conversation) and Sensemaker::CsvExporter, which turns that conversation into the CSV format expected by the sensemaking-tools CLI.

Other analysis libraries can use Conversation directly (e.g. Conversation.new(analysable_type, analysable_id)) and implement their own exporters or pipelines that consume #comments and #compile_context without going through Sensemaker.
