### PR TITLE
Disable LLM providers with a blank configuration 

### DIFF
--- a/app/lib/llm/config.rb
+++ b/app/lib/llm/config.rb
@@ -5,7 +5,7 @@ module Llm
         RubyLLM.context do |config|
           ENV["GOOGLE_APPLICATION_CREDENTIALS"] ||= Rails.application.secrets.google_application_credentials
 
-          Tenant.current_secrets.llm&.each do |key, value|
+          llm_secrets.each do |key, value|
             config.send("#{key}=", value)
           end
         end
@@ -37,6 +37,10 @@ module Llm
 
         def llm_model
           Setting["llm.model"]
+        end
+
+        def llm_secrets
+          Tenant.current_secrets.llm || {}
         end
     end
   end

--- a/app/lib/llm/config.rb
+++ b/app/lib/llm/config.rb
@@ -5,7 +5,7 @@ module Llm
         RubyLLM.context do |config|
           ENV["GOOGLE_APPLICATION_CREDENTIALS"] ||= Rails.application.secrets.google_application_credentials
 
-          llm_secrets.each do |key, value|
+          llm_secrets.compact_blank.each do |key, value|
             config.send("#{key}=", value)
           end
         end

--- a/spec/lib/image_suggestions/pexels_spec.rb
+++ b/spec/lib/image_suggestions/pexels_spec.rb
@@ -54,7 +54,7 @@ describe ImageSuggestions::Pexels do
 
     let(:image_url) { "https://example.com/image.jpg?auto=compress&cs=tinysrgb&h=900" }
     let(:downloaded_io) { StringIO.new("fake image bytes") }
-    let(:uri_double) { double("URI") }
+    let(:uri_double) { double }
 
     before do
       allow(::Pexels::Client).to receive(:new).and_return(pexels_client)

--- a/spec/lib/llm/config_spec.rb
+++ b/spec/lib/llm/config_spec.rb
@@ -45,6 +45,12 @@ describe Llm::Config do
       expect(providers[:OpenAI]).to eq({ enabled: true })
       expect(providers[:DeepSeek]).to eq({ enabled: false })
     end
+
+    it "does not enable any providers when the LLM configuration is nil" do
+      stub_secrets({})
+
+      expect(Llm::Config.providers.values).to all eq({ enabled: false })
+    end
   end
 
   describe "evaluates provider configuration across different tenants" do

--- a/spec/lib/llm/config_spec.rb
+++ b/spec/lib/llm/config_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 describe Llm::Config do
   describe ".context" do
     let(:config) { double }
-    let(:context_double) { double("RubyLLM::Context", config: config) }
+    let(:context_double) { double(config: config) }
 
     before do
       stub_secrets(llm: { openai_api_key: "1234" })
@@ -47,7 +47,7 @@ describe Llm::Config do
     end
 
     it "maps provider enabled status using RubyLLM providers" do
-      context = double("RubyLLM::Context", config: double)
+      context = double(config: double)
       allow(Llm::Config).to receive(:context).and_return(context)
       allow(RubyLLM::Providers).to receive(:constants).and_return([:OpenAI])
 

--- a/spec/lib/llm/config_spec.rb
+++ b/spec/lib/llm/config_spec.rb
@@ -46,6 +46,12 @@ describe Llm::Config do
       expect(providers[:DeepSeek]).to eq({ enabled: false })
     end
 
+    it "discards providers with a blank configuration" do
+      stub_secrets(llm: { openai_api_key: "" })
+
+      expect(Llm::Config.providers[:OpenAI]).to eq({ enabled: false })
+    end
+
     it "does not enable any providers when the LLM configuration is nil" do
       stub_secrets({})
 

--- a/spec/lib/llm/config_spec.rb
+++ b/spec/lib/llm/config_spec.rb
@@ -37,23 +37,13 @@ describe Llm::Config do
   end
 
   describe ".providers" do
-    before do
-      dummy_provider = Class.new do
-        def self.configured?(_config)
-          true
-        end
-      end
-      stub_const("RubyLLM::Providers::OpenAI", dummy_provider)
-    end
-
-    it "maps provider enabled status using RubyLLM providers" do
-      context = double(config: double)
-      allow(Llm::Config).to receive(:context).and_return(context)
-      allow(RubyLLM::Providers).to receive(:constants).and_return([:OpenAI])
+    it "maps provider enabled status using configured providers" do
+      stub_secrets(llm: { openai_api_key: "1234" })
 
       providers = Llm::Config.providers
 
-      expect(providers).to eq({ OpenAI: { enabled: true }})
+      expect(providers[:OpenAI]).to eq({ enabled: true })
+      expect(providers[:DeepSeek]).to eq({ enabled: false })
     end
   end
 

--- a/spec/models/machine_learning_spec.rb
+++ b/spec/models/machine_learning_spec.rb
@@ -407,7 +407,7 @@ describe MachineLearning do
         Process.waitpid Process.fork { abort "error message" }
       end
 
-      mailer = double("mailer")
+      mailer = double
       expect(mailer).to receive(:deliver_later)
       expect(Mailer).to receive(:machine_learning_error).and_return mailer
 

--- a/spec/system/admin/settings_spec.rb
+++ b/spec/system/admin/settings_spec.rb
@@ -349,7 +349,7 @@ describe "Admin settings", :admin do
       before do
         allow(Llm::Config)
           .to receive(:providers).and_return({ OpenAI: { enabled: true }})
-        ruby_llm_models = [double("Model", name: "GPT-4.1 mini", id: "gpt-4o-mini")]
+        ruby_llm_models = [double(name: "GPT-4.1 mini", id: "gpt-4o-mini")]
         allow(RubyLLM.models).to receive(:by_provider).with(:openai).and_return(ruby_llm_models)
         stub_secrets(pexels_access_key: "test_key")
       end

--- a/spec/system/budgets/investments_spec.rb
+++ b/spec/system/budgets/investments_spec.rb
@@ -844,7 +844,7 @@ describe "Budget Investments" do
                 "Pexels::Photo",
                 id: "suggested-photo-1",
                 src: { "small" => "https://example.com/suggested.jpg" },
-                user: double("Pexels::User", name: "Test Photographer")
+                user: double(name: "Test Photographer")
               )
             ]
           ),


### PR DESCRIPTION
## References

* We added the option to configure LLMs in pull request #6068

## Objectives

* Make sure the LLM providers we list as enabled are actually configured
* Don't enable any LLM providers when using the default `secrets.yml.example` file