### PR TITLE
Singularise model names in activerecord.yml locales

### DIFF
--- a/config/locales/en/activerecord.yml
+++ b/config/locales/en/activerecord.yml
@@ -106,22 +106,22 @@ en:
       legislation/proposal:
         one: "Proposal"
         other: "Proposals"
-      legislation/draft_versions:
+      legislation/draft_version:
         one: "Draft version"
         other: "Draft versions"
-      legislation/questions:
+      legislation/question:
         one: "Question"
         other: "Questions"
-      legislation/question_options:
+      legislation/question_option:
         one: "Question option"
         other: "Question options"
-      legislation/answers:
+      legislation/answer:
         one: "Answer"
         other: "Answers"
-      documents:
+      document:
         one: "Document"
         other: "Documents"
-      images:
+      image:
         one: "Image"
         other: "Images"
       tenant:

--- a/config/locales/en/activerecord.yml
+++ b/config/locales/en/activerecord.yml
@@ -118,9 +118,6 @@ en:
       legislation/answer:
         one: "Answer"
         other: "Answers"
-      document:
-        one: "Document"
-        other: "Documents"
       image:
         one: "Image"
         other: "Images"

--- a/config/locales/es/activerecord.yml
+++ b/config/locales/es/activerecord.yml
@@ -106,22 +106,22 @@ es:
       legislation/proposal:
         one: "Propuesta"
         other: "Propuestas"
-      legislation/draft_versions:
+      legislation/draft_version:
         one: "Versión del borrador"
         other: "Versiones del borrador"
-      legislation/questions:
+      legislation/question:
         one: "Pregunta"
         other: "Preguntas"
-      legislation/question_options:
+      legislation/question_option:
         one: "Opción de respuesta cerrada"
         other: "Opciones de respuesta cerrada"
-      legislation/answers:
+      legislation/answer:
         one: "Respuesta"
         other: "Respuestas"
-      documents:
+      document:
         one: "Documento"
         other: "Documentos"
-      images:
+      image:
         one: "Imagen"
         other: "Imágenes"
       tenant:

--- a/config/locales/es/activerecord.yml
+++ b/config/locales/es/activerecord.yml
@@ -118,9 +118,6 @@ es:
       legislation/answer:
         one: "Respuesta"
         other: "Respuestas"
-      document:
-        one: "Documento"
-        other: "Documentos"
       image:
         one: "Imagen"
         other: "Imágenes"


### PR DESCRIPTION
## Objectives

Fixes a number of model names in the es/en activerecord locales by using singular keys. 

For example, the key `es.activerecord.models.legislation/questions` won't be recognised.

```ruby
I18n.locale = :es
Legislation::Question.model_name.human #=> "Question"
```

With singular keys e.g. `es.activerecord.models.legislation/question`:

```ruby
I18n.locale = :es
Legislation::Question.model_name.human #=> "Pregunta"
```
