### PR TITLE
Replace jquery-ujs with rails-ujs before jQuery 4

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -11,7 +11,7 @@
 // about supported directives.
 //
 //= require jquery
-//= require jquery-ujs
+//= require rails-ujs
 //= require jquery-ui/ui/version
 //= require jquery-ui/ui/data
 //= require jquery-ui/ui/ie

--- a/app/assets/javascripts/forms.js
+++ b/app/assets/javascripts/forms.js
@@ -10,7 +10,8 @@
     },
     submitOnChange: function(selector) {
       $("body").on("change", selector, function() {
-        $(this).closest("form").submit();
+        var form = $(this).closest("form")[0];
+        form.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
         return false;
       });
     },

--- a/app/assets/javascripts/legislation_annotatable.js
+++ b/app/assets/javascripts/legislation_annotatable.js
@@ -112,8 +112,9 @@
         if ($("[data-legislation-open-phase]").data("legislation-open-phase") !== false) {
           App.LegislationAnnotatable.highlight("#7fff9a");
           $("#comments-box textarea").trigger("focus");
-          $("#new_legislation_annotation").on("ajax:complete", function(e, xhr) {
-            var responseJSON = xhr.responseJSON;
+          $("#new_legislation_annotation").on("ajax:complete", function(e) {
+            var xhr = e.originalEvent.detail[0];
+            var responseJSON = JSON.parse(xhr.responseText);
             if (xhr.status === 200) {
               App.LegislationAnnotatable.remove_highlight();
               App.LegislationAnnotatable.app.annotations.runHook("annotationCreated", [responseJSON]);

--- a/app/assets/javascripts/legislation_annotatable.js
+++ b/app/assets/javascripts/legislation_annotatable.js
@@ -112,15 +112,16 @@
         if ($("[data-legislation-open-phase]").data("legislation-open-phase") !== false) {
           App.LegislationAnnotatable.highlight("#7fff9a");
           $("#comments-box textarea").trigger("focus");
-          $("#new_legislation_annotation").on("ajax:complete", function(e, data) {
-            if (data.status === 200) {
+          $("#new_legislation_annotation").on("ajax:complete", function(e, xhr) {
+            var responseJSON = xhr.responseJSON;
+            if (xhr.status === 200) {
               App.LegislationAnnotatable.remove_highlight();
-              App.LegislationAnnotatable.app.annotations.runHook("annotationCreated", [data.responseJSON]);
+              App.LegislationAnnotatable.app.annotations.runHook("annotationCreated", [responseJSON]);
               $("#comments-box").html("").hide();
-              App.LegislationAnnotatable.loadAnnotationComments(annotation_url, data.responseJSON.id);
+              App.LegislationAnnotatable.loadAnnotationComments(annotation_url, responseJSON.id);
             } else {
               $(e.target).find("label").addClass("error");
-              $("<small class='error'>" + data.responseJSON[0] + "</small>").insertAfter($(e.target).find("textarea"));
+              $("<small class='error'>" + responseJSON[0] + "</small>").insertAfter($(e.target).find("textarea"));
             }
           });
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,13 +6,13 @@
     "": {
       "name": "consuldemocracy",
       "dependencies": {
+        "@rails/ujs": "^7.1.3-4",
         "blueimp-file-upload": "^10.32.0",
         "c3": "0.4.23",
         "d3": "3.5.17",
         "foundation-sites": "^6.8.1",
         "jquery": "^3.7.1",
         "jquery-ui": "^1.13.3",
-        "jquery-ujs": "^1.2.3",
         "leaflet": "^1.9.4",
         "leaflet.markercluster": "^1.5.3",
         "markdown-it": "^14.1.1"
@@ -514,6 +514,11 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/@rails/ujs": {
+      "version": "7.1.3-4",
+      "resolved": "https://registry.npmjs.org/@rails/ujs/-/ujs-7.1.3-4.tgz",
+      "integrity": "sha512-z0ckI5jrAJfImcObjMT1RBz2IxH6I5q6ZTMFex6AfxSQKZuuL8JxAXvg2CvBuodGCxKvybFVolDyMHXlBLeYAA=="
     },
     "node_modules/@sindresorhus/merge-streams": {
       "version": "4.0.0",
@@ -1659,14 +1664,6 @@
       "integrity": "sha512-D2YJfswSJRh/B8M/zCowDpNFfwsDmtfnMPwjJTyvl+CBqzpYwQ+gFYIbUUlzijy/Qvoy30H1YhoSui4MNYpRwA==",
       "dependencies": {
         "jquery": ">=1.8.0 <4.0.0"
-      }
-    },
-    "node_modules/jquery-ujs": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/jquery-ujs/-/jquery-ujs-1.2.3.tgz",
-      "integrity": "sha512-59wvfx5vcCTHMeQT1/OwFiAj+UffLIwjRIoXdpO7Z7BCFGepzq9T9oLVeoItjTqjoXfUrHJvV7QU6pUR+UzOoA==",
-      "peerDependencies": {
-        "jquery": ">=1.8.0"
       }
     },
     "node_modules/js-tokens": {

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
   "name": "consuldemocracy",
   "dependencies": {
+    "@rails/ujs": "^7.1.3-4",
     "blueimp-file-upload": "^10.32.0",
     "c3": "0.4.23",
     "d3": "3.5.17",
     "foundation-sites": "^6.8.1",
     "jquery": "^3.7.1",
     "jquery-ui": "^1.13.3",
-    "jquery-ujs": "^1.2.3",
     "leaflet": "^1.9.4",
     "leaflet.markercluster": "^1.5.3",
     "markdown-it": "^14.1.1"


### PR DESCRIPTION
## References
Related PR: Bump jquery from 3.7.1 to 4.0.0 #6224

## Objectives
This PR replaces jquery-ujs with @rails/ujs.

This is a preparatory change for the jQuery 4 upgrade. During the work on #6224, we found that `jquery-ujs` does not handle some AJAX script responses correctly with jQuery 4, especially remote forms and buttons that rely on `format.js` / `.js.erb` responses.

`@rails/ujs` is the Rails-provided replacement for `jquery-ujs`. It keeps support for the existing UJS features used by the application.

The PR also updates the annotation AJAX handler because `rails-ujs` exposes AJAX callback parameters through `event.detail` instead of passing them as additional jQuery handler arguments, as documented in the [Rails UJS event handlers guide](https://guides.rubyonrails.org/v6.1.0/working_with_javascript_in_rails.html#rails-ujs-event-handlers)⁠
