### PR TITLE
Replace blueimp-file-upload with Dropzone for direct uploads

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -52,6 +52,7 @@
 //= require jquery-ui/ui/widgets/sortable
 //= require blueimp-file-upload/js/jquery.iframe-transport
 //= require blueimp-file-upload/js/jquery.fileupload
+//= require @deltablot/dropzone/dist/dropzone-min
 //= require foundation-sites
 //= require turbolinks
 //= require turbolinks_anchors

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -92,6 +92,7 @@
 //= require legislation_annotatable
 //= require legislation_draft_versions
 //= require followable
+//= require attachable
 //= require documentable
 //= require imageable
 //= require tree_navigator

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -50,8 +50,6 @@
 //= require jquery-ui/ui/i18n/datepicker-en-GB
 //= require jquery-ui/ui/widgets/autocomplete
 //= require jquery-ui/ui/widgets/sortable
-//= require blueimp-file-upload/js/jquery.iframe-transport
-//= require blueimp-file-upload/js/jquery.fileupload
 //= require @deltablot/dropzone/dist/dropzone-min
 //= require foundation-sites
 //= require turbolinks

--- a/app/assets/javascripts/attachable.js
+++ b/app/assets/javascripts/attachable.js
@@ -1,0 +1,120 @@
+(function() {
+  "use strict";
+
+  App.Attachable = {
+    setupInput: function(config) {
+      var $input, $container, uploadData, dropzone, $zone, dropzoneOptions;
+
+      $input = $(config.input);
+      $container = $input.closest(config.attachmentContainer);
+      $zone = $("<div>", { class: "hidden-dropzone-upload" });
+      $container.append($zone);
+
+      uploadData = {};
+
+      dropzoneOptions = {
+        url: $input.data("url"),
+        paramName: "attachment",
+        maxFiles: 1,
+        clickable: false,
+        headers: { "X-CSRF-Token": $("meta[name=csrf-token]").attr("content") },
+        previewTemplate: "<div></div>"
+      };
+
+      dropzone = new Dropzone($zone[0], dropzoneOptions);
+
+      $input.on("change", function() {
+        uploadData = App.Attachable.buildData(config.input);
+        App.Attachable.setFilename(uploadData, this.files[0].name);
+        dropzone.addFile(this.files[0]);
+      });
+
+      dropzone.on("addedfile", function() {
+        uploadData = App.Attachable.buildData(config.input);
+        App.Attachable.clearProgressBar(uploadData);
+        App.Attachable.setProgressBar(uploadData, "uploading");
+      });
+
+      dropzone.on("uploadprogress", function(_file, progress) {
+        $(uploadData.progressBar).find(".loading-bar").css("width", progress + "%");
+      });
+
+      dropzone.on("success", function(_file, response) {
+        var destroyAttachmentLink;
+
+        $(uploadData.cachedAttachmentField).val(response.cached_attachment);
+        App.Attachable.setTitleFromFile(uploadData, response.filename);
+        App.Attachable.setProgressBar(uploadData, "complete");
+        App.Attachable.setFilename(uploadData, response.filename);
+        App.Attachable.clearInputErrors(uploadData);
+        destroyAttachmentLink = $(response.destroy_link);
+        $(uploadData.destroyAttachmentLinkContainer).html(destroyAttachmentLink);
+
+        if (config.onSuccess) {
+          config.onSuccess(uploadData, response);
+        }
+      });
+
+      dropzone.on("error", function(file, message) {
+        $(uploadData.cachedAttachmentField).val("");
+        App.Attachable.clearFilename(uploadData);
+        App.Attachable.setProgressBar(uploadData, "errors");
+        App.Attachable.clearInputErrors(uploadData);
+        App.Attachable.setInputErrors(uploadData, message.errors);
+        $(uploadData.destroyAttachmentLinkContainer).find("a.delete:not(.remove-nested)").remove();
+        $(uploadData.addAttachmentLabel).addClass("error");
+
+        if (config.onError) {
+          config.onError(uploadData);
+        }
+
+        dropzone.removeFile(file);
+      });
+    },
+    buildData: function(input) {
+      var data, wrapper;
+
+      data = [];
+      wrapper = $(input).closest(".direct-upload");
+
+      data.wrapper = wrapper;
+      data.progressBar = $(wrapper).find(".progress-bar-placeholder");
+      data.errorContainer = $(wrapper).find(".attachment-errors");
+      data.fileNameContainer = $(wrapper).find("p.file-name");
+      data.destroyAttachmentLinkContainer = $(wrapper).find(".action-remove");
+      data.addAttachmentLabel = $(wrapper).find(".action-add label");
+      data.cachedAttachmentField = $(wrapper).find("input[name$='[cached_attachment]']");
+      data.titleField = $(wrapper).find("input[name$='[title]']");
+
+      $(wrapper).find(".progress-bar-placeholder").css("display", "block");
+
+      return data;
+    },
+    clearFilename: function(data) {
+      $(data.fileNameContainer).text("");
+    },
+    clearInputErrors: function(data) {
+      $(data.errorContainer).find("small.error").remove();
+    },
+    clearProgressBar: function(data) {
+      $(data.progressBar).find(".loading-bar").removeClass("complete errors uploading").css("width", "0px");
+    },
+    setFilename: function(data, file_name) {
+      $(data.fileNameContainer).text(file_name);
+    },
+    setProgressBar: function(data, klass) {
+      $(data.progressBar).find(".loading-bar").addClass(klass);
+    },
+    setTitleFromFile: function(data, title) {
+      if ($(data.titleField).val() === "") {
+        $(data.titleField).val(title);
+      }
+    },
+    setInputErrors: function(data, errors) {
+      if (!errors) {
+        return;
+      }
+      $(data.errorContainer).append("<small class='error'>" + errors + "</small>");
+    }
+  };
+}).call(this);

--- a/app/assets/javascripts/documentable.js
+++ b/app/assets/javascripts/documentable.js
@@ -22,51 +22,91 @@
       App.Documentable.initializeRemoveCachedDocumentLinks();
     },
     initializeDirectUploadInput: function(input) {
-      var inputData;
-      inputData = this.buildData([], input);
-      $(input).fileupload({
+      var $input, uploadData, dropzone, $zone;
+
+      $input = $(input);
+
+      if ($input.data("documentableDropzone")) {
+        return;
+      }
+
+
+      $zone = $input.closest(".document-attachment").find(".js-document-dropzone");
+      if ($zone.length === 0) {
+        $zone = $("<div>", { class: "js-document-dropzone hidden-dropzone-upload" });
+        $input.closest(".document-attachment").append($zone);
+      }
+
+      uploadData = {};
+
+      dropzone = new Dropzone($zone[0], {
+        url: $input.data("url"),
         paramName: "attachment",
-        formData: null,
-        add: function(e, data) {
-          var upload_data;
-          upload_data = App.Documentable.buildData(data, e.target);
-          App.Documentable.clearProgressBar(upload_data);
-          App.Documentable.setProgressBar(upload_data, "uploading");
-          upload_data.submit();
-        },
-        change: function(e, data) {
-          data.files.forEach(function(file) {
-            App.Documentable.setFilename(inputData, file.name);
-          });
-        },
-        fail: function(e, data) {
-          $(data.cachedAttachmentField).val("");
-          App.Documentable.clearFilename(data);
-          App.Documentable.setProgressBar(data, "errors");
-          App.Documentable.clearInputErrors(data);
-          App.Documentable.setInputErrors(data);
-          $(data.destroyAttachmentLinkContainer).find("a.delete:not(.remove-nested)").remove();
-          $(data.addAttachmentLabel).addClass("error");
-        },
-        done: function(e, data) {
-          var destroyAttachmentLink;
-          $(data.cachedAttachmentField).val(data.result.cached_attachment);
-          App.Documentable.setTitleFromFile(data, data.result.filename);
-          App.Documentable.setProgressBar(data, "complete");
-          App.Documentable.setFilename(data, data.result.filename);
-          App.Documentable.clearInputErrors(data);
-          destroyAttachmentLink = $(data.result.destroy_link);
-          $(data.destroyAttachmentLinkContainer).html(destroyAttachmentLink);
-          if (input.lockUpload) {
-            App.Documentable.showNotice();
-          }
-        },
-        progress: function(e, data) {
-          var progress;
-          progress = parseInt(data.loaded / data.total * 100, 10);
-          $(data.progressBar).find(".loading-bar").css("width", progress + "%");
+        maxFiles: 1,
+        clickable: false,
+        autoProcessQueue: true,
+        headers: { "X-CSRF-Token": $("meta[name=csrf-token]").attr("content") },
+        previewTemplate: "<div></div>"
+      });
+
+      $input.on("change.documentable", function() {
+        if (this.files.length === 0) {
+          return;
+        }
+
+        uploadData = App.Documentable.buildData([], input);
+        App.Documentable.setFilename(uploadData, this.files[0].name);
+        dropzone.removeAllFiles(true);
+        dropzone.addFile(this.files[0]);
+      });
+
+      dropzone.on("addedfile", function() {
+        uploadData = App.Documentable.buildData([], input);
+        App.Documentable.clearProgressBar(uploadData);
+        App.Documentable.setProgressBar(uploadData, "uploading");
+      });
+
+      dropzone.on("uploadprogress", function(_file, progress) {
+        $(uploadData.progressBar).find(".loading-bar").css("width", progress + "%");
+      });
+
+      dropzone.on("success", function(_file, response) {
+        var destroyAttachmentLink;
+
+        $(uploadData.cachedAttachmentField).val(response.cached_attachment);
+        App.Documentable.setTitleFromFile(uploadData, response.filename);
+        App.Documentable.setProgressBar(uploadData, "complete");
+        App.Documentable.setFilename(uploadData, response.filename);
+        App.Documentable.clearInputErrors(uploadData);
+        destroyAttachmentLink = $(response.destroy_link);
+        $(uploadData.destroyAttachmentLinkContainer).html(destroyAttachmentLink);
+
+        if (input.lockUpload) {
+          App.Documentable.showNotice();
         }
       });
+
+      dropzone.on("error", function(file, message, xhr) {
+        var errors;
+
+        if (xhr && xhr.responseJSON && xhr.responseJSON.errors) {
+          errors = xhr.responseJSON.errors;
+        } else {
+          errors = message;
+        }
+
+        uploadData.jqXHR = xhr || { responseJSON: { errors: errors } };
+        $(uploadData.cachedAttachmentField).val("");
+        App.Documentable.clearFilename(uploadData);
+        App.Documentable.setProgressBar(uploadData, "errors");
+        App.Documentable.clearInputErrors(uploadData);
+        App.Documentable.setInputErrors(uploadData);
+        $(uploadData.destroyAttachmentLinkContainer).find("a.delete:not(.remove-nested)").remove();
+        $(uploadData.addAttachmentLabel).addClass("error");
+        dropzone.removeFile(file);
+      });
+
+      $input.data("documentableDropzone", dropzone);
     },
     buildData: function(data, input) {
       var wrapper;

--- a/app/assets/javascripts/documentable.js
+++ b/app/assets/javascripts/documentable.js
@@ -22,129 +22,15 @@
       App.Documentable.initializeRemoveCachedDocumentLinks();
     },
     initializeDirectUploadInput: function(input) {
-      var $input, uploadData, dropzone, $zone;
-
-      $input = $(input);
-
-      if ($input.data("documentableDropzone")) {
-        return;
-      }
-
-
-      $zone = $input.closest(".document-attachment").find(".js-document-dropzone");
-      if ($zone.length === 0) {
-        $zone = $("<div>", { class: "js-document-dropzone hidden-dropzone-upload" });
-        $input.closest(".document-attachment").append($zone);
-      }
-
-      uploadData = {};
-
-      dropzone = new Dropzone($zone[0], {
-        url: $input.data("url"),
-        paramName: "attachment",
-        maxFiles: 1,
-        clickable: false,
-        autoProcessQueue: true,
-        headers: { "X-CSRF-Token": $("meta[name=csrf-token]").attr("content") },
-        previewTemplate: "<div></div>"
-      });
-
-      $input.on("change.documentable", function() {
-        if (this.files.length === 0) {
-          return;
-        }
-
-        uploadData = App.Documentable.buildData([], input);
-        App.Documentable.setFilename(uploadData, this.files[0].name);
-        dropzone.removeAllFiles(true);
-        dropzone.addFile(this.files[0]);
-      });
-
-      dropzone.on("addedfile", function() {
-        uploadData = App.Documentable.buildData([], input);
-        App.Documentable.clearProgressBar(uploadData);
-        App.Documentable.setProgressBar(uploadData, "uploading");
-      });
-
-      dropzone.on("uploadprogress", function(_file, progress) {
-        $(uploadData.progressBar).find(".loading-bar").css("width", progress + "%");
-      });
-
-      dropzone.on("success", function(_file, response) {
-        var destroyAttachmentLink;
-
-        $(uploadData.cachedAttachmentField).val(response.cached_attachment);
-        App.Documentable.setTitleFromFile(uploadData, response.filename);
-        App.Documentable.setProgressBar(uploadData, "complete");
-        App.Documentable.setFilename(uploadData, response.filename);
-        App.Documentable.clearInputErrors(uploadData);
-        destroyAttachmentLink = $(response.destroy_link);
-        $(uploadData.destroyAttachmentLinkContainer).html(destroyAttachmentLink);
-
-        if (input.lockUpload) {
-          App.Documentable.showNotice();
+      App.Attachable.setupInput({
+        input: input,
+        attachmentContainer: ".document-attachment",
+        onSuccess: function() {
+          if (input.lockUpload) {
+            App.Documentable.showNotice();
+          }
         }
       });
-
-      dropzone.on("error", function(file, message, xhr) {
-        var errors;
-
-        if (xhr && xhr.responseJSON && xhr.responseJSON.errors) {
-          errors = xhr.responseJSON.errors;
-        } else {
-          errors = message;
-        }
-
-        uploadData.jqXHR = xhr || { responseJSON: { errors: errors } };
-        $(uploadData.cachedAttachmentField).val("");
-        App.Documentable.clearFilename(uploadData);
-        App.Documentable.setProgressBar(uploadData, "errors");
-        App.Documentable.clearInputErrors(uploadData);
-        App.Documentable.setInputErrors(uploadData);
-        $(uploadData.destroyAttachmentLinkContainer).find("a.delete:not(.remove-nested)").remove();
-        $(uploadData.addAttachmentLabel).addClass("error");
-        dropzone.removeFile(file);
-      });
-
-      $input.data("documentableDropzone", dropzone);
-    },
-    buildData: function(data, input) {
-      var wrapper;
-      wrapper = $(input).closest(".direct-upload");
-      data.progressBar = $(wrapper).find(".progress-bar-placeholder");
-      data.errorContainer = $(wrapper).find(".attachment-errors");
-      data.fileNameContainer = $(wrapper).find("p.file-name");
-      data.destroyAttachmentLinkContainer = $(wrapper).find(".action-remove");
-      data.addAttachmentLabel = $(wrapper).find(".action-add label");
-      data.cachedAttachmentField = $(wrapper).find("input[name$='[cached_attachment]']");
-      data.titleField = $(wrapper).find("input[name$='[title]']");
-      $(wrapper).find(".progress-bar-placeholder").css("display", "block");
-      return data;
-    },
-    clearFilename: function(data) {
-      $(data.fileNameContainer).text("");
-    },
-    clearInputErrors: function(data) {
-      $(data.errorContainer).find("small.error").remove();
-    },
-    clearProgressBar: function(data) {
-      $(data.progressBar).find(".loading-bar").removeClass("complete errors uploading").css("width", "0px");
-    },
-    setFilename: function(data, file_name) {
-      $(data.fileNameContainer).text(file_name);
-    },
-    setProgressBar: function(data, klass) {
-      $(data.progressBar).find(".loading-bar").addClass(klass);
-    },
-    setTitleFromFile: function(data, title) {
-      if ($(data.titleField).val() === "") {
-        $(data.titleField).val(title);
-      }
-    },
-    setInputErrors: function(data) {
-      var errors;
-      errors = "<small class='error'>" + data.jqXHR.responseJSON.errors + "</small>";
-      $(data.errorContainer).append(errors);
     },
     lockUploads: function() {
       $("#new_document_link").addClass("hide");

--- a/app/assets/javascripts/imageable.js
+++ b/app/assets/javascripts/imageable.js
@@ -22,50 +22,89 @@
       App.Imageable.initializeAttachSuggestedImage();
     },
     initializeDirectUploadInput: function(input) {
-      var inputData;
-      inputData = this.buildData([], input);
-      $(input).fileupload({
+      var $input, uploadData, dropzone, $zone;
+
+      $input = $(input);
+
+      if ($input.data("imageableDropzone")) {
+        return;
+      }
+
+      $zone = $input.closest(".image-attachment").find(".js-image-dropzone");
+      if ($zone.length === 0) {
+        $zone = $("<div>", { class: "js-image-dropzone hidden-dropzone-upload" });
+        $input.closest(".image-attachment").append($zone);
+      }
+
+      uploadData = {};
+
+      dropzone = new Dropzone($zone[0], {
+        url: $input.data("url"),
         paramName: "attachment",
-        formData: null,
-        add: function(e, data) {
-          var upload_data;
-          upload_data = App.Imageable.buildData(data, e.target);
-          App.Imageable.clearProgressBar(upload_data);
-          App.Imageable.setProgressBar(upload_data, "uploading");
-          upload_data.submit();
-        },
-        change: function(e, data) {
-          data.files.forEach(function(file) {
-            App.Imageable.setFilename(inputData, file.name);
-          });
-        },
-        fail: function(e, data) {
-          $(data.cachedAttachmentField).val("");
-          App.Imageable.clearFilename(data);
-          App.Imageable.setProgressBar(data, "errors");
-          App.Imageable.clearInputErrors(data);
-          App.Imageable.setInputErrors(data);
-          App.Imageable.clearPreview(data);
-          $(data.destroyAttachmentLinkContainer).find("a.delete:not(.remove-nested)").remove();
-          $(data.addAttachmentLabel).addClass("error");
-        },
-        done: function(e, data) {
-          var destroyAttachmentLink;
-          $(data.cachedAttachmentField).val(data.result.cached_attachment);
-          App.Imageable.setTitleFromFile(data, data.result.filename);
-          App.Imageable.setProgressBar(data, "complete");
-          App.Imageable.setFilename(data, data.result.filename);
-          App.Imageable.clearInputErrors(data);
-          App.Imageable.setPreview(data);
-          destroyAttachmentLink = $(data.result.destroy_link);
-          $(data.destroyAttachmentLinkContainer).html(destroyAttachmentLink);
-        },
-        progress: function(e, data) {
-          var progress;
-          progress = parseInt(data.loaded / data.total * 100, 10);
-          $(data.progressBar).find(".loading-bar").css("width", progress + "%");
-        }
+        maxFiles: 1,
+        clickable: false,
+        autoProcessQueue: true,
+        headers: { "X-CSRF-Token": $("meta[name=csrf-token]").attr("content") },
+        previewTemplate: "<div></div>"
       });
+
+      $input.on("change.imageable", function() {
+        if (this.files.length === 0) {
+          return;
+        }
+
+        uploadData = App.Imageable.buildData([], input);
+        App.Imageable.setFilename(uploadData, this.files[0].name);
+        dropzone.removeAllFiles(true);
+        dropzone.addFile(this.files[0]);
+      });
+
+      dropzone.on("addedfile", function() {
+        uploadData = App.Imageable.buildData([], input);
+        App.Imageable.clearProgressBar(uploadData);
+        App.Imageable.setProgressBar(uploadData, "uploading");
+      });
+
+      dropzone.on("uploadprogress", function(_file, progress) {
+        $(uploadData.progressBar).find(".loading-bar").css("width", progress + "%");
+      });
+
+      dropzone.on("success", function(_file, response) {
+        var destroyAttachmentLink;
+
+        uploadData.result = response;
+        $(uploadData.cachedAttachmentField).val(response.cached_attachment);
+        App.Imageable.setTitleFromFile(uploadData, response.filename);
+        App.Imageable.setProgressBar(uploadData, "complete");
+        App.Imageable.setFilename(uploadData, response.filename);
+        App.Imageable.clearInputErrors(uploadData);
+        App.Imageable.setPreview(uploadData);
+        destroyAttachmentLink = $(response.destroy_link);
+        $(uploadData.destroyAttachmentLinkContainer).html(destroyAttachmentLink);
+      });
+
+      dropzone.on("error", function(file, message, xhr) {
+        var errors;
+
+        if (xhr && xhr.responseJSON && xhr.responseJSON.errors) {
+          errors = xhr.responseJSON.errors;
+        } else {
+          errors = message;
+        }
+
+        uploadData.jqXHR = xhr || { responseJSON: { errors: errors } };
+        $(uploadData.cachedAttachmentField).val("");
+        App.Imageable.clearFilename(uploadData);
+        App.Imageable.setProgressBar(uploadData, "errors");
+        App.Imageable.clearInputErrors(uploadData);
+        App.Imageable.setInputErrors(uploadData);
+        App.Imageable.clearPreview(uploadData);
+        $(uploadData.destroyAttachmentLinkContainer).find("a.delete:not(.remove-nested)").remove();
+        $(uploadData.addAttachmentLabel).addClass("error");
+        dropzone.removeFile(file);
+      });
+
+      $input.data("imageableDropzone", dropzone);
     },
     buildData: function(data, input) {
       var wrapper;

--- a/app/assets/javascripts/imageable.js
+++ b/app/assets/javascripts/imageable.js
@@ -22,142 +22,33 @@
       App.Imageable.initializeAttachSuggestedImage();
     },
     initializeDirectUploadInput: function(input) {
-      var $input, uploadData, dropzone, $zone;
-
-      $input = $(input);
-
-      if ($input.data("imageableDropzone")) {
-        return;
-      }
-
-      $zone = $input.closest(".image-attachment").find(".js-image-dropzone");
-      if ($zone.length === 0) {
-        $zone = $("<div>", { class: "js-image-dropzone hidden-dropzone-upload" });
-        $input.closest(".image-attachment").append($zone);
-      }
-
-      uploadData = {};
-
-      dropzone = new Dropzone($zone[0], {
-        url: $input.data("url"),
-        paramName: "attachment",
-        maxFiles: 1,
-        clickable: false,
-        autoProcessQueue: true,
-        headers: { "X-CSRF-Token": $("meta[name=csrf-token]").attr("content") },
-        previewTemplate: "<div></div>"
-      });
-
-      $input.on("change.imageable", function() {
-        if (this.files.length === 0) {
-          return;
+      App.Attachable.setupInput({
+        input: input,
+        attachmentContainer: ".image-attachment",
+        onSuccess: function(uploadData, response) {
+          uploadData.result = response;
+          App.Imageable.setPreview(uploadData);
+        },
+        onError: function(uploadData) {
+          App.Imageable.clearPreview(uploadData);
         }
-
-        uploadData = App.Imageable.buildData([], input);
-        App.Imageable.setFilename(uploadData, this.files[0].name);
-        dropzone.removeAllFiles(true);
-        dropzone.addFile(this.files[0]);
       });
-
-      dropzone.on("addedfile", function() {
-        uploadData = App.Imageable.buildData([], input);
-        App.Imageable.clearProgressBar(uploadData);
-        App.Imageable.setProgressBar(uploadData, "uploading");
-      });
-
-      dropzone.on("uploadprogress", function(_file, progress) {
-        $(uploadData.progressBar).find(".loading-bar").css("width", progress + "%");
-      });
-
-      dropzone.on("success", function(_file, response) {
-        var destroyAttachmentLink;
-
-        uploadData.result = response;
-        $(uploadData.cachedAttachmentField).val(response.cached_attachment);
-        App.Imageable.setTitleFromFile(uploadData, response.filename);
-        App.Imageable.setProgressBar(uploadData, "complete");
-        App.Imageable.setFilename(uploadData, response.filename);
-        App.Imageable.clearInputErrors(uploadData);
-        App.Imageable.setPreview(uploadData);
-        destroyAttachmentLink = $(response.destroy_link);
-        $(uploadData.destroyAttachmentLinkContainer).html(destroyAttachmentLink);
-      });
-
-      dropzone.on("error", function(file, message, xhr) {
-        var errors;
-
-        if (xhr && xhr.responseJSON && xhr.responseJSON.errors) {
-          errors = xhr.responseJSON.errors;
-        } else {
-          errors = message;
-        }
-
-        uploadData.jqXHR = xhr || { responseJSON: { errors: errors } };
-        $(uploadData.cachedAttachmentField).val("");
-        App.Imageable.clearFilename(uploadData);
-        App.Imageable.setProgressBar(uploadData, "errors");
-        App.Imageable.clearInputErrors(uploadData);
-        App.Imageable.setInputErrors(uploadData);
-        App.Imageable.clearPreview(uploadData);
-        $(uploadData.destroyAttachmentLinkContainer).find("a.delete:not(.remove-nested)").remove();
-        $(uploadData.addAttachmentLabel).addClass("error");
-        dropzone.removeFile(file);
-      });
-
-      $input.data("imageableDropzone", dropzone);
-    },
-    buildData: function(data, input) {
-      var wrapper;
-      wrapper = $(input).closest(".direct-upload");
-      data.wrapper = wrapper;
-      data.progressBar = $(wrapper).find(".progress-bar-placeholder");
-      data.preview = $(wrapper).find(".image-preview");
-      data.errorContainer = $(wrapper).find(".attachment-errors");
-      data.fileNameContainer = $(wrapper).find("p.file-name");
-      data.destroyAttachmentLinkContainer = $(wrapper).find(".action-remove");
-      data.addAttachmentLabel = $(wrapper).find(".action-add label");
-      data.cachedAttachmentField = $(wrapper).find("input[name$='[cached_attachment]']");
-      data.titleField = $(wrapper).find("input[name$='[title]']");
-      $(wrapper).find(".progress-bar-placeholder").css("display", "block");
-      return data;
-    },
-    clearFilename: function(data) {
-      $(data.fileNameContainer).text("");
-    },
-    clearInputErrors: function(data) {
-      $(data.errorContainer).find("small.error").remove();
-    },
-    clearProgressBar: function(data) {
-      $(data.progressBar).find(".loading-bar").removeClass("complete errors uploading").css("width", "0px");
     },
     clearPreview: function(data) {
       $(data.wrapper).find(".image-preview").remove();
     },
-    setFilename: function(data, file_name) {
-      $(data.fileNameContainer).text(file_name);
-    },
-    setProgressBar: function(data, klass) {
-      $(data.progressBar).find(".loading-bar").addClass(klass);
-    },
-    setTitleFromFile: function(data, title) {
-      if ($(data.titleField).val() === "") {
-        $(data.titleField).val(title);
-      }
-    },
-    setInputErrors: function(data) {
-      var errors;
-      errors = "<small class='error'>" + data.jqXHR.responseJSON.errors + "</small>";
-      $(data.errorContainer).append(errors);
-    },
+
     setPreview: function(data) {
-      var image_preview;
+      var preview, image_preview;
+
       image_preview = "<div class='small-12 column text-center image-preview'>" +
         "<figure><img src='" + data.result.attachment_url + "' class='cached-image'></figure></div>";
-      if ($(data.preview).length > 0) {
-        $(data.preview).replaceWith(image_preview);
+      preview = data.wrapper.find(".image-preview");
+
+      if ($(preview).length > 0) {
+        $(preview).replaceWith(image_preview);
       } else {
         $(image_preview).insertBefore($(data.wrapper).find(".attachment-actions"));
-        data.preview = $(data.wrapper).find(".image-preview");
       }
     },
     initializeRemoveCachedImageLinks: function() {
@@ -193,8 +84,8 @@
         }
 
         dataString = App.Imageable.imageSuggestionsParams(form, resourceType);
-        var uploadData = App.Imageable.buildData([], button.closest(".image-fields.direct-upload"));
-        App.Imageable.clearInputErrors(uploadData);
+        var uploadData = App.Attachable.buildData(button.closest(".image-fields.direct-upload"));
+        App.Attachable.clearInputErrors(uploadData);
         $.ajax({
           url: "/image_suggestions",
           type: "POST",
@@ -204,7 +95,7 @@
       });
     },
     attachSuggestedImageSuccess: function(responseData) {
-      var data = App.Imageable.buildData([], this);
+      var data = App.Attachable.buildData(this);
       data.result = {
         cached_attachment: responseData.cached_attachment,
         filename: responseData.filename,
@@ -212,18 +103,17 @@
         destroy_link: responseData.destroy_link
       };
       $(data.cachedAttachmentField).val(data.result.cached_attachment);
-      App.Imageable.setTitleFromFile(data, data.result.filename);
-      App.Imageable.setFilename(data, data.result.filename);
+      App.Attachable.setTitleFromFile(data, data.result.filename);
+      App.Attachable.setFilename(data, data.result.filename);
       App.Imageable.setPreview(data);
       $(data.destroyAttachmentLinkContainer).html(data.result.destroy_link);
       $("#new_image_link").addClass("hide");
-      App.Imageable.clearInputErrors(data);
+      App.Attachable.clearInputErrors(data);
     },
     attachSuggestedImageError: function(xhr) {
-      var data = App.Imageable.buildData([], this);
-      data.jqXHR = xhr;
-      App.Imageable.clearInputErrors(data);
-      App.Imageable.setInputErrors(data);
+      var data = App.Attachable.buildData(this);
+      App.Attachable.clearInputErrors(data);
+      App.Attachable.setInputErrors(data, xhr.responseJSON && xhr.responseJSON.errors);
     },
     initializeAttachSuggestedImage: function() {
       $("body").on("click", ".suggested-image-button", function() {

--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -32,6 +32,7 @@ module.exports = defineConfig([globalIgnores([
       annotator: "readonly",
       c3: "readonly",
       CKEDITOR: "readonly",
+      Dropzone: "readonly",
       L: "readonly",
       Turbolinks: "readonly",
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
       "dependencies": {
         "@deltablot/dropzone": "^7.4.3",
         "@rails/ujs": "^7.1.3-4",
-        "blueimp-file-upload": "^10.32.0",
         "c3": "0.4.23",
         "d3": "3.5.17",
         "foundation-sites": "^6.8.1",
@@ -649,40 +648,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/blueimp-canvas-to-blob": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/blueimp-canvas-to-blob/-/blueimp-canvas-to-blob-3.5.0.tgz",
-      "integrity": "sha512-1Aq2Yn6SUsOERT4Ng7GUWRy6oRvqeNU2Iwhcq5ZH7aoejFkLEKjRx/XcpepfU7IMmj3sONSmiLmSgzj9umGUPw==",
-      "optional": true
-    },
-    "node_modules/blueimp-file-upload": {
-      "version": "10.32.0",
-      "resolved": "https://registry.npmjs.org/blueimp-file-upload/-/blueimp-file-upload-10.32.0.tgz",
-      "integrity": "sha512-3WMJw5Cbfz94Adl1OeyH+rRpGwHiNHzja+CR6aRWPoAtwrUwvP5gXKo0XdX+sdPE+iCU63Xmba88hoHQmzY8RQ==",
-      "optionalDependencies": {
-        "blueimp-canvas-to-blob": "3",
-        "blueimp-load-image": "5",
-        "blueimp-tmpl": "3"
-      },
-      "peerDependencies": {
-        "jquery": ">=1.7"
-      }
-    },
-    "node_modules/blueimp-load-image": {
-      "version": "5.16.0",
-      "resolved": "https://registry.npmjs.org/blueimp-load-image/-/blueimp-load-image-5.16.0.tgz",
-      "integrity": "sha512-3DUSVdOtlfNRk7moRZuTwDmA3NnG8KIJuLcq3c0J7/BIr6X3Vb/EpX3kUH1joxUhmoVF4uCpDfz7wHkz8pQajA==",
-      "optional": true
-    },
-    "node_modules/blueimp-tmpl": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/blueimp-tmpl/-/blueimp-tmpl-3.6.0.tgz",
-      "integrity": "sha512-FPbl2VMophcudvT2Li+y10RtKT4l7wBto1NZycXoVQb1JVlo8QbjDgEqL9Ph41/rUl4dTOv3mqWPoxqCHA1b7A==",
-      "optional": true,
-      "bin": {
-        "tmpl.js": "js/compile.js"
       }
     },
     "node_modules/brace-expansion": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,6 +6,7 @@
     "": {
       "name": "consuldemocracy",
       "dependencies": {
+        "@deltablot/dropzone": "^7.4.3",
         "@rails/ujs": "^7.1.3-4",
         "blueimp-file-upload": "^10.32.0",
         "c3": "0.4.23",
@@ -248,6 +249,14 @@
       },
       "peerDependencies": {
         "postcss-selector-parser": "^7.1.1"
+      }
+    },
+    "node_modules/@deltablot/dropzone": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@deltablot/dropzone/-/dropzone-7.4.3.tgz",
+      "integrity": "sha512-qTj4KEalPcYrocazuKYfhAS3hfgAu17KXw0DkpUj71Aw9E1/x5vTSNK5hvIJLkbpt/pBECU18JkjA3yguONcPA==",
+      "dependencies": {
+        "@swc/helpers": "^0.5.18"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -553,6 +562,14 @@
       },
       "peerDependencies": {
         "stylelint": "^17.6.0"
+      }
+    },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.23",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.23.tgz",
+      "integrity": "sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==",
+      "dependencies": {
+        "tslib": "^2.8.0"
       }
     },
     "node_modules/@types/estree": {
@@ -2718,6 +2735,11 @@
       "engines": {
         "node": ">=8.0"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "consuldemocracy",
   "dependencies": {
+    "@deltablot/dropzone": "^7.4.3",
     "@rails/ujs": "^7.1.3-4",
     "blueimp-file-upload": "^10.32.0",
     "c3": "0.4.23",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "dependencies": {
     "@deltablot/dropzone": "^7.4.3",
     "@rails/ujs": "^7.1.3-4",
-    "blueimp-file-upload": "^10.32.0",
     "c3": "0.4.23",
     "d3": "3.5.17",
     "foundation-sites": "^6.8.1",


### PR DESCRIPTION
## References

- Related to #6224 (Bump jquery from 3.7.1 to 4.0.0).
- Context: making file uploads compatible with jQuery 4 would require vendoring `jquery.fileupload.js` from `blueimp-file-upload` and maintaining a local patch (jQuery 4 removed helpers such as `$.trim`, `$.isNumeric`, `$.type` and `$.isArray`, which blueimp relies on). Instead of maintaining that patch, this PR removes blueimp and migrates uploads to Dropzone (`@deltablot/dropzone`).

## Objectives

- Remove the `blueimp-file-upload` dependency so we don't have to vendor or patch `jquery.fileupload.js` for jQuery 4.0.0.
- Migrate the direct uploads for documents and images to Dropzone while keeping the same markup, the same UI and the same backend contract.

