### PR TITLE
Require consent for notifications by default

### DIFF
--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -90,7 +90,7 @@ class Setting < ApplicationRecord
         "feature.machine_learning": false,
         "feature.remove_investments_supports": true,
         "feature.cookies_consent": false,
-        "feature.gdpr.require_consent_for_notifications": false,
+        "feature.gdpr.require_consent_for_notifications": true,
         "feature.gdpr.warning_for_external_links": false,
         "homepage.widgets.feeds.debates": true,
         "homepage.widgets.feeds.processes": true,

--- a/spec/components/users/public_activity_component_spec.rb
+++ b/spec/components/users/public_activity_component_spec.rb
@@ -9,7 +9,7 @@ describe Users::PublicActivityComponent, controller: UsersController do
 
   describe "follows tab" do
     context "public interests is checked" do
-      let(:user) { create(:user, public_interests: true) }
+      let(:user) { create(:user, public_interests: true, public_activity: true) }
       let(:component) { Users::PublicActivityComponent.new(user) }
 
       it "is displayed for everyone" do
@@ -40,7 +40,7 @@ describe Users::PublicActivityComponent, controller: UsersController do
     end
 
     context "public interests is not checked" do
-      let(:user) { create(:user, public_interests: false) }
+      let(:user) { create(:user, public_interests: false, public_activity: true) }
       let(:component) { Users::PublicActivityComponent.new(user) }
 
       it "is displayed for its owner" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -34,6 +34,7 @@ RSpec.configure do |config|
   config.before do |example|
     Globalize.set_fallbacks_to_all_available_locales
     Setting["feature.user.skip_verification"] = nil
+    Setting["feature.gdpr.require_consent_for_notifications"] = nil
   end
 
   config.around do |example|


### PR DESCRIPTION
Quoting from commit e7f221038:

> For compatibility with existing installations, we're using a setting, disabled by default. Once we release version 2.4.0 we will enable it by default, which won't affect existing installations but only new ones.

Since we've already released version 2.5.0, we can enable it by default.