### PR TITLE
Add a link to the source code in the footer

### DIFF
--- a/.erb_lint.yml
+++ b/.erb_lint.yml
@@ -15,7 +15,7 @@ linters:
     exclude:
       - app/components/budgets/investments/content_blocks_component.html.erb
       - app/components/layout/cookies_consent/vendors/scripts_component.html.erb
-      - app/components/layout/footer_component.html.erb
+      - app/components/layout/legal_links_component.html.erb
       - app/components/layout/social_component.html.erb
       - app/components/layout/subnavigation_component.html.erb
       - app/components/layout/top_links_component.html.erb

--- a/Capfile
+++ b/Capfile
@@ -25,3 +25,5 @@ install_plugin Capistrano::SCM::Git
 Dir.glob("lib/capistrano/tasks/*.rake").each { |r| import r }
 Dir.glob("lib/capistrano/tasks/*.cap").each { |r| import r }
 Dir.glob("lib/capistrano/**/*.rb").each { |r| import r }
+
+require_relative "lib/consul/repository"

--- a/Capfile
+++ b/Capfile
@@ -24,6 +24,5 @@ install_plugin Capistrano::SCM::Git
 # Load custom tasks from `lib/capistrano/tasks` if you have any defined
 Dir.glob("lib/capistrano/tasks/*.rake").each { |r| import r }
 Dir.glob("lib/capistrano/tasks/*.cap").each { |r| import r }
-Dir.glob("lib/capistrano/**/*.rb").each { |r| import r }
 
 require_relative "lib/consul/repository"

--- a/app/components/layout/footer_component.html.erb
+++ b/app/components/layout/footer_component.html.erb
@@ -24,19 +24,7 @@
   <div class="subfooter row">
     <div class="small-12 medium-8 column">
       <%= t("layouts.footer.copyright", year: Time.current.year) %>
-      <ul class="legal">
-        <li><%= link_to t("layouts.footer.privacy"), page_path("privacy") %></li>
-        <li><%= link_to t("layouts.footer.conditions"), page_path("conditions") %></li>
-        <li><%= link_to t("layouts.footer.accessibility"), page_path("accessibility") %></li>
-        <% if feature?(:cookies_consent) %>
-          <li class="cookies-consent-management-footer-content">
-            <a href="#cookies_consent_management" data-open="cookies_consent_management">
-              <%= t("layouts.footer.cookies_consent_management") %>
-            </a>
-          </li>
-        <% end %>
-        <%= raw footer_legal_content_block %>
-      </ul>
+      <%= render Layout::LegalLinksComponent.new %>
     </div>
 
     <%= render Layout::SocialComponent.new %>

--- a/app/components/layout/footer_component.rb
+++ b/app/components/layout/footer_component.rb
@@ -1,12 +1,6 @@
 class Layout::FooterComponent < ApplicationComponent
-  delegate :content_block, to: :helpers
-
   def render?
     !Rails.application.multitenancy_management_mode?
-  end
-
-  def footer_legal_content_block
-    content_block("footer_legal")
   end
 
   private

--- a/app/components/layout/legal_links_component.html.erb
+++ b/app/components/layout/legal_links_component.html.erb
@@ -2,6 +2,7 @@
   <li><%= privacy_link %></li>
   <li><%= conditions_link %></li>
   <li><%= accessibility_link %></li>
+  <li><%= repo_link %></li>
   <% if feature?(:cookies_consent) %>
     <li class="cookies-consent-management-footer-content">
       <a href="#cookies_consent_management" data-open="cookies_consent_management">

--- a/app/components/layout/legal_links_component.html.erb
+++ b/app/components/layout/legal_links_component.html.erb
@@ -1,7 +1,7 @@
 <ul class="legal">
-  <li><%= link_to t("layouts.footer.privacy"), page_path("privacy") %></li>
-  <li><%= link_to t("layouts.footer.conditions"), page_path("conditions") %></li>
-  <li><%= link_to t("layouts.footer.accessibility"), page_path("accessibility") %></li>
+  <li><%= privacy_link %></li>
+  <li><%= conditions_link %></li>
+  <li><%= accessibility_link %></li>
   <% if feature?(:cookies_consent) %>
     <li class="cookies-consent-management-footer-content">
       <a href="#cookies_consent_management" data-open="cookies_consent_management">

--- a/app/components/layout/legal_links_component.html.erb
+++ b/app/components/layout/legal_links_component.html.erb
@@ -1,0 +1,13 @@
+<ul class="legal">
+  <li><%= link_to t("layouts.footer.privacy"), page_path("privacy") %></li>
+  <li><%= link_to t("layouts.footer.conditions"), page_path("conditions") %></li>
+  <li><%= link_to t("layouts.footer.accessibility"), page_path("accessibility") %></li>
+  <% if feature?(:cookies_consent) %>
+    <li class="cookies-consent-management-footer-content">
+      <a href="#cookies_consent_management" data-open="cookies_consent_management">
+        <%= t("layouts.footer.cookies_consent_management") %>
+      </a>
+    </li>
+  <% end %>
+  <%= raw footer_legal_content_block %>
+</ul>

--- a/app/components/layout/legal_links_component.rb
+++ b/app/components/layout/legal_links_component.rb
@@ -4,4 +4,18 @@ class Layout::LegalLinksComponent < ApplicationComponent
   def footer_legal_content_block
     content_block("footer_legal")
   end
+
+  private
+
+    def privacy_link
+      link_to t("layouts.footer.privacy"), page_path("privacy")
+    end
+
+    def conditions_link
+      link_to t("layouts.footer.conditions"), page_path("conditions")
+    end
+
+    def accessibility_link
+      link_to t("layouts.footer.accessibility"), page_path("accessibility")
+    end
 end

--- a/app/components/layout/legal_links_component.rb
+++ b/app/components/layout/legal_links_component.rb
@@ -1,0 +1,7 @@
+class Layout::LegalLinksComponent < ApplicationComponent
+  delegate :content_block, to: :helpers
+
+  def footer_legal_content_block
+    content_block("footer_legal")
+  end
+end

--- a/app/components/layout/legal_links_component.rb
+++ b/app/components/layout/legal_links_component.rb
@@ -1,3 +1,5 @@
+require "consul/repository"
+
 class Layout::LegalLinksComponent < ApplicationComponent
   delegate :content_block, to: :helpers
 
@@ -17,5 +19,16 @@ class Layout::LegalLinksComponent < ApplicationComponent
 
     def accessibility_link
       link_to t("layouts.footer.accessibility"), page_path("accessibility")
+    end
+
+    # This link makes it easy to comply with the AGPL. Remember that,
+    # to comply with the AGPL, any person visiting your website must
+    # also have (read) access to your source code.
+    def repo_link
+      link_to t("layouts.footer.source_code"), repo_url, rel: "nofollow external"
+    end
+
+    def repo_url
+      Consul::Repository.url.delete_suffix(".git")
     end
 end

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -22,7 +22,8 @@ set :application, deploysecret(:app_name, default: "consul")
 set :deploy_to, deploysecret(:deploy_to)
 set :ssh_options, port: deploysecret(:ssh_port)
 
-set :repo_url, "https://github.com/consuldemocracy/consuldemocracy.git"
+# To use your own repository, don't change this line. Change `lib/consul/repository.rb` instead.
+set :repo_url, Consul::Repository.url # Don't change this line!
 
 set :revision, `git rev-parse --short #{fetch(:branch)}`.strip
 

--- a/config/locales/en/general.yml
+++ b/config/locales/en/general.yml
@@ -203,6 +203,7 @@ en:
       participation_text: Decide how to shape the city you want to live in.
       participation_title: Participation
       privacy: Privacy Policy
+      source_code: Source code
     header:
       administration_menu: Menu
       administration: Administration

--- a/config/locales/es/general.yml
+++ b/config/locales/es/general.yml
@@ -203,6 +203,7 @@ es:
       participation_text: Decide cómo debe ser la ciudad que quieres.
       participation_title: Participación
       privacy: Política de privacidad
+      source_code: Código fuente
     header:
       administration_menu: Menú
       administration: Administración

--- a/lib/consul/repository.rb
+++ b/lib/consul/repository.rb
@@ -1,0 +1,26 @@
+module Consul
+  module Repository
+    class << self
+      # This URL will be used to deploy your source code with Capistrano.
+      # In order to comply with the AGPL, a link to this URL will also be
+      # automatically added to the footer, alongside other legal links
+      # like terms and conditions.
+      #
+      # By default, it uses the Consul Democracy repository. Change this
+      # method in order to deploy code from your own repository (for
+      # instance, your fork of the Consul Democracy repository).
+      #
+      # Remember that, to comply with the AGPL, any person visiting your
+      # website must also have (read) access to your source code.
+      def url
+        consul_url
+      end
+
+      private
+
+        def consul_url
+          "https://github.com/consuldemocracy/consuldemocracy.git"
+        end
+    end
+  end
+end

--- a/spec/components/layout/footer_component_spec.rb
+++ b/spec/components/layout/footer_component_spec.rb
@@ -20,24 +20,4 @@ describe Layout::FooterComponent do
 
     expect(page).not_to be_rendered
   end
-
-  describe "link to manage cookies" do
-    it "shows a link to the cookies management modal when the cookies consent is enabled" do
-      Setting["feature.cookies_consent"] = true
-
-      render_inline Layout::FooterComponent.new
-
-      page.find(".subfooter") do |footer|
-        expect(footer).to have_css "a[data-open=cookies_consent_management]", text: "Manage cookies"
-      end
-    end
-
-    it "does not show a link to the cookies management modal when the cookies consent is disabled" do
-      Setting["feature.cookies_consent"] = false
-
-      render_inline Layout::FooterComponent.new
-
-      expect(page).not_to have_content "Manage cookies"
-    end
-  end
 end

--- a/spec/components/layout/legal_links_component_spec.rb
+++ b/spec/components/layout/legal_links_component_spec.rb
@@ -1,6 +1,12 @@
 require "rails_helper"
 
 describe Layout::LegalLinksComponent do
+  it "shows a link to the source code" do
+    render_inline Layout::LegalLinksComponent.new
+
+    expect(page).to have_link "Source code"
+  end
+
   describe "link to manage cookies" do
     it "shows a link to the cookies management modal when the cookies consent is enabled" do
       Setting["feature.cookies_consent"] = true

--- a/spec/components/layout/legal_links_component_spec.rb
+++ b/spec/components/layout/legal_links_component_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+
+describe Layout::LegalLinksComponent do
+  describe "link to manage cookies" do
+    it "shows a link to the cookies management modal when the cookies consent is enabled" do
+      Setting["feature.cookies_consent"] = true
+
+      render_inline Layout::LegalLinksComponent.new
+
+      expect(page).to have_css "a[data-open=cookies_consent_management]", text: "Manage cookies"
+    end
+
+    it "does not show a link to the cookies management modal when the cookies consent is disabled" do
+      Setting["feature.cookies_consent"] = false
+
+      render_inline Layout::LegalLinksComponent.new
+
+      expect(page).not_to have_content "Manage cookies"
+    end
+  end
+end


### PR DESCRIPTION
## Objectives

* Make it easier for institutions using Consul Democracy to comply with the AGPL.

## Visual changes

### Before these changes

<img width="799" height="259" alt="There isn't a link to the source code in the footer" src="https://github.com/user-attachments/assets/66e46d10-76a1-4e50-a81c-d7cc49ce1908" />


### Aftere these changes

<img width="799" height="259" alt="One of the legal links in the footer is a link to the source code" src="https://github.com/user-attachments/assets/3b253b66-c00a-4eff-8ec2-c1eb2e9d9cff" />

## Release notes

* :warning: In order to make it easier to comply with the AGPL (the license Consul Democracy uses), we've added a link to the source code in the footer. Please change the `url` method in `lib/consul/repository.rb` so it points to your repository. If you're using Capistrano for deployment, make sure the `repo_url` is set to `Consul::Repository.url`.