### PR TITLE
Re-initialize admin menu after updating feature flags

### DIFF
--- a/app/views/admin/settings/update.js.erb
+++ b/app/views/admin/settings/update.js.erb
@@ -7,5 +7,6 @@ var form = $("<%= j render Admin::Settings::FeaturedSettingsFormComponent.new(
 $("#" + form.attr("id")).html(form.html()).find("[type='submit']").focus();
 
 <% if @setting.prefix == "feature" || @setting.prefix == "process" %>
-  $("#side_menu").html("<%= j render Admin::MenuComponent.new %>").foundation();
+  $("#side_menu").html("<%= j render Admin::MenuComponent.new %>");
+  App.AdminMenu.initialize();
 <% end %>

--- a/spec/system/admin/feature_flags_spec.rb
+++ b/spec/system/admin/feature_flags_spec.rb
@@ -63,6 +63,36 @@ describe "Admin feature flags", :admin do
     end
   end
 
+  scenario "Keeps collapsed menu sections after updating a feature" do
+    visit admin_settings_path
+    click_link "Features"
+
+    within "#side_menu" do
+      expect(page).to have_css "button[aria-expanded='true']", exact_text: "Settings"
+      expect(page).to have_css "button[aria-expanded='false']", exact_text: "Messages to users"
+      expect(page).not_to have_link "Newsletters"
+
+      click_button "Messages to users"
+
+      expect(page).to have_link "Newsletters"
+    end
+
+    within "tr", text: "Twitter login" do
+      click_button "Yes"
+      expect(page).to have_button "No"
+    end
+
+    within "#side_menu" do
+      expect(page).to have_css "button[aria-expanded='true']", exact_text: "Settings"
+      expect(page).to have_css "button[aria-expanded='false']", exact_text: "Messages to users"
+      expect(page).not_to have_link "Newsletters"
+
+      click_button "Messages to users"
+
+      expect(page).to have_link "Newsletters"
+    end
+  end
+
   scenario "Disable a feature" do
     visit admin_settings_path
     click_link "Features"


### PR DESCRIPTION
## References
Regression surfaced after #5460 in the commit (db25dc13e1 "Use buttons to open/close admin navigation submenus"), which replaced Foundation's accordion menu with custom JavaScript (App.AdminMenu) that hides collapsed submenu sections only on page load.

The AJAX update of feature settings in the commit(ead5eac67f "Update settings using an AJAX requests") already replaced #side_menu HTML on each toggle, but this did not cause visible issues until the accordion was removed.

## Objectives
Fix the admin sidebar so that, after enabling or disabling a feature in Settings, collapsed menu sections stay collapsed instead of showing all submenus at once.

Re-initialize `App.AdminMenu` when the side menu HTML is replaced via AJAX in `admin/settings/update.js.erb`.
