### PR TITLE
Restore image cancel behavior after validation errors

### DIFF
--- a/app/assets/javascripts/documentable.js
+++ b/app/assets/javascripts/documentable.js
@@ -2,7 +2,7 @@
   "use strict";
   App.Documentable = {
     initialize: function() {
-      $(".js-document-attachment").each(function() {
+      $("#nested-documents [type=file]").each(function() {
         App.Documentable.initializeDirectUploadInput(this);
       });
       $("#nested-documents").on("cocoon:after-remove", function() {
@@ -10,7 +10,7 @@
       });
       $("#nested-documents").on("cocoon:after-insert", function(e, nested_document) {
         var input, document_fields;
-        input = $(nested_document).find(".js-document-attachment");
+        input = $(nested_document).find("[type=file]");
         document_fields = $(nested_document).closest("#nested-documents").find(".document-fields:visible");
 
         input.lockUpload = document_fields.length >= $("#nested-documents").data("max-documents-allowed");

--- a/app/assets/javascripts/imageable.js
+++ b/app/assets/javascripts/imageable.js
@@ -2,19 +2,19 @@
   "use strict";
   App.Imageable = {
     initialize: function() {
-      $(".js-image-attachment").each(function() {
+      $("#nested-image [type=file]").each(function() {
         App.Imageable.initializeDirectUploadInput(this);
       });
       $("#nested-image").on("cocoon:after-remove", function() {
         $("#new_image_link").removeClass("hide");
       });
       $("#nested-image").on("cocoon:before-insert", function() {
-        $(".js-image-attachment").closest(".image-fields").remove();
+        $("#nested-image [type=file]").closest(".image-fields").remove();
       });
       $("#nested-image").on("cocoon:after-insert", function(e, nested_image) {
         var input;
         $("#new_image_link").addClass("hide");
-        input = $(nested_image).find(".js-image-attachment");
+        input = $(nested_image).find("[type=file]");
         App.Imageable.initializeDirectUploadInput(input);
       });
       App.Imageable.initializeRemoveCachedImageLinks();

--- a/app/components/attachable/fields_component.rb
+++ b/app/components/attachable/fields_component.rb
@@ -49,7 +49,6 @@ class Attachable::FieldsComponent < ApplicationComponent
       f.file_field :attachment,
                    label_options: { class: "button hollow #{klass}" },
                    accept: accepted_content_types_extensions,
-                   class: "js-#{singular_name}-attachment",
                    data: { url: direct_upload_path }
     end
 

--- a/spec/system/nested_imageable_spec.rb
+++ b/spec/system/nested_imageable_spec.rb
@@ -68,13 +68,17 @@ describe "Nested imageable" do
       expect(cached_attachment_field.value).to be_empty
     end
 
-    scenario "Should show image errors after invalid form submit" do
+    scenario "Shows image errors after invalid submit and restores add link on cancel" do
       click_link "Add image"
       click_button submit_button_text
 
       within "#nested-image .image-fields" do
         expect(page).to have_content("can't be blank", count: 2)
+        click_link "Cancel"
       end
+
+      expect(page).not_to have_content "Choose image"
+      expect(page).to have_link "Add image"
     end
 
     scenario "Render image preview after sending the form with validation errors" do


### PR DESCRIPTION
## References

Related PR: #6414 , specifically commit 00ffe208e3 ("Migrate image uploads from blueimp to Dropzone").

## Objectives

Fix a regression in the nested image field. After a validation error, clicking "Cancel" on the image block removed the fields but did not restore the "Add image" button, leaving the image section empty.

