### PR TITLE
Transpose poll results table orientation to vertical

### DIFF
--- a/app/components/polls/results/question_component.html.erb
+++ b/app/components/polls/results/question_component.html.erb
@@ -1,42 +1,34 @@
 <h3 id="<%= question.title.parameterize %>"><%= question.title %></h3>
 <table id="question_<%= question.id %>_results_table">
   <% if question.accepts_options? %>
-    <thead>
-      <tr>
-        <%- question.question_options.each do |option| %>
-          <th scope="col" class="<%= option_styles(option) %>">
+    <tbody>
+      <%- question.question_options.each do |option| %>
+        <tr>
+          <th scope="row" class="<%= option_styles(option) %>">
             <% if most_voted_option?(option) %>
               <span class="show-for-sr"><%= t("polls.show.results.most_voted_answer") %></span>
             <% end %>
             <%= option.title %>
           </th>
-        <% end %>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <%- question.question_options.each do |option| %>
           <td class="<%= option_styles(option) %>">
             <%= number_with_percentage(option.total_votes, option.total_votes_percentage) %>
           </td>
-        <% end %>
-      </tr>
+        </tr>
+      <% end %>
     </tbody>
   <% else %>
-    <thead>
-      <tr>
-        <th scope="col"><%= t("polls.show.results.open_ended.valid") %></th>
-        <th scope="col"><%= t("polls.show.results.open_ended.blank") %></th>
-      </tr>
-    </thead>
     <tbody>
       <tr>
+        <th scope="row"><%= t("polls.show.results.open_ended.valid") %></th>
         <td>
           <%= number_with_percentage(
             question.open_ended_valid_answers_count,
             question.open_ended_valid_percentage
           ) %>
         </td>
+      </tr>
+      <tr>
+        <th scope="row"><%= t("polls.show.results.open_ended.blank") %></th>
         <td>
           <%= number_with_percentage(
             question.open_ended_blank_answers_count,

--- a/spec/components/polls/results/question_component_spec.rb
+++ b/spec/components/polls/results/question_component_spec.rb
@@ -12,7 +12,7 @@ describe Polls::Results::QuestionComponent do
 
       render_inline Polls::Results::QuestionComponent.new(question)
 
-      expect(page).to have_table with_rows: [{ "Most voted answer: Yes" => "1 (50%)",
+      expect(page).to have_table with_cols: [{ "Most voted answer: Yes" => "1 (50%)",
                                                "No" => "1 (50%)" }]
 
       page.find("table") do |table|
@@ -28,7 +28,7 @@ describe Polls::Results::QuestionComponent do
     it "renders open_ended headers and empty counts when there are no participants" do
       render_inline Polls::Results::QuestionComponent.new(open_ended_question)
 
-      expect(page).to have_table with_rows: [{ "Valid" => "0 (0%)",
+      expect(page).to have_table with_cols: [{ "Valid" => "0 (0%)",
                                                "Blank" => "0 (0%)" }]
     end
 
@@ -40,7 +40,7 @@ describe Polls::Results::QuestionComponent do
 
       render_inline Polls::Results::QuestionComponent.new(open_ended_question)
 
-      expect(page).to have_table with_rows: [{ "Valid" => "3 (75%)",
+      expect(page).to have_table with_cols: [{ "Valid" => "3 (75%)",
                                                "Blank" => "1 (25%)" }]
     end
   end

--- a/spec/components/polls/results_component_spec.rb
+++ b/spec/components/polls/results_component_spec.rb
@@ -24,12 +24,12 @@ describe Polls::ResultsComponent do
 
     expect(page).to have_content "Do you like Consul Democracy?"
     expect(page).to have_table "question_#{question_1.id}_results_table",
-                               with_rows: [{ "Most voted answer: Yes" => "2 (66.67%)",
+                               with_cols: [{ "Most voted answer: Yes" => "2 (66.67%)",
                                              "No" => "1 (33.33%)" }]
 
     expect(page).to have_content "Which option do you prefer?"
     expect(page).to have_table "question_#{question_2.id}_results_table",
-                               with_rows: [{ "Most voted answer: Answer A" => "1 (33.33%)",
+                               with_cols: [{ "Most voted answer: Answer A" => "1 (33.33%)",
                                              "Answer B" => "1 (33.33%)",
                                              "Answer C" => "1 (33.33%)" }]
   end


### PR DESCRIPTION
Transpose the Poll Results Table. This swaps the rows and columns, transforming the table to be vertical instead of horizontal.

## References

Fix for #5512 

## Visual Changes

Before:
<img width="845" height="153" alt="image" src="https://github.com/user-attachments/assets/d38ecd01-63d8-4def-918e-e1cd9cc29b78" /> (Desktop)

<img width="677" height="482" alt="image" src="https://github.com/user-attachments/assets/b98c5b1e-5c4a-4f33-86c0-33c49d063a42" /> (Mobile)

After:
<img width="835" height="236" alt="image" src="https://github.com/user-attachments/assets/ab190d98-de89-4103-a23a-8cbdf49fc38c" /> (Desktop)

<img width="755" height="487" alt="image" src="https://github.com/user-attachments/assets/5a7e5dc0-c5c6-4657-aee3-6cd0a8c6a1f9" /> (Mobile)

Co-authored-by: James Duffy <jduffy3@gmail.com>
Co-authored-by: Mark Simpson <verdammelt@gmail.com>
