### PR TITLE
Replace capybara-webmock with Puffing Billy

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -82,9 +82,9 @@ end
 
 group :test do
   gem "capybara", "~> 3.40.0"
-  gem "capybara-webmock", "~> 0.7.0"
   gem "email_spec", "~> 2.3.1"
   gem "pdf-reader", "~> 2.15.1"
+  gem "puffing-billy", "~> 4.0"
   gem "rspec-rails", "~> 8.0.4"
   gem "selenium-webdriver", "~> 4.43.0"
   gem "simplecov", "~> 0.22.0", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -152,13 +152,6 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
-    capybara-webmock (0.7.0)
-      capybara (>= 2.4, < 4)
-      rack (>= 1.4)
-      rack-proxy (>= 0.6.0)
-      rexml (>= 3.2)
-      selenium-webdriver (>= 4.0)
-      webrick (>= 1.7)
     caxlsx (4.4.1)
       htmlentities (~> 4.3, >= 4.3.4)
       marcel (~> 1.0)
@@ -187,6 +180,7 @@ GEM
     coffee-script-source (1.12.2)
     concurrent-ruby (1.3.6)
     connection_pool (2.5.5)
+    cookiejar (0.3.4)
     crass (1.0.6)
     csv (3.3.5)
     daemons (1.4.1)
@@ -213,6 +207,17 @@ GEM
     diff-lcs (1.6.2)
     docile (1.4.0)
     drb (2.2.3)
+    em-http-request (1.1.7)
+      addressable (>= 2.3.4)
+      cookiejar (!= 0.3.1)
+      em-socksify (>= 0.3)
+      eventmachine (>= 1.0.3)
+      http_parser.rb (>= 0.6.0)
+    em-socksify (0.3.3)
+      base64
+      eventmachine (>= 1.0.0.beta.4)
+    em-synchrony (1.0.6)
+      eventmachine (>= 1.0.0.beta.1)
     email_spec (2.3.1)
       htmlentities (~> 4.3)
       launchy (>= 2.1, < 4.0)
@@ -229,6 +234,8 @@ GEM
       smart_properties
     erubi (1.13.1)
     event_stream_parser (1.0.0)
+    eventmachine (1.2.7)
+    eventmachine_httpserver (0.2.1)
     execjs (2.10.0)
     exiftool (1.3.0)
       json
@@ -306,6 +313,7 @@ GEM
       reline
     htmlbeautifier (1.4.3)
     htmlentities (4.4.2)
+    http_parser.rb (0.8.1)
     httparty (0.24.2)
       csv
       mini_mime (>= 1.0.0)
@@ -541,6 +549,15 @@ GEM
       date
       stringio
     public_suffix (6.0.2)
+    puffing-billy (4.0.4)
+      addressable (~> 2.5)
+      cgi
+      em-http-request (~> 1.1, >= 1.1.0)
+      em-synchrony
+      eventmachine (~> 1.2)
+      eventmachine_httpserver
+      http_parser.rb (~> 0.8.0)
+      multi_json
     puma (6.6.1)
       nio4r (~> 2.0)
     racc (1.8.1)
@@ -557,8 +574,6 @@ GEM
     rack-protection (3.2.0)
       base64 (>= 0.1.0)
       rack (~> 2.2, >= 2.2.4)
-    rack-proxy (0.7.6)
-      rack
     rack-session (1.0.2)
       rack (< 3)
     rack-test (2.2.0)
@@ -866,7 +881,6 @@ DEPENDENCIES
   capistrano3-delayed-job (~> 1.7.6)
   capistrano3-puma (~> 6.2.0)
   capybara (~> 3.40.0)
-  capybara-webmock (~> 0.7.0)
   caxlsx (~> 4.4.1)
   caxlsx_rails (~> 0.6.4)
   ckeditor (~> 4.3.0)
@@ -919,6 +933,7 @@ DEPENDENCIES
   pronto-erb_lint (~> 0.1.6)
   pronto-rubocop (~> 0.11.6)
   pronto-stylelint (~> 0.11.1)
+  puffing-billy (~> 4.0)
   puma (~> 6.6.1)
   rails (~> 7.2.3.1)
   recipient_interceptor (~> 0.3.3)

--- a/app/assets/javascripts/imageable.js
+++ b/app/assets/javascripts/imageable.js
@@ -187,7 +187,7 @@
       App.Imageable.setInputErrors(data);
     },
     initializeAttachSuggestedImage: function() {
-      $("body").on("click", ".js-attach-suggested-image", function() {
+      $("body").on("click", ".suggested-image-button", function() {
         var imageId, resourceType, resourceId, dataString, wrapper;
         imageId = $(this).data("image-id");
         wrapper = $(this).closest(".suggested-images-wrapper");

--- a/app/assets/stylesheets/mixins/uploads.scss
+++ b/app/assets/stylesheets/mixins/uploads.scss
@@ -59,14 +59,17 @@
       }
     }
 
-    .suggested-images-grid .suggested-image-cell {
-      margin-bottom: 1rem;
+    .suggested-images {
+      @include dynamic-grid($min-column-width: clamp(3rem, 40%, 10rem));
+      list-style: none;
 
-      .suggested-image {
-        height: auto;
+      button {
+        min-width: 1rem;
+      }
+
+      img {
         min-height: rem-calc(120);
         object-fit: cover;
-        width: 100%;
       }
     }
 

--- a/app/components/image_suggestions/suggestions_component.html.erb
+++ b/app/components/image_suggestions/suggestions_component.html.erb
@@ -10,10 +10,7 @@
     <div class="small-12 column suggested-images-grid">
       <% images.each_with_index do |image, index| %>
         <div class="small-6 medium-3 column suggested-image-cell">
-          <button type="button"
-                  class="suggested-image-button"
-                  data-image-id="<%= image.id %>"
-                  id="suggested-image-<%= image.id %>">
+          <button type="button" class="suggested-image-button" data-image-id="<%= image.id %>">
             <%= image_tag(image.src["small"], alt: image.user.name, class: "suggested-image") %>
             <span class="show-for-sr">
               <%= t("images.form.attach_suggested_image_aria_label", index: index + 1, count: images.count) %>

--- a/app/components/image_suggestions/suggestions_component.html.erb
+++ b/app/components/image_suggestions/suggestions_component.html.erb
@@ -7,11 +7,11 @@
   <% end %>
   <% if images.any? %>
     <p class="help-text mb-2"><%= t("images.form.pick_an_image") %></p>
-    <ul class="small-12 column suggested-images-grid">
+    <ul class="suggested-images">
       <% images.each_with_index do |image, index| %>
-        <li class="small-6 medium-3 column suggested-image-cell">
+        <li>
           <button type="button" class="suggested-image-button" data-image-id="<%= image.id %>">
-            <%= image_tag(image.src["small"], alt: image.user.name, class: "suggested-image") %>
+            <%= image_tag(image.src["small"], alt: image.user.name) %>
             <span class="show-for-sr">
               <%= t("images.form.attach_suggested_image_aria_label", index: index + 1, count: images.count) %>
             </span>

--- a/app/components/image_suggestions/suggestions_component.html.erb
+++ b/app/components/image_suggestions/suggestions_component.html.erb
@@ -7,18 +7,18 @@
   <% end %>
   <% if images.any? %>
     <p class="help-text mb-2"><%= t("images.form.pick_an_image") %></p>
-    <div class="small-12 column suggested-images-grid">
+    <ul class="small-12 column suggested-images-grid">
       <% images.each_with_index do |image, index| %>
-        <div class="small-6 medium-3 column suggested-image-cell">
+        <li class="small-6 medium-3 column suggested-image-cell">
           <button type="button" class="suggested-image-button" data-image-id="<%= image.id %>">
             <%= image_tag(image.src["small"], alt: image.user.name, class: "suggested-image") %>
             <span class="show-for-sr">
               <%= t("images.form.attach_suggested_image_aria_label", index: index + 1, count: images.count) %>
             </span>
           </button>
-        </div>
+        </li>
       <% end %>
-    </div>
+    </ul>
   <% else %>
     <div>
       <small class="error"><%= t("images.form.no_images_found") %></small>

--- a/app/components/image_suggestions/suggestions_component.html.erb
+++ b/app/components/image_suggestions/suggestions_component.html.erb
@@ -13,12 +13,10 @@
           <button type="button"
                   class="js-attach-suggested-image suggested-image-button"
                   data-image-id="<%= image.id %>"
-                  id="suggested-image-<%= image.id %>"
-                  aria-label="<%= t("images.form.attach_suggested_image_aria_label", index: index + 1, count: images.count) %>"
-                  aria-describedby="suggested-image-desc-<%= image.id %>">
+                  id="suggested-image-<%= image.id %>">
             <%= image_tag(image.src["small"], alt: image.user.name, class: "suggested-image") %>
-            <span id="suggested-image-desc-<%= image.id %>" class="show-for-sr">
-              <%= t("images.form.attach_suggested_image") %>
+            <span class="show-for-sr">
+              <%= t("images.form.attach_suggested_image_aria_label", index: index + 1, count: images.count) %>
             </span>
           </button>
         </div>

--- a/app/components/image_suggestions/suggestions_component.html.erb
+++ b/app/components/image_suggestions/suggestions_component.html.erb
@@ -11,7 +11,7 @@
       <% images.each_with_index do |image, index| %>
         <div class="small-6 medium-3 column suggested-image-cell">
           <button type="button"
-                  class="js-attach-suggested-image suggested-image-button"
+                  class="suggested-image-button"
                   data-image-id="<%= image.id %>"
                   id="suggested-image-<%= image.id %>">
             <%= image_tag(image.src["small"], alt: image.user.name, class: "suggested-image") %>

--- a/app/views/image_suggestions/create.js.erb
+++ b/app/views/image_suggestions/create.js.erb
@@ -1,7 +1,7 @@
 $(".suggested-images-container").replaceWith("<%= j render(ImageSuggestions::SuggestionsComponent.new(@suggestions)) %>");
 
 var imageFields = $(".suggested-images-wrapper").closest(".image-fields.direct-upload");
-if (imageFields.find(".js-attach-suggested-image").length > 0) {
+if (imageFields.find(".suggested-image-button").length > 0) {
   imageFields.find("label.button").addClass("hide");
 } else {
   imageFields.find("label.button").removeClass("hide");

--- a/config/locales/en/images.yml
+++ b/config/locales/en/images.yml
@@ -9,7 +9,6 @@ en:
       or_separator: or
       suggest_image_with_ai: Suggest an image with AI
       suggested_images_container: Suggested images
-      attach_suggested_image: Attach suggested image
       attach_suggested_image_aria_label: "Attach suggested image %{index} of %{count}"
       pick_an_image: "Select an image from the suggestions below:"
       no_images_found: No suggestions could be found.

--- a/config/locales/es/images.yml
+++ b/config/locales/es/images.yml
@@ -9,7 +9,6 @@ es:
       or_separator: o
       suggest_image_with_ai: Sugerir una imagen con IA
       suggested_images_container: Imágenes sugeridas
-      attach_suggested_image: Adjuntar imagen sugerida
       attach_suggested_image_aria_label: "Adjuntar imagen sugerida %{index} de %{count}"
       pick_an_image: "Selecciona una imagen de las sugerencias siguientes:"
       no_images_found: No se encontraron sugerencias.

--- a/docs/en/features/image_suggestions.md
+++ b/docs/en/features/image_suggestions.md
@@ -158,18 +158,6 @@ The image suggestions feature works with any resource that:
 
 Currently, this is only implemented on with Budget Investments feature!
 
-## Customization
-
-### Styling
-
-The suggested images grid uses CSS classes that can be customized:
-
-- `.suggested-images-container`: Container for all suggested images
-- `.suggested-image-button`: Individual image button
-- `.suggested-image`: The image element itself
-
-Styles are defined in `app/assets/stylesheets/mixins/uploads.scss`.
-
 ## Pricing Considerations
 
 ### LLM Costs

--- a/docs/en/features/image_suggestions.md
+++ b/docs/en/features/image_suggestions.md
@@ -165,7 +165,7 @@ Currently, this is only implemented on with Budget Investments feature!
 The suggested images grid uses CSS classes that can be customized:
 
 - `.suggested-images-container`: Container for all suggested images
-- `.js-attach-suggested-image`: Individual image button
+- `.suggested-image-button`: Individual image button
 - `.suggested-image`: The image element itself
 
 Styles are defined in `app/assets/stylesheets/mixins/uploads.scss`.

--- a/docs/es/features/image_suggestions.md
+++ b/docs/es/features/image_suggestions.md
@@ -164,7 +164,7 @@ La funcionalidad de sugerencias de imágenes funciona con cualquier recurso que:
 La cuadrícula de imágenes sugeridas usa clases CSS que se pueden personalizar:
 
 - `.suggested-images-container`: Contenedor para todas las imágenes sugeridas
-- `.js-attach-suggested-image`: Botón de imagen individual
+- `.suggested-image-button`: Botón de imagen individual
 - `.suggested-image`: El elemento de imagen en sí
 
 Los estilos están definidos en `app/assets/stylesheets/mixins/uploads.scss`.

--- a/docs/es/features/image_suggestions.md
+++ b/docs/es/features/image_suggestions.md
@@ -157,18 +157,6 @@ La funcionalidad de sugerencias de imágenes funciona con cualquier recurso que:
 
 ¡Actualmente, esto solo está implementado con la funcionalidad de proyectos de gasto!
 
-## Personalización
-
-### Estilos
-
-La cuadrícula de imágenes sugeridas usa clases CSS que se pueden personalizar:
-
-- `.suggested-images-container`: Contenedor para todas las imágenes sugeridas
-- `.suggested-image-button`: Botón de imagen individual
-- `.suggested-image`: El elemento de imagen en sí
-
-Los estilos están definidos en `app/assets/stylesheets/mixins/uploads.scss`.
-
 ## Consideraciones de Precios
 
 ### Costos de LLM

--- a/spec/components/image_suggestions/suggestions_component_spec.rb
+++ b/spec/components/image_suggestions/suggestions_component_spec.rb
@@ -52,11 +52,9 @@ describe ImageSuggestions::SuggestionsComponent do
     it "includes accessibility attributes for container, buttons and images" do
       render_inline component
 
-      expect(page).to have_css ".suggested-images-container[role='region'][aria-label='Suggested images']"
-      expect(page).to have_css ".js-attach-suggested-image[aria-label='Attach suggested image 1 of 1']"
+      expect(page).to have_button "Attach suggested image 1 of 1"
       expect(page).to have_css "img.suggested-image[alt='Photographer 1']"
-      expect(page).to have_css "[aria-describedby='suggested-image-desc-1']"
-      expect(page).to have_css "#suggested-image-desc-1"
+      expect(page).to have_css ".suggested-images-container[role='region'][aria-label='Suggested images']"
     end
   end
 end

--- a/spec/components/image_suggestions/suggestions_component_spec.rb
+++ b/spec/components/image_suggestions/suggestions_component_spec.rb
@@ -43,7 +43,6 @@ describe ImageSuggestions::SuggestionsComponent do
       render_inline component
 
       expect(page).to have_css ".suggested-image-button", count: 1
-      expect(page).to have_css "#suggested-image-1"
       expect(page).to have_css "img", count: 1
       expect(page).to have_css "img[src='https://example.com/image1.jpg']"
     end

--- a/spec/components/image_suggestions/suggestions_component_spec.rb
+++ b/spec/components/image_suggestions/suggestions_component_spec.rb
@@ -52,7 +52,7 @@ describe ImageSuggestions::SuggestionsComponent do
 
       expect(page).to have_button "Attach suggested image 1 of 1"
       expect(page).to have_css ".suggested-images-container[role='region'][aria-label='Suggested images']"
-      expect(page).to have_css "img.suggested-image[alt='Photographer 1']"
+      expect(page).to have_css ".suggested-images img[alt='Photographer 1']"
     end
   end
 end

--- a/spec/components/image_suggestions/suggestions_component_spec.rb
+++ b/spec/components/image_suggestions/suggestions_component_spec.rb
@@ -42,9 +42,8 @@ describe ImageSuggestions::SuggestionsComponent do
     it "renders the grid with attach buttons" do
       render_inline component
 
-      expect(page).to have_css ".js-attach-suggested-image", count: 1
+      expect(page).to have_css ".suggested-image-button", count: 1
       expect(page).to have_css "#suggested-image-1"
-      expect(page).to have_css ".suggested-image-button"
       expect(page).to have_css "img", count: 1
       expect(page).to have_css "img[src='https://example.com/image1.jpg']"
     end
@@ -53,8 +52,8 @@ describe ImageSuggestions::SuggestionsComponent do
       render_inline component
 
       expect(page).to have_button "Attach suggested image 1 of 1"
-      expect(page).to have_css "img.suggested-image[alt='Photographer 1']"
       expect(page).to have_css ".suggested-images-container[role='region'][aria-label='Suggested images']"
+      expect(page).to have_css "img.suggested-image[alt='Photographer 1']"
     end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -19,7 +19,12 @@ require "custom_spec_helper"
 require "capybara/rails"
 require "capybara/rspec"
 require "selenium/webdriver"
+require "billy/capybara/rspec"
 require "view_component/test_helpers"
+
+Billy.configure do |config|
+  config.non_whitelisted_requests_disabled = true
+end
 
 module ViewComponent
   module TestHelpers
@@ -75,7 +80,9 @@ Capybara.register_driver :headless_chrome do |app|
     opts.add_argument "--headless"
     opts.add_argument "--no-sandbox"
     opts.add_argument "--window-size=1200,800"
-    opts.add_argument "--proxy-server=#{Capybara.app_host}:#{Capybara::Webmock.port_number}"
+    opts.add_argument "--ignore-certificate-errors"
+    opts.add_argument "--proxy-server=#{Billy.proxy.host}:#{Billy.proxy.port}"
+    opts.add_argument "--proxy-bypass-list=127.0.0.1;localhost;lvh.me;*.lvh.me"
   end
 
   Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -52,14 +52,6 @@ RSpec.configure do |config|
     Rails.application.load_seed
   end
 
-  config.before(:each, type: :system) do
-    Capybara::Webmock.start
-  end
-
-  config.after(:suite) do
-    Capybara::Webmock.stop
-  end
-
   config.before(:each, type: :system) do |example|
     driven_by :headless_chrome
     Capybara.default_set_options = { clear: :backspace }

--- a/spec/system/budgets/investments_spec.rb
+++ b/spec/system/budgets/investments_spec.rb
@@ -865,7 +865,7 @@ describe "Budget Investments" do
           .and_return(fixture_file_upload("clippy.jpg"))
       end
 
-      scenario "User can suggest images, attach one and create the investment", :js do
+      scenario "User can suggest images, attach one and create the investment" do
         login_as(author)
         visit new_budget_investment_path(budget)
 

--- a/spec/system/budgets/investments_spec.rb
+++ b/spec/system/budgets/investments_spec.rb
@@ -879,7 +879,6 @@ describe "Budget Investments" do
         click_button "Suggest an image with AI"
 
         expect(page).to have_content "Select an image from the suggestions below:"
-        expect(ImageSuggestions::Llm::Client).to have_received(:call)
 
         within(".suggested-images-container") do
           click_button "Attach suggested image 1 of 1"

--- a/spec/system/external_links_spec.rb
+++ b/spec/system/external_links_spec.rb
@@ -1,6 +1,10 @@
 require "rails_helper"
 
 describe "Warning for external links" do
+  before do
+    proxy.stub("http://www.gnu.org/licenses/agpl-3.0.html").and_return(body: "<html></html>", code: 200)
+  end
+
   context "when the feature is enabled" do
     before { Setting["feature.gdpr.warning_for_external_links"] = true }
 

--- a/spec/system/notifications_spec.rb
+++ b/spec/system/notifications_spec.rb
@@ -154,6 +154,8 @@ describe "Notifications" do
     end
 
     scenario "With external link" do
+      proxy.stub("https://www.external.link.dev:443/").and_return(body: "<html></html>", code: 200)
+
       visit notifications_path
       expect(page).to have_content("Notification title")
       expect(page).to have_content("Notification body")


### PR DESCRIPTION
## References
Related PR: #6399 

While working on the Rack 3 upgrade, we found that `capybara-webmock` needs local patches to keep working with Rack 3. The gem is used for system specs, so this PR replaces it with Puffing Billy instead of adding a temporary patch for `capybara-webmock`.

## Objectives

Replace `capybara-webmock` with Puffing Billy for system specs.

This keeps the same general purpose: Chrome/Selenium traffic goes through a test proxy, local application requests are allowed, and external browser requests are blocked so the test suite does not depend on external services.

Require `billy/capybara/rspec` so the proxy is stopped after the suite; without it the CI process hangs even when all tests pass.

## Notes

One behaviour difference is that Puffing Billy blocks non-whitelisted external requests, while `capybara-webmock` returned an empty 200 response.