### PR TITLE
Fix DoubleLinkError caused by duplicate inclusion of custom assets

### DIFF
--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,7 +1,7 @@
 //= link ckeditor/application.css
 //= link ckeditor/application.js
 //
-//= link_tree ../images
+//= link_directory ../images .png
 //= link application.css
 //= link application-rtl.css
 //= link administration.css
@@ -17,5 +17,5 @@
 //= link noscript.css
 //= link print.css
 //= link pdf_fonts.css
-//= link_tree ../../../vendor/assets/images
+// //= link_tree ../../../vendor/assets/images
 //= link_tree ../../../node_modules/leaflet/dist/images


### PR DESCRIPTION
 Fixes #4882
## References
Fixes Sprockets::DoubleLinkError during asset precompilation.

## Objectives
![before](https://github.com/user-attachments/assets/d8d17d3d-975d-4c6e-ace3-51154038fa8c)
![after](https://github.com/user-attachments/assets/264d544f-4eb3-44ec-ba2a-8dbd638dabb6)

Fix duplicate asset inclusion that causes `Sprockets::DoubleLinkError` when files with the same name exist in both `images/` and `images/custom/`.

## Problem
Running:
bundle exec rake assets:precompile
resulted in:
Sprockets::DoubleLinkError:
Multiple files with the same output path cannot be linked ("logo_header.png")

## Root Cause
The `app/assets/images/custom/` directory is already added to the asset load path via an initializer.
However, `manifest.js` also included:
//= link_tree ../images/custom .png
This caused assets in `custom/` to be included twice that is one via asset load path and another one via explicit manifest linking

Since Sprockets resolves assets by logical path (ignoring directory structure), both:
app/assets/images/logo_header.png  
app/assets/images/custom/logo_header.png  
map to the same output path, causing a conflict.

## Fix
Removed redundant inclusion from `manifest.js`:
- //= link_tree ../images/custom .png
and restricted default inclusion to:
//= link_directory ../images .png

## Visual Changes
No UI changes. This is a backend asset pipeline fix.

## Notes
After applying the fix:
bundle exec rake assets:precompile
runs successfully without errors.