### PR TITLE
Add creation date and comments to CSV exports

### DIFF
--- a/app/assets/stylesheets/shared/download_csv_link.scss
+++ b/app/assets/stylesheets/shared/download_csv_link.scss
@@ -1,0 +1,9 @@
+.download-csv-link {
+  @include hollow-button;
+  @include has-fa-icon(download, solid);
+  float: $global-right;
+
+  &::before {
+    margin-#{$global-right}: 0.2em;
+  }
+}

--- a/app/components/shared/download_csv_link_component.html.erb
+++ b/app/components/shared/download_csv_link_component.html.erb
@@ -1,3 +1,3 @@
 <%= link_to t("admin.budget_investments.index.download_current_selection"),
             csv_path,
-            class: "float-right small clear" %>
+            class: "download-csv-link" %>

--- a/app/models/budget/investment/exporter.rb
+++ b/app/models/budget/investment/exporter.rb
@@ -14,7 +14,7 @@ class Budget::Investment::Exporter
 
   private
 
-    def headers
+    def model_headers
       [
         I18n.t("admin.budget_investments.index.list.id"),
         I18n.t("admin.budget_investments.index.list.title"),
@@ -32,7 +32,7 @@ class Budget::Investment::Exporter
       ]
     end
 
-    def csv_values(investment)
+    def record_csv_values(investment)
       [
         investment.id.to_s,
         investment.title,

--- a/app/models/budget/investment/exporter.rb
+++ b/app/models/budget/investment/exporter.rb
@@ -27,7 +27,8 @@ class Budget::Investment::Exporter
         I18n.t("admin.budget_investments.index.list.valuation_finished"),
         I18n.t("admin.budget_investments.index.list.selected"),
         I18n.t("admin.budget_investments.index.list.visible_to_valuators"),
-        I18n.t("admin.budget_investments.index.list.author_username")
+        I18n.t("admin.budget_investments.index.list.author_username"),
+        Budget::Investment.human_attribute_name(:created_at)
       ]
     end
 
@@ -44,7 +45,8 @@ class Budget::Investment::Exporter
         investment.valuation_finished? ? I18n.t("shared.yes") : I18n.t("shared.no"),
         investment.selected? ? I18n.t("shared.yes") : I18n.t("shared.no"),
         investment.visible_to_valuators? ? I18n.t("shared.yes") : I18n.t("shared.no"),
-        investment.author.username
+        investment.author.username,
+        I18n.l(investment.created_at, format: :datetime)
       ]
     end
 

--- a/app/models/concerns/csv_exporter.rb
+++ b/app/models/concerns/csv_exporter.rb
@@ -2,7 +2,63 @@ module CsvExporter
   def to_csv
     CSV.generate(headers: true) do |csv|
       csv << headers
-      records.each { |record| csv << csv_values(record) }
+      records.each do |record|
+        comments = record.comments.sort_by(&:created_at)
+
+        if comments.any?
+          comments.each { |comment| csv << csv_values(record, comment) }
+        else
+          csv << csv_values(record)
+        end
+      end
     end
   end
+
+  private
+
+    def csv_values(record, comment = nil)
+      record_csv_values(record) + comment_csv_values(comment)
+    end
+
+    def headers
+      model_headers + comment_csv_headers
+    end
+
+    def record_csv_values(record)
+      raise "This method must be implemented in class #{self.class.name}"
+    end
+
+    def model_headers
+      raise "This method must be implemented in class #{self.class.name}"
+    end
+
+    def comment_csv_headers
+      [
+        I18n.t("admin.comments.index.id"),
+        I18n.t("admin.comments.index.author"),
+        I18n.t("admin.comments.index.content"),
+        Comment.human_attribute_name(:parent_id),
+        Comment.human_attribute_name(:created_at)
+      ].map { |name| comment_header(name) }
+    end
+
+    def comment_csv_values(comment)
+      return empty_comment_csv_values unless comment
+
+      [
+        comment.id.to_s,
+        comment.author&.email.to_s,
+        comment.body,
+        comment.parent_id.to_s,
+        I18n.l(comment.created_at, format: :datetime)
+      ]
+    end
+
+    def empty_comment_csv_values
+      Array.new(comment_csv_headers.size, "")
+    end
+
+    def comment_header(name)
+      "#{Comment.model_name.human} #{name}"
+    end
 end

--- a/app/models/concerns/csv_exporter.rb
+++ b/app/models/concerns/csv_exporter.rb
@@ -3,7 +3,7 @@ module CsvExporter
     CSV.generate(headers: true) do |csv|
       csv << headers
       records.each do |record|
-        comments = record.comments.sort_by(&:created_at)
+        comments = comments_in_reading_order(record)
 
         if comments.any?
           comments.each { |comment| csv << csv_values(record, comment) }
@@ -60,5 +60,11 @@ module CsvExporter
 
     def comment_header(name)
       "#{Comment.model_name.human} #{name}"
+    end
+
+    def comments_in_reading_order(record)
+      Comment.sort_by_ancestry(record.comments) do |comment, sibling|
+        comment.created_at <=> sibling.created_at
+      end
     end
 end

--- a/app/models/debate/exporter.rb
+++ b/app/models/debate/exporter.rb
@@ -13,7 +13,8 @@ class Debate::Exporter
       [
         I18n.t("admin.debates.index.id"),
         Debate.human_attribute_name(:title),
-        I18n.t("admin.debates.index.author")
+        I18n.t("admin.debates.index.author"),
+        Debate.human_attribute_name(:created_at)
       ]
     end
 
@@ -21,7 +22,8 @@ class Debate::Exporter
       [
         debate.id.to_s,
         debate.title,
-        debate.author.email
+        debate.author.email,
+        I18n.l(debate.created_at, format: :datetime)
       ]
     end
 end

--- a/app/models/debate/exporter.rb
+++ b/app/models/debate/exporter.rb
@@ -9,7 +9,7 @@ class Debate::Exporter
 
   private
 
-    def headers
+    def model_headers
       [
         I18n.t("admin.debates.index.id"),
         Debate.human_attribute_name(:title),
@@ -18,7 +18,7 @@ class Debate::Exporter
       ]
     end
 
-    def csv_values(debate)
+    def record_csv_values(debate)
       [
         debate.id.to_s,
         debate.title,

--- a/app/models/proposal/exporter.rb
+++ b/app/models/proposal/exporter.rb
@@ -28,7 +28,8 @@ class Proposal::Exporter
         I18n.t("admin.proposals.index.list.id"),
         I18n.t("admin.proposals.index.list.title"),
         I18n.t("admin.proposals.index.list.author"),
-        I18n.t("admin.proposals.index.list.summary")
+        I18n.t("admin.proposals.index.list.summary"),
+        Proposal.human_attribute_name(:created_at)
       ]
     end
 
@@ -37,7 +38,8 @@ class Proposal::Exporter
         proposal.id.to_s,
         proposal.title,
         proposal.author.email,
-        proposal.summary
+        proposal.summary,
+        I18n.l(proposal.created_at, format: :datetime)
       ]
     end
 end

--- a/app/models/proposal/exporter.rb
+++ b/app/models/proposal/exporter.rb
@@ -23,7 +23,7 @@ class Proposal::Exporter
       }
     end
 
-    def headers
+    def model_headers
       [
         I18n.t("admin.proposals.index.list.id"),
         I18n.t("admin.proposals.index.list.title"),
@@ -33,7 +33,7 @@ class Proposal::Exporter
       ]
     end
 
-    def csv_values(proposal)
+    def record_csv_values(proposal)
       [
         proposal.id.to_s,
         proposal.title,

--- a/config/locales/en/activerecord.yml
+++ b/config/locales/en/activerecord.yml
@@ -1,5 +1,6 @@
 en:
   attributes:
+    created_at: Created at
     geozone_id: "Scope of operation"
     results_enabled: "Show results"
     stats_enabled: "Show stats"
@@ -358,7 +359,6 @@ en:
         title: "Title"
       site_customization/page:
         content: Content
-        created_at: Created at
         subtitle: Subtitle
         slug: Slug
         status: Status

--- a/config/locales/en/activerecord.yml
+++ b/config/locales/en/activerecord.yml
@@ -249,6 +249,7 @@ en:
         main_link_url: "The link takes you to (add a link)"
       comment:
         body: "Comment"
+        parent_id: "Parent"
         user: "User"
       debate:
         author: "Author"

--- a/config/locales/es/activerecord.yml
+++ b/config/locales/es/activerecord.yml
@@ -1,5 +1,6 @@
 es:
   attributes:
+    created_at: Fecha de creación
     geozone_id: "Ámbito de actuación"
     results_enabled: "Mostrar resultados"
     stats_enabled: "Mostrar estadísticas"
@@ -358,7 +359,6 @@ es:
         document_numbers: "Números de documentos"
       site_customization/page:
         content: Contenido
-        created_at: Creada
         subtitle: Subtítulo
         slug: Slug
         status: Estado

--- a/config/locales/es/activerecord.yml
+++ b/config/locales/es/activerecord.yml
@@ -249,6 +249,7 @@ es:
         main_link_url: "El enlace te lleva a (añade un enlace)"
       comment:
         body: "Comentario"
+        parent_id: "Padre"
         user: "Usuario"
       debate:
         author: "Autor"

--- a/spec/models/budget/investment/exporter_spec.rb
+++ b/spec/models/budget/investment/exporter_spec.rb
@@ -1,0 +1,44 @@
+require "rails_helper"
+
+describe Budget::Investment::Exporter do
+  describe "#to_csv" do
+    let(:budget) { create(:budget) }
+    let(:investment) do
+      create(:budget_investment, budget: budget,
+                                 title: "Le Investment",
+                                 created_at: Time.zone.local(2026, 6, 1, 14, 56, 10))
+    end
+
+    context "when the investment has comments" do
+      let(:root_comment) do
+        create(:budget_investment_comment, commentable: investment,
+                                           body: "I think it should",
+                                           created_at: Time.zone.local(2026, 6, 1, 14, 58, 10))
+      end
+      let(:reply) do
+        create(:budget_investment_comment, commentable: investment,
+                                           body: "I disagree",
+                                           parent_id: root_comment.id,
+                                           created_at: Time.zone.local(2026, 6, 1, 14, 59, 10))
+      end
+
+      it "generates one row per comment" do
+        csv_contents = <<~CSV
+          ID,Title,Supports,Administrator,Valuator,Valuation Group,Scope of operation,\
+          Feasibility,Val. Fin.,Selected,Show to valuators,Author username,Created at,\
+          Comment ID,Comment Author,Comment Content,Comment Parent,Comment Created at
+          #{investment.id},#{investment.title},#{investment.total_votes},No admin assigned,\
+          -,-,#{investment.heading.name},Undecided,No,No,No,#{investment.author.username},\
+          2026-06-01 14:56:10,#{root_comment.id},\
+          #{root_comment.author.email},#{root_comment.body},"",2026-06-01 14:58:10
+          #{investment.id},#{investment.title},#{investment.total_votes},No admin assigned,\
+          -,-,#{investment.heading.name},Undecided,No,No,No,#{investment.author.username},\
+          2026-06-01 14:56:10,#{reply.id},\
+          #{reply.author.email},#{reply.body},#{root_comment.id},2026-06-01 14:59:10
+        CSV
+
+        expect(Budget::Investment::Exporter.new([investment]).to_csv).to eq csv_contents
+      end
+    end
+  end
+end

--- a/spec/models/csv_exporter_spec.rb
+++ b/spec/models/csv_exporter_spec.rb
@@ -1,0 +1,55 @@
+require "rails_helper"
+
+describe CsvExporter do
+  describe "comment reading order" do
+    factories = [
+      :budget_investment,
+      :debate,
+      :proposal
+    ]
+    let(:factory) { factories.sample }
+    let(:exporter_class) do
+      case factory
+      when :proposal
+        Proposal::Exporter
+      when :debate
+        Debate::Exporter
+      when :budget_investment
+        Budget::Investment::Exporter
+      end
+    end
+    let(:resource) { create(factory) }
+
+    it "orders comments in tree order instead of global chronological order" do
+      first_root = create(:comment, commentable: resource,
+                                    body: "First thread",
+                                    created_at: Time.zone.local(2026, 6, 1, 15, 0, 0))
+      second_root = create(:comment, commentable: resource,
+                                     body: "Second thread",
+                                     created_at: Time.zone.local(2026, 6, 1, 15, 5, 0))
+      reply = create(:comment, commentable: resource,
+                               body: "Reply to first",
+                               parent_id: first_root.id,
+                               created_at: Time.zone.local(2026, 6, 1, 15, 10, 0))
+      second_reply = create(:comment, commentable: resource,
+                                      body: "Another reply to first",
+                                      parent_id: first_root.id,
+                                      created_at: Time.zone.local(2026, 6, 1, 15, 11, 0))
+      nested_reply = create(:comment, commentable: resource,
+                                      body: "Reply to first reply",
+                                      parent_id: reply.id,
+                                      created_at: Time.zone.local(2026, 6, 1, 15, 15, 0))
+
+      csv = exporter_class.new([resource]).to_csv
+      rows = CSV.parse(csv, headers: true)
+
+      expect(rows.by_col["Comment Content"]).to eq [
+        first_root.body,
+        reply.body,
+        nested_reply.body,
+        second_reply.body,
+        second_root.body
+      ]
+    end
+  end
+end

--- a/spec/models/debate/exporter_spec.rb
+++ b/spec/models/debate/exporter_spec.rb
@@ -1,0 +1,37 @@
+require "rails_helper"
+
+describe Debate::Exporter do
+  describe "#to_csv" do
+    let(:debate) do
+      create(:debate, title: "Should Pluto be a planet?",
+                      created_at: Time.zone.local(2026, 6, 1, 14, 56, 10))
+    end
+
+    context "when the debate has comments" do
+      let(:root_comment) do
+        create(:comment, commentable: debate,
+                         body: "I think it should",
+                         created_at: Time.zone.local(2026, 6, 1, 14, 58, 10))
+      end
+      let(:reply) do
+        create(:comment, commentable: debate,
+                         body: "I disagree",
+                         parent_id: root_comment.id,
+                         created_at: Time.zone.local(2026, 6, 1, 14, 59, 10))
+      end
+
+      it "generates one row per comment" do
+        csv_contents = <<~CSV
+          ID,Title,Author,Created at,Comment ID,\
+          Comment Author,Comment Content,Comment Parent,Comment Created at
+          #{debate.id},#{debate.title},#{debate.author.email},2026-06-01 14:56:10,\
+          #{root_comment.id},#{root_comment.author.email},#{root_comment.body},"",2026-06-01 14:58:10
+          #{debate.id},#{debate.title},#{debate.author.email},2026-06-01 14:56:10,\
+          #{reply.id},#{reply.author.email},#{reply.body},#{root_comment.id},2026-06-01 14:59:10
+        CSV
+
+        expect(Debate::Exporter.new([debate]).to_csv).to eq csv_contents
+      end
+    end
+  end
+end

--- a/spec/models/proposal/exporter_spec.rb
+++ b/spec/models/proposal/exporter_spec.rb
@@ -1,0 +1,40 @@
+require "rails_helper"
+
+describe Proposal::Exporter do
+  describe "#to_csv" do
+    let(:proposal) do
+      create(:proposal, title: "Make Pluto a planet again",
+                        summary: "summary 1",
+                        created_at: Time.zone.local(2026, 6, 1, 14, 56, 10))
+    end
+
+    context "when the proposal has comments" do
+      let(:root_comment) do
+        create(:comment, commentable: proposal,
+                         body: "I think it should",
+                         created_at: Time.zone.local(2026, 6, 1, 14, 58, 10))
+      end
+      let(:reply) do
+        create(:comment, commentable: proposal,
+                         body: "I disagree",
+                         parent_id: root_comment.id,
+                         created_at: Time.zone.local(2026, 6, 1, 14, 59, 10))
+      end
+
+      it "generates one row per comment" do
+        csv_contents = <<~CSV
+          ID,Proposal,Author,Summary,Created at,Comment ID,\
+          Comment Author,Comment Content,Comment Parent,Comment Created at
+          #{proposal.id},#{proposal.title},#{proposal.author.email},#{proposal.summary},\
+          2026-06-01 14:56:10,\
+          #{root_comment.id},#{root_comment.author.email},#{root_comment.body},"",2026-06-01 14:58:10
+          #{proposal.id},#{proposal.title},#{proposal.author.email},#{proposal.summary},\
+          2026-06-01 14:56:10,\
+          #{reply.id},#{reply.author.email},#{reply.body},#{root_comment.id},2026-06-01 14:59:10
+        CSV
+
+        expect(Proposal::Exporter.new([proposal]).to_csv).to eq csv_contents
+      end
+    end
+  end
+end

--- a/spec/system/admin/budget_investments_spec.rb
+++ b/spec/system/admin/budget_investments_spec.rb
@@ -1662,25 +1662,25 @@ describe "Admin budget investments", :admin do
       first_budget_heading = create(:budget_heading, group: budget_group, name: "Budget Heading")
       second_budget_heading = create(:budget_heading, group: budget_group, name: "Other Heading")
       first_investment = create(:budget_investment, :feasible,
-                                                    :selected,
-                                                    title: "Le Investment",
-                                                    budget: budget, group: budget_group,
-                                                    heading: first_budget_heading,
-                                                    cached_votes_up: 88, price: 99,
-                                                    valuators: [],
-                                                    valuator_groups: [valuator_group],
-                                                    administrator: admin,
-                                                    visible_to_valuators: true,
-                                                    created_at: Time.zone.local(2026, 6, 1, 14, 56, 10))
+                                :selected,
+                                title: "Le Investment",
+                                budget: budget, group: budget_group,
+                                heading: first_budget_heading,
+                                cached_votes_up: 88, price: 99,
+                                valuators: [],
+                                valuator_groups: [valuator_group],
+                                administrator: admin,
+                                visible_to_valuators: true,
+                                created_at: Time.zone.local(2026, 6, 1, 14, 56, 10))
       second_investment = create(:budget_investment, :unfeasible,
-                                                     title: "Alt Investment",
-                                                     budget: budget, group: budget_group,
-                                                     heading: second_budget_heading,
-                                                     cached_votes_up: 66, price: 88,
-                                                     valuators: [valuator],
-                                                     valuator_groups: [],
-                                                     visible_to_valuators: false,
-                                                     created_at: Time.zone.local(2026, 6, 1, 14, 58, 20))
+                                 title: "Alt Investment",
+                                 budget: budget, group: budget_group,
+                                 heading: second_budget_heading,
+                                 cached_votes_up: 66, price: 88,
+                                 valuators: [valuator],
+                                 valuator_groups: [],
+                                 visible_to_valuators: false,
+                                 created_at: Time.zone.local(2026, 6, 1, 14, 58, 20))
 
       visit admin_budget_budget_investments_path(budget)
 
@@ -1691,13 +1691,16 @@ describe "Admin budget investments", :admin do
       expect(header).to match(/filename="budget_investments.csv"/)
 
       csv_contents = "ID,Title,Supports,Administrator,Valuator,Valuation Group,Scope of operation," \
-                     "Feasibility,Val. Fin.,Selected,Show to valuators,Author username,Created at\n" \
+                     "Feasibility,Val. Fin.,Selected,Show to valuators,Author username,Created at," \
+                     "Comment ID,Comment Author,Comment Content,Comment Parent,Comment Created at\n" \
                      "#{first_investment.id},Le Investment,88,Admin,-,Valuator Group," \
                      "Budget Heading,Feasible (€99),Yes,Yes,Yes," \
-                     "#{first_investment.author.username},2026-06-01 14:56:10\n" \
+                     "#{first_investment.author.username},2026-06-01 14:56:10," \
+                     "\"\",\"\",\"\",\"\",\"\"\n" \
                      "#{second_investment.id},Alt Investment,66,No admin assigned,Valuator,-," \
                      "Other Heading,Unfeasible,No,No,No," \
-                     "#{second_investment.author.username},2026-06-01 14:58:20\n"
+                     "#{second_investment.author.username},2026-06-01 14:58:20," \
+                     "\"\",\"\",\"\",\"\",\"\"\n"
 
       expect(page.body).to eq(csv_contents)
     end

--- a/spec/system/admin/budget_investments_spec.rb
+++ b/spec/system/admin/budget_investments_spec.rb
@@ -1661,21 +1661,26 @@ describe "Admin budget investments", :admin do
       budget_group = create(:budget_group, name: "Budget Group", budget: budget)
       first_budget_heading = create(:budget_heading, group: budget_group, name: "Budget Heading")
       second_budget_heading = create(:budget_heading, group: budget_group, name: "Other Heading")
-      first_investment = create(:budget_investment, :feasible, :selected, title: "Le Investment",
-                                                                          budget: budget, group: budget_group,
-                                                                          heading: first_budget_heading,
-                                                                          cached_votes_up: 88, price: 99,
-                                                                          valuators: [],
-                                                                          valuator_groups: [valuator_group],
-                                                                          administrator: admin,
-                                                                          visible_to_valuators: true)
-      second_investment = create(:budget_investment, :unfeasible, title: "Alt Investment",
-                                                                  budget: budget, group: budget_group,
-                                                                  heading: second_budget_heading,
-                                                                  cached_votes_up: 66, price: 88,
-                                                                  valuators: [valuator],
-                                                                  valuator_groups: [],
-                                                                  visible_to_valuators: false)
+      first_investment = create(:budget_investment, :feasible,
+                                                    :selected,
+                                                    title: "Le Investment",
+                                                    budget: budget, group: budget_group,
+                                                    heading: first_budget_heading,
+                                                    cached_votes_up: 88, price: 99,
+                                                    valuators: [],
+                                                    valuator_groups: [valuator_group],
+                                                    administrator: admin,
+                                                    visible_to_valuators: true,
+                                                    created_at: Time.zone.local(2026, 6, 1, 14, 56, 10))
+      second_investment = create(:budget_investment, :unfeasible,
+                                                     title: "Alt Investment",
+                                                     budget: budget, group: budget_group,
+                                                     heading: second_budget_heading,
+                                                     cached_votes_up: 66, price: 88,
+                                                     valuators: [valuator],
+                                                     valuator_groups: [],
+                                                     visible_to_valuators: false,
+                                                     created_at: Time.zone.local(2026, 6, 1, 14, 58, 20))
 
       visit admin_budget_budget_investments_path(budget)
 
@@ -1686,12 +1691,13 @@ describe "Admin budget investments", :admin do
       expect(header).to match(/filename="budget_investments.csv"/)
 
       csv_contents = "ID,Title,Supports,Administrator,Valuator,Valuation Group,Scope of operation," \
-                     "Feasibility,Val. Fin.,Selected,Show to valuators,Author username\n" \
+                     "Feasibility,Val. Fin.,Selected,Show to valuators,Author username,Created at\n" \
                      "#{first_investment.id},Le Investment,88,Admin,-,Valuator Group," \
                      "Budget Heading,Feasible (€99),Yes,Yes,Yes," \
-                     "#{first_investment.author.username}\n#{second_investment.id}," \
-                     "Alt Investment,66,No admin assigned,Valuator,-,Other Heading," \
-                     "Unfeasible,No,No,No,#{second_investment.author.username}\n"
+                     "#{first_investment.author.username},2026-06-01 14:56:10\n" \
+                     "#{second_investment.id},Alt Investment,66,No admin assigned,Valuator,-," \
+                     "Other Heading,Unfeasible,No,No,No," \
+                     "#{second_investment.author.username},2026-06-01 14:58:20\n"
 
       expect(page.body).to eq(csv_contents)
     end

--- a/spec/system/admin/debates_spec.rb
+++ b/spec/system/admin/debates_spec.rb
@@ -48,13 +48,14 @@ describe "Admin debates", :admin do
       expect(header).to match(/filename="debates.csv"/)
 
       csv_contents = <<~CSV
-        ID,Title,Author,Created at
+        ID,Title,Author,Created at,Comment ID,\
+        Comment Author,Comment Content,Comment Parent,Comment Created at
         #{third_debate.id},#{third_debate.title},\
-        #{third_debate.author.email},2026-06-01 15:00:30
+        #{third_debate.author.email},2026-06-01 15:00:30,"","","","",""
         #{second_debate.id},#{second_debate.title},\
-        #{second_debate.author.email},2026-06-01 14:58:20
+        #{second_debate.author.email},2026-06-01 14:58:20,"","","","",""
         #{first_debate.id},#{first_debate.title},\
-        #{first_debate.author.email},2026-06-01 14:56:10
+        #{first_debate.author.email},2026-06-01 14:56:10,"","","","",""
       CSV
 
       expect(page.body).to eq(csv_contents)
@@ -73,7 +74,8 @@ describe "Admin debates", :admin do
 
       click_link "Download current selection"
 
-      expect(page.body).to have_content "ID,Title,Author,Created at"
+      expect(page.body).to have_content "ID,Title,Author,Created at,Comment ID," \
+                                        "Comment Author,Comment Content,Comment Parent,Comment Created at"
       expect(page.body).to have_content "Should Pluto be a planet?"
       expect(page.body).not_to have_content "Best approach for public transport"
     end

--- a/spec/system/admin/debates_spec.rb
+++ b/spec/system/admin/debates_spec.rb
@@ -32,9 +32,12 @@ describe "Admin debates", :admin do
 
   context "Selecting csv", :no_js do
     scenario "Downloading CSV file" do
-      first_debate = create(:debate, title: "Should Pluto be a planet?")
-      second_debate = create(:debate, title: "Best approach for public transport")
-      third_debate = create(:debate, title: "Green spaces in the city")
+      first_debate = create(:debate, title: "Should Pluto be a planet?",
+                                     created_at: Time.zone.local(2026, 6, 1, 14, 56, 10))
+      second_debate = create(:debate, title: "Best approach for public transport",
+                                      created_at: Time.zone.local(2026, 6, 1, 14, 58, 20))
+      third_debate = create(:debate, title: "Green spaces in the city",
+                                     created_at: Time.zone.local(2026, 6, 1, 15, 00, 30))
 
       visit admin_debates_path
 
@@ -45,10 +48,13 @@ describe "Admin debates", :admin do
       expect(header).to match(/filename="debates.csv"/)
 
       csv_contents = <<~CSV
-        ID,Title,Author
-        #{third_debate.id},#{third_debate.title},#{third_debate.author.email}
-        #{second_debate.id},#{second_debate.title},#{second_debate.author.email}
-        #{first_debate.id},#{first_debate.title},#{first_debate.author.email}
+        ID,Title,Author,Created at
+        #{third_debate.id},#{third_debate.title},\
+        #{third_debate.author.email},2026-06-01 15:00:30
+        #{second_debate.id},#{second_debate.title},\
+        #{second_debate.author.email},2026-06-01 14:58:20
+        #{first_debate.id},#{first_debate.title},\
+        #{first_debate.author.email},2026-06-01 14:56:10
       CSV
 
       expect(page.body).to eq(csv_contents)
@@ -67,7 +73,7 @@ describe "Admin debates", :admin do
 
       click_link "Download current selection"
 
-      expect(page.body).to have_content "ID,Title,Author"
+      expect(page.body).to have_content "ID,Title,Author,Created at"
       expect(page.body).to have_content "Should Pluto be a planet?"
       expect(page.body).not_to have_content "Best approach for public transport"
     end

--- a/spec/system/admin/proposals_spec.rb
+++ b/spec/system/admin/proposals_spec.rb
@@ -128,13 +128,14 @@ describe "Admin proposals", :admin do
       expect(header).to match(/filename="proposals.csv"/)
 
       csv_contents = <<~CSV
-        ID,Proposal,Author,Summary,Created at
+        ID,Proposal,Author,Summary,Created at,\
+        Comment ID,Comment Author,Comment Content,Comment Parent,Comment Created at
         #{third_proposal.id},#{third_proposal.title},\
-        #{third_proposal.author.email},#{third_proposal.summary},2026-06-01 15:00:30
+        #{third_proposal.author.email},#{third_proposal.summary},2026-06-01 15:00:30,"","","","",""
         #{second_proposal.id},#{second_proposal.title},\
-        #{second_proposal.author.email},#{second_proposal.summary},2026-06-01 14:58:20
+        #{second_proposal.author.email},#{second_proposal.summary},2026-06-01 14:58:20,"","","","",""
         #{first_proposal.id},#{first_proposal.title},\
-        #{first_proposal.author.email},#{first_proposal.summary},2026-06-01 14:56:10
+        #{first_proposal.author.email},#{first_proposal.summary},2026-06-01 14:56:10,"","","","",""
       CSV
 
       expect(page.body).to eq(csv_contents)
@@ -153,7 +154,8 @@ describe "Admin proposals", :admin do
 
       click_link "Download current selection"
 
-      expect(page.body).to have_content "ID,Proposal,Author,Summary,Created at"
+      expect(page.body).to have_content "ID,Proposal,Author,Summary,Created at,Comment ID," \
+                                        "Comment Author,Comment Content,Comment Parent,Comment Created at"
       expect(page.body).to have_content "Make Pluto a planet again"
       expect(page.body).not_to have_content "Build a monument"
     end

--- a/spec/system/admin/proposals_spec.rb
+++ b/spec/system/admin/proposals_spec.rb
@@ -109,10 +109,15 @@ describe "Admin proposals", :admin do
 
   context "Selecting csv", :no_js do
     scenario "Downloading CSV file" do
-      first_proposal = create(:proposal, title: "Make Pluto a planet again", summary: "summary 1")
+      first_proposal = create(:proposal, title: "Make Pluto a planet again",
+                                         summary: "summary 1",
+                                         created_at: Time.zone.local(2026, 6, 1, 14, 56, 10))
       second_proposal = create(:proposal, title: "Build a monument to honour CONSUL developers",
-                                          summary: "summary 2")
-      third_proposal = create(:proposal, title: "Build another monument just because", summary: "summary 3")
+                                          summary: "summary 2",
+                                          created_at: Time.zone.local(2026, 6, 1, 14, 58, 20))
+      third_proposal = create(:proposal, title: "Build another monument just because",
+                                         summary: "summary 3",
+                                         created_at: Time.zone.local(2026, 6, 1, 15, 00, 30))
 
       visit admin_proposals_path
 
@@ -123,13 +128,13 @@ describe "Admin proposals", :admin do
       expect(header).to match(/filename="proposals.csv"/)
 
       csv_contents = <<~CSV
-        ID,Proposal,Author,Summary
+        ID,Proposal,Author,Summary,Created at
         #{third_proposal.id},#{third_proposal.title},\
-        #{third_proposal.author.email},#{third_proposal.summary}
+        #{third_proposal.author.email},#{third_proposal.summary},2026-06-01 15:00:30
         #{second_proposal.id},#{second_proposal.title},\
-        #{second_proposal.author.email},#{second_proposal.summary}
+        #{second_proposal.author.email},#{second_proposal.summary},2026-06-01 14:58:20
         #{first_proposal.id},#{first_proposal.title},\
-        #{first_proposal.author.email},#{first_proposal.summary}
+        #{first_proposal.author.email},#{first_proposal.summary},2026-06-01 14:56:10
       CSV
 
       expect(page.body).to eq(csv_contents)
@@ -148,7 +153,7 @@ describe "Admin proposals", :admin do
 
       click_link "Download current selection"
 
-      expect(page.body).to have_content "ID,Proposal,Author,Summary"
+      expect(page.body).to have_content "ID,Proposal,Author,Summary,Created at"
       expect(page.body).to have_content "Make Pluto a planet again"
       expect(page.body).not_to have_content "Build a monument"
     end


### PR DESCRIPTION
## References
Related PR's: #6302  and #6189 

## Objectives

Extend the admin CSV exports for debates, proposals and budget investments so admins can analyze content outside the application:

* Add a `Created at` column to all three exports.
* Add associated comments to the CSV, using one row per comment and repeating the parent record data on each row.
* Include comment metadata: ID, author (email), body (without HTML), parent ID and creation date.

## Release Notes
⚠️  https://github.com/consuldemocracy/consuldemocracy/pull/6367#discussion_r3324853745
> The investments CSV export format has changed. A single investment can now generate multiple rows in the CSV file (one line per comment related to that investment). If you're using custom software to process this CSV export, you might have to modify it accordingly.

