### PR TITLE
Increase Pexels AI image suggestions from 4 to 8

### DIFF
--- a/app/lib/image_suggestions/llm/client.rb
+++ b/app/lib/image_suggestions/llm/client.rb
@@ -1,7 +1,7 @@
 module ImageSuggestions
   module Llm
     class Client
-      NUMBER_OF_IMAGES = 4
+      NUMBER_OF_IMAGES = 8
 
       def self.call(title:, description:)
         new(title: title, description: description).call

--- a/spec/lib/image_suggestions/llm/client_spec.rb
+++ b/spec/lib/image_suggestions/llm/client_spec.rb
@@ -42,7 +42,7 @@ describe ImageSuggestions::Llm::Client do
     it "searches Pexels with the generated query" do
       expect(ImageSuggestions::Pexels).to receive(:search).with(
         search_query,
-        per_page: 4
+        per_page: 8
       ).and_return(pexels_results)
 
       result = client.call
@@ -95,7 +95,7 @@ describe ImageSuggestions::Llm::Client do
       it "passes stripped query to Pexels" do
         expect(ImageSuggestions::Pexels).to receive(:search).with(
           "search query",
-          per_page: 4
+          per_page: 8
         ).and_return(pexels_results)
         client.call
       end


### PR DESCRIPTION
## References

Related PR: #6190 

## Objectives

Offer users more Pexels image options when using AI image suggestions, since four results felt a bit limited for choosing a good descriptive image.


## Visual Changes
- Before
<img width="1508" height="657" alt="Four Pexels images in a single row in the optional image section" src="https://github.com/user-attachments/assets/77435de6-2efa-449d-ad18-46fcc684c50d" />

- After
<img width="1486" height="827" alt="Eight Pexels images in a 4×2 grid in the same optional image section" src="https://github.com/user-attachments/assets/5c5d9dca-2a98-4727-8caf-fbabba761109" />
