### PR TITLE
Disable Turbolinks for notification links

### DIFF
--- a/app/views/notifications/_notification.html.erb
+++ b/app/views/notifications/_notification.html.erb
@@ -5,7 +5,7 @@
                   title: notification.notifiable_title,
                   body: notification.notifiable_body } %>
     <% link_text = render "/notifications/notification_body", locals %>
-    <%= link_to_if notification.link.present?, link_text, notification.link, class: "notification-link" %>
+    <%= link_to_if notification.link.present?, link_text, notification.link, class: "notification-link", data: { turbolinks: false } %>
   <% else %>
     <p>
       <strong>


### PR DESCRIPTION
## References
Related PR: #6401 


## Objectives
Notification links first open `/notifications/:id`. That route marks the notification as read and then redirects the user to the final link.

After adding Puffing Billy, external links go through the test proxy. This can make the redirect flow a bit slower in CI and expose a flaky system spec.

Turbolinks is not useful for this flow because there is no intermediate page to render. This PR disables Turbolinks for notification links, so the browser uses a normal navigation and follows the redirect directly.