### PR TITLE
Rate limit LLM image suggestions

### DIFF
--- a/app/controllers/image_suggestions_controller.rb
+++ b/app/controllers/image_suggestions_controller.rb
@@ -5,6 +5,12 @@ class ImageSuggestionsController < ApplicationController
   before_action :authenticate_user!
   skip_authorization_check
 
+  rate_limit to: 10,
+             within: 15.minutes,
+             by: -> { current_user.id },
+             only: :create,
+             with: -> { render_rate_limit_response }
+
   def create
     @suggestions = ImageSuggestions::Llm::Client.call(
       title: image_suggestion_params[:title],
@@ -46,6 +52,15 @@ class ImageSuggestionsController < ApplicationController
   end
 
   private
+
+    def render_rate_limit_response
+      @suggestions = ImageSuggestions::Llm::Client::Response.new
+      @suggestions.errors << I18n.t("images.errors.messages.rate_limit_exceeded")
+
+      respond_to do |format|
+        format.js { render :create }
+      end
+    end
 
     def image_suggestion_params
       @image_suggestion_params ||= params.require(params[:resource_type].parameterize.underscore)

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -30,6 +30,7 @@ Rails.application.configure do
   # Show full error reports and disable caching.
   config.consider_all_requests_local = true
   config.action_controller.perform_caching = false
+  config.action_controller.cache_store = :memory_store
   config.cache_store = :null_store
 
   # Render exception templates for rescuable exceptions and raise for other exceptions.

--- a/config/locales/en/images.yml
+++ b/config/locales/en/images.yml
@@ -22,5 +22,6 @@ en:
       messages:
         title_and_description_required: To suggest images, please write a title and description first.
         llm_not_configured: LLM is not properly configured. Please contact an administrator.
+        rate_limit_exceeded: Please wait a few minutes before generating new suggestions.
         in_between: must be in between %{min} and %{max}
         wrong_content_type: content type %{content_type} does not match any of accepted content types %{accepted_content_types}

--- a/config/locales/es/images.yml
+++ b/config/locales/es/images.yml
@@ -22,5 +22,6 @@ es:
       messages:
         title_and_description_required: Para sugerir imágenes, por favor escribe primero un título y una descripción.
         llm_not_configured: El LLM no está configurado correctamente. Por favor, contacta con un administrador.
+        rate_limit_exceeded: Espera unos minutos antes de generar nuevas sugerencias.
         in_between: debe estar entre %{min} y %{max}
         wrong_content_type: El tipo de contenido %{content_type} de la imagen no coincide con ninguno de los tipos de contenido aceptados %{accepted_content_types}

--- a/spec/controllers/image_suggestions_controller_spec.rb
+++ b/spec/controllers/image_suggestions_controller_spec.rb
@@ -44,6 +44,49 @@ describe ImageSuggestionsController do
         }, format: :js
       end.to raise_error(ActionController::ParameterMissing)
     end
+
+    context "when rate limit is exceeded" do
+      render_views
+
+      let(:params) { { resource_type: resource_type, budget_investment: budget_investment_params } }
+
+      before { ImageSuggestionsController.cache_store.clear }
+
+      it "renders rate limit error message" do
+        10.times { post :create, params: params, format: :js }
+
+        post :create, params: params, format: :js
+
+        expect(response).to be_successful
+        expect(response.body).to include "Please wait a few minutes before generating new suggestions."
+      end
+
+      it "allows new requests after waiting a few minutes" do
+        10.times { post :create, params: params, format: :js }
+
+        post :create, params: params, format: :js
+
+        expect(response).to be_successful
+        expect(response.body).to include "Please wait a few minutes before generating new suggestions."
+
+        travel_to(15.minutes.from_now + 1.second) do
+          post :create, params: params, format: :js
+
+          expect(response).to be_successful
+          expect(response.body).not_to include "Please wait a few minutes before generating new suggestions."
+        end
+      end
+
+      it "does not affect other users" do
+        10.times { post :create, params: params, format: :js }
+
+        sign_in create(:user)
+        post :create, params: params, format: :js
+
+        expect(response).to be_successful
+        expect(response.body).not_to include "Please wait a few minutes before generating new suggestions."
+      end
+    end
   end
 
   describe "POST attach" do


### PR DESCRIPTION
## References

This PR is a small upgrade to the https://github.com/consuldemocracy/consuldemocracy/pull/6190 that prevents a possible bad actor to abuse image suggestions feature and possibly incur excessive costs to the Consul host.

## Objectives

* Prevent excessive usage / spamming of the button
* Still allow liberal limits for any genuine users

## Visual Changes

* No visual changes to the interface

## Notes

* At this point, we decided to not allow personalization of the rate limit. All variables are codified as a constants so this could be done at a later stage.