### PR TITLE
Avoid creating duplicate votes

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -678,6 +678,9 @@ RSpec/OverwritingSetup:
 RSpec/ReceiveMessages:
   Enabled: true
 
+RSpec/RepeatedDescription:
+  Enabled: true
+
 RSpec/RepeatedExample:
   Enabled: true
 

--- a/app/controllers/comments/votes_controller.rb
+++ b/app/controllers/comments/votes_controller.rb
@@ -7,7 +7,7 @@ module Comments
 
     def create
       authorize! :create, Vote.new(voter: current_user, votable: @comment)
-      @comment.vote_by(voter: current_user, vote: params[:value])
+      current_user.with_lock { @comment.vote_by(voter: current_user, vote: params[:value]) }
 
       respond_to do |format|
         format.html { redirect_to request.referer, notice: I18n.t("flash.actions.create.vote") }

--- a/app/controllers/legislation/proposals/votes_controller.rb
+++ b/app/controllers/legislation/proposals/votes_controller.rb
@@ -10,7 +10,7 @@ module Legislation
 
       def create
         authorize! :create, Vote.new(voter: current_user, votable: @proposal)
-        @proposal.vote_by(voter: current_user, vote: params[:value])
+        current_user.with_lock { @proposal.vote_by(voter: current_user, vote: params[:value]) }
 
         respond_to do |format|
           format.html { redirect_to request.referer, notice: I18n.t("flash.actions.create.vote") }

--- a/app/lib/duplicate_records_logger.rb
+++ b/app/lib/duplicate_records_logger.rb
@@ -1,0 +1,21 @@
+class DuplicateRecordsLogger
+  def info(message)
+    logger.info(message)
+  end
+
+  def logger
+    @logger ||= ActiveSupport::Logger.new(log_file).tap do |logger|
+      logger.formatter = Rails.application.config.log_formatter
+    end
+  end
+
+  private
+
+    def log_file
+      File.join(File.dirname(Rails.application.config.default_log_file), log_filename)
+    end
+
+    def log_filename
+      "duplicate_records.log"
+    end
+end

--- a/app/models/budget/investment.rb
+++ b/app/models/budget/investment.rb
@@ -314,7 +314,7 @@ class Budget
     end
 
     def register_selection(user)
-      vote_by(voter: user, vote: "yes") if selectable_by?(user)
+      user.with_lock { vote_by(voter: user, vote: "yes") } if selectable_by?(user)
     end
 
     def calculate_confidence_score

--- a/app/models/debate.rb
+++ b/app/models/debate.rb
@@ -101,7 +101,7 @@ class Debate < ApplicationRecord
 
   def register_vote(user, vote_value)
     if votable_by?(user)
-      transaction do
+      user.with_lock do
         if user.unverified? && !user.voted_for?(self)
           Debate.increment_counter(:cached_anonymous_votes_total, id)
         end

--- a/app/models/debate.rb
+++ b/app/models/debate.rb
@@ -88,7 +88,9 @@ class Debate < ApplicationRecord
   end
 
   def total_anonymous_votes
-    cached_anonymous_votes_total
+    return 0 if Setting["feature.user.skip_verification"].present?
+
+    Vote.where(votable: self, voter: User.unverified).count
   end
 
   def editable?
@@ -101,13 +103,7 @@ class Debate < ApplicationRecord
 
   def register_vote(user, vote_value)
     if votable_by?(user)
-      user.with_lock do
-        if user.unverified? && !user.voted_for?(self)
-          Debate.increment_counter(:cached_anonymous_votes_total, id)
-        end
-
-        vote_by(voter: user, vote: vote_value)
-      end
+      user.with_lock { vote_by(voter: user, vote: vote_value) }
     end
   end
 
@@ -124,7 +120,7 @@ class Debate < ApplicationRecord
   def anonymous_votes_ratio
     return 0 if cached_votes_total == 0
 
-    (cached_anonymous_votes_total.to_f / cached_votes_total) * 100
+    (total_anonymous_votes.to_f / cached_votes_total) * 100
   end
 
   def after_commented

--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -183,7 +183,7 @@ class Proposal < ApplicationRecord
 
   def register_vote(user, vote_value)
     if votable_by?(user) && !archived?
-      vote_by(voter: user, vote: vote_value)
+      user.with_lock { vote_by(voter: user, vote: vote_value) }
     end
   end
 

--- a/app/models/signature.rb
+++ b/app/models/signature.rb
@@ -27,14 +27,17 @@ class Signature < ApplicationRecord
 
   def assign_vote_to_user
     set_user
-    if signable.is_a? Budget::Investment
-      if [nil, :no_selecting_allowed].include?(signable.reason_for_not_being_selectable_by(user))
-        signable.vote_by(voter: user, vote: "yes")
+    user.with_lock do
+      if signable.is_a? Budget::Investment
+        if [nil, :no_selecting_allowed].include?(signable.reason_for_not_being_selectable_by(user))
+          signable.vote_by(voter: user, vote: "yes")
+          assign_signature_to_vote
+        end
+      else
+        signable.register_vote(user, "yes")
+        assign_signature_to_vote
       end
-    else
-      signable.register_vote(user, "yes")
     end
-    assign_signature_to_vote
   end
 
   def assign_signature_to_vote

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -312,7 +312,19 @@ class User < ApplicationRecord
     end
 
     Budget::Ballot.where(user_id: other_user.id).update_all(user_id: id)
-    Vote.where("voter_id = ? AND voter_type = ?", other_user.id, "User").update_all(voter_id: id)
+
+    with_lock do
+      Vote.where(voter_id: other_user.id, voter_type: "User").find_each do |vote|
+        votable = vote.votable
+        if Vote.where(voter_id: id, voter_type: "User", votable: votable).any?
+          vote.delete
+          votable&.update_cached_votes
+        else
+          vote.update_column(:voter_id, id)
+        end
+      end
+    end
+
     data_log = "id: #{other_user.id} - #{Time.current.strftime("%Y-%m-%d %H:%M:%S")}"
     update!(former_users_data_log: "#{former_users_data_log} | #{data_log}")
   end

--- a/db/migrate/20260728143353_remove_cached_anonymous_votes_total_from_debates.rb
+++ b/db/migrate/20260728143353_remove_cached_anonymous_votes_total_from_debates.rb
@@ -1,0 +1,5 @@
+class RemoveCachedAnonymousVotesTotalFromDebates < ActiveRecord::Migration[8.0]
+  def change
+    remove_column :debates, :cached_anonymous_votes_total, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_10_09_085528) do
+ActiveRecord::Schema[8.0].define(version: 2026_07_28_143353) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -526,7 +526,6 @@ ActiveRecord::Schema[8.0].define(version: 2025_10_09_085528) do
     t.integer "cached_votes_down", default: 0
     t.integer "comments_count", default: 0
     t.datetime "confirmed_hide_at", precision: nil
-    t.integer "cached_anonymous_votes_total", default: 0
     t.integer "cached_votes_score", default: 0
     t.bigint "hot_score", default: 0
     t.integer "confidence_score", default: 0

--- a/lib/tasks/consul.rake
+++ b/lib/tasks/consul.rake
@@ -3,8 +3,10 @@ namespace :consul do
   task execute_release_tasks: ["settings:rename_setting_keys",
                                "settings:add_new_settings",
                                "cache:clear",
-                               "execute_release_2.5.1_tasks"]
+                               "execute_release_2.6.0_tasks"]
 
-  desc "Runs tasks needed to upgrade from 2.4.1 to 2.5.1"
-  task "execute_release_2.5.1_tasks": []
+  desc "Runs tasks needed to upgrade from 2.5.1 to 2.6.0"
+  task "execute_release_2.6.0_tasks": [
+    "votes:remove_duplicate_votes"
+  ]
 end

--- a/lib/tasks/votes.rake
+++ b/lib/tasks/votes.rake
@@ -2,6 +2,7 @@ namespace :votes do
   desc "Removes duplicate votes"
   task remove_duplicate_votes: :environment do
     logger = ApplicationLogger.new
+    duplicate_records_logger = DuplicateRecordsLogger.new
     logger.info "Removing duplicate votes"
 
     Tenant.run_on_each do
@@ -24,11 +25,13 @@ namespace :votes do
           votable&.update_cached_votes
 
           tenant_info = " on tenant #{Tenant.current_schema}" unless Tenant.default?
-          logger.info "Deleted duplicate record with ID #{vote.id} " \
-                      "from the #{Vote.table_name} table " \
-                      "with voter_id #{voter_id}, voter_type #{voter_type}, " \
-                      "votable_id #{votable_id} and votable_type #{votable_type}" \
-                      + tenant_info.to_s
+          log_message = "Deleted duplicate record with ID #{vote.id} " \
+                        "from the #{Vote.table_name} table " \
+                        "with voter_id #{voter_id}, voter_type #{voter_type}, " \
+                        "votable_id #{votable_id} and votable_type #{votable_type}" \
+                        + tenant_info.to_s
+          logger.info(log_message)
+          duplicate_records_logger.info(log_message)
         end
       end
     end

--- a/lib/tasks/votes.rake
+++ b/lib/tasks/votes.rake
@@ -1,4 +1,39 @@
 namespace :votes do
+  desc "Removes duplicate votes"
+  task remove_duplicate_votes: :environment do
+    logger = ApplicationLogger.new
+    logger.info "Removing duplicate votes"
+
+    Tenant.run_on_each do
+      duplicate_ids = Vote.select(:voter_id, :voter_type, :votable_id, :votable_type)
+                          .group(:voter_id, :voter_type, :votable_id, :votable_type)
+                          .having("count(*) > 1")
+                          .pluck(:voter_id, :voter_type, :votable_id, :votable_type)
+
+      duplicate_ids.each do |voter_id, voter_type, votable_id, votable_type|
+        votes = Vote.where(
+                  voter_id: voter_id,
+                  voter_type: voter_type,
+                  votable_id: votable_id,
+                  votable_type: votable_type
+                )
+
+        votes.excluding(votes.first).each do |vote|
+          votable = vote.votable
+          vote.delete
+          votable&.update_cached_votes
+
+          tenant_info = " on tenant #{Tenant.current_schema}" unless Tenant.default?
+          logger.info "Deleted duplicate record with ID #{vote.id} " \
+                      "from the #{Vote.table_name} table " \
+                      "with voter_id #{voter_id}, voter_type #{voter_type}, " \
+                      "votable_id #{votable_id} and votable_type #{votable_type}" \
+                      + tenant_info.to_s
+        end
+      end
+    end
+  end
+
   desc "Resets hot_score to its new value"
   task reset_hot_score: :environment do
     models = [Debate, Proposal, Legislation::Proposal]

--- a/spec/controllers/comments/votes_controller_spec.rb
+++ b/spec/controllers/comments/votes_controller_spec.rb
@@ -2,19 +2,33 @@ require "rails_helper"
 
 describe Comments::VotesController do
   let(:comment) { create(:debate_comment) }
+  let(:user) { create(:user) }
 
   describe "POST create" do
     it "allows voting" do
-      sign_in create(:user)
+      sign_in user
 
       expect do
         post :create, xhr: true, params: { comment_id: comment.id, value: "yes" }
       end.to change { comment.reload.votes_for.size }.by(1)
     end
 
+    it "does not create two records with two simultaneous requests", :race_condition do
+      sign_in user
+
+      2.times.map do
+        Thread.new do
+          post :create, xhr: true, params: { comment_id: comment.id, value: "yes" }
+        rescue AbstractController::DoubleRenderError
+        end
+      end.each(&:join)
+
+      expect(Vote.where(voter: user, votable: comment).count).to eq 1
+    end
+
     it "redirects authenticated users without JavaScript to the same page" do
       request.env["HTTP_REFERER"] = comment_path(comment)
-      sign_in create(:user)
+      sign_in user
 
       expect do
         post :create, params: { comment_id: comment.id, value: "yes" }
@@ -26,7 +40,6 @@ describe Comments::VotesController do
   end
 
   describe "DELETE destroy" do
-    let(:user) { create(:user) }
     let!(:vote) { create(:vote, votable: comment, voter: user) }
 
     it "redirects unidentified users to the sign in page" do

--- a/spec/controllers/legislation/proposals/votes_controller_spec.rb
+++ b/spec/controllers/legislation/proposals/votes_controller_spec.rb
@@ -29,6 +29,20 @@ describe Legislation::Proposals::VotesController do
       end.to change { proposal.reload.votes_for.size }.by(1)
     end
 
+    it "does not create two records with two simultaneous requests", :race_condition do
+      user = create(:user, :level_two)
+      sign_in user
+
+      2.times.map do
+        Thread.new do
+          post :create, xhr: true, params: vote_params
+        rescue AbstractController::DoubleRenderError
+        end
+      end.each(&:join)
+
+      expect(Vote.where(voter: user, votable: proposal).count).to eq 1
+    end
+
     it "does not allow voting if user is not level_two_or_three_verified" do
       sign_in create(:user)
 

--- a/spec/lib/tasks/votes_spec.rb
+++ b/spec/lib/tasks/votes_spec.rb
@@ -1,0 +1,54 @@
+require "rails_helper"
+
+describe "votes tasks" do
+  let(:user) { create(:user) }
+  let(:debate) { create(:debate) }
+
+  describe "votes:remove_duplicate_votes" do
+    before { Rake::Task["votes:remove_duplicate_votes"].reenable }
+
+    it "removes duplicate votes" do
+      second_user = create(:user)
+      other_debate = create(:debate)
+
+      vote = create(:vote, voter: user, votable: debate)
+      second_vote = create(:vote, voter: second_user, votable: debate)
+      other_debate_vote = create(:vote, voter: user, votable: other_debate)
+
+      attributes = { voter_id: user.id, voter_type: "User", votable_id: debate.id, votable_type: "Debate" }
+
+      2.times { insert(:vote, attributes) }
+      insert(:vote, attributes.merge(voter_id: second_user.id))
+
+      debate.update_column(:cached_votes_up, 99)
+
+      expect(Vote.count).to eq 6
+
+      Rake.application.invoke_task("votes:remove_duplicate_votes")
+
+      expect(Vote.count).to eq 3
+      expect(Vote.all).to match_array [vote, second_vote, other_debate_vote]
+      expect(debate.reload.cached_votes_up).to eq 2
+    end
+
+    it "removes duplicate votes on tenants" do
+      create(:tenant, schema: "votes")
+
+      Tenant.switch("votes") do
+        user = create(:user)
+        debate = create(:debate)
+
+        create(:vote, voter: user, votable: debate)
+        insert(:vote, voter_id: user.id, voter_type: "User", votable_id: debate.id, votable_type: "Debate")
+
+        expect(Vote.count).to eq 2
+      end
+
+      Rake.application.invoke_task("votes:remove_duplicate_votes")
+
+      Tenant.switch("votes") do
+        expect(Vote.count).to eq 1
+      end
+    end
+  end
+end

--- a/spec/models/budget/investment_spec.rb
+++ b/spec/models/budget/investment_spec.rb
@@ -1103,6 +1103,21 @@ describe Budget::Investment do
     end
   end
 
+  describe "#register_selection" do
+    let(:budget) { create(:budget, :selecting) }
+    let(:investment) { create(:budget_investment, budget: budget) }
+
+    it "does not create two votes when calling the method twice at the same time", :race_condition do
+      user = create(:user, :level_two)
+
+      2.times.map do
+        Thread.new { investment.register_selection(user) }
+      end.each(&:join)
+
+      expect(Vote.where(voter: user, votable: investment).count).to eq 1
+    end
+  end
+
   describe "#voted_in?" do
     let(:user) { create(:user) }
     let(:investment) { create(:budget_investment) }

--- a/spec/models/budget_spec.rb
+++ b/spec/models/budget_spec.rb
@@ -535,7 +535,7 @@ describe Budget do
       expect(budget.single_heading?).to be false
     end
 
-    it "returns false for budgets with one group and multiple headings" do
+    it "returns false for budgets with multiple groups and multiple headings" do
       2.times { create(:budget_group, budget: budget) }
       2.times { create(:budget_heading, group: budget.groups.sample) }
 

--- a/spec/models/debate_spec.rb
+++ b/spec/models/debate_spec.rb
@@ -139,19 +139,25 @@ describe Debate do
     end
 
     it "is true for anonymous users if allowed anonymous votes" do
-      debate.update!(cached_anonymous_votes_total: 420, cached_votes_total: 1000)
+      debate.update!(cached_votes_total: 1000)
+      allow(debate).to receive(:total_anonymous_votes).and_return(420)
+
       user = create(:user)
       expect(debate.votable_by?(user)).to be true
     end
 
     it "is true for anonymous users if less than 100 votes" do
-      debate.update!(cached_anonymous_votes_total: 90, cached_votes_total: 92)
+      debate.update!(cached_votes_total: 92)
+      allow(debate).to receive(:total_anonymous_votes).and_return(90)
+
       user = create(:user)
       expect(debate.votable_by?(user)).to be true
     end
 
     it "is false for anonymous users if too many anonymous votes" do
-      debate.update!(cached_anonymous_votes_total: 520, cached_votes_total: 1000)
+      debate.update!(cached_votes_total: 1000)
+      allow(debate).to receive(:total_anonymous_votes).and_return(520)
+
       user = create(:user)
       expect(debate.votable_by?(user)).to be false
     end
@@ -169,11 +175,6 @@ describe Debate do
         user = create(:user, residence_verified_at: Time.current, confirmed_phone: "666333111")
         expect { debate.register_vote(user, "yes") }.to change { debate.reload.votes_for.size }.by(1)
       end
-
-      it "does not increase anonymous votes counter" do
-        user = create(:user, residence_verified_at: Time.current, confirmed_phone: "666333111")
-        expect { debate.register_vote(user, "yes") }.not_to change { debate.reload.total_anonymous_votes }
-      end
     end
 
     describe "from level three verified users" do
@@ -181,43 +182,34 @@ describe Debate do
         user = create(:user, verified_at: Time.current)
         expect { debate.register_vote(user, "yes") }.to change { debate.reload.votes_for.size }.by(1)
       end
-
-      it "does not increase anonymous votes counter" do
-        user = create(:user, verified_at: Time.current)
-        expect { debate.register_vote(user, "yes") }.not_to change { debate.reload.total_anonymous_votes }
-      end
     end
 
     describe "from anonymous users when anonymous votes are allowed" do
-      before { debate.update(cached_anonymous_votes_total: 42, cached_votes_total: 100) }
+      before do
+        debate.update!(cached_votes_total: 100)
+        allow(debate).to receive(:total_anonymous_votes).and_return(42)
+      end
 
       it "registers vote" do
         user = create(:user)
         expect { debate.register_vote(user, "yes") }.to change { debate.reload.votes_for.size }.by(1)
       end
-
-      it "increases anonymous votes counter" do
-        user = create(:user)
-        expect { debate.register_vote(user, "yes") }.to change { debate.reload.total_anonymous_votes }.by(1)
-      end
     end
 
     describe "from anonymous users when there are too many anonymous votes" do
-      before { debate.update(cached_anonymous_votes_total: 520, cached_votes_total: 1000) }
+      before do
+        debate.update!(cached_votes_total: 1000)
+        allow(debate).to receive(:total_anonymous_votes).and_return(520)
+      end
 
       it "does not register vote" do
         user = create(:user)
         expect { debate.register_vote(user, "yes") }.not_to change { debate.reload.votes_for.size }
       end
-
-      it "does not increase anonymous votes counter" do
-        user = create(:user)
-        expect { debate.register_vote(user, "yes") }.not_to change { debate.reload.total_anonymous_votes }
-      end
     end
 
     it "does not create two votes when calling the method twice at the same time", :race_condition do
-      debate.update!(cached_anonymous_votes_total: 42, cached_votes_total: 100)
+      debate.update!(cached_votes_total: 100)
       user = create(:user)
 
       2.times.map do
@@ -225,14 +217,36 @@ describe Debate do
       end.each(&:join)
 
       expect(Vote.where(voter: user, votable: debate).count).to eq 1
-      expect(debate.reload.cached_anonymous_votes_total).to eq 43
+      expect(debate.reload.cached_votes_total).to eq 1
     end
   end
 
   describe "#anonymous_votes_ratio" do
     it "returns the percentage of anonymous votes of the total votes" do
-      debate = create(:debate, cached_anonymous_votes_total: 25, cached_votes_total: 100)
-      expect(debate.anonymous_votes_ratio).to eq(25.0)
+      debate = create(:debate)
+      2.times { create(:vote, votable: debate, voter: create(:user)) }
+      3.times { create(:vote, votable: debate, voter: create(:user, :level_two)) }
+
+      expect(debate.anonymous_votes_ratio).to eq 40.0
+    end
+
+    it "ignores votes in other debates" do
+      debate = create(:debate)
+
+      create(:vote, votable: debate, voter: create(:user, :level_two))
+      create(:vote, votable: create(:debate), voter: create(:user))
+
+      expect(debate.anonymous_votes_ratio).to eq 0.0
+    end
+
+    it "returns 0 when skipping verification" do
+      Setting["feature.user.skip_verification"] = true
+      debate = create(:debate)
+
+      create(:vote, votable: debate, voter: create(:user, :level_two))
+      create(:vote, votable: debate, voter: create(:user))
+
+      expect(debate.anonymous_votes_ratio).to eq 0.0
     end
   end
 

--- a/spec/models/debate_spec.rb
+++ b/spec/models/debate_spec.rb
@@ -215,6 +215,18 @@ describe Debate do
         expect { debate.register_vote(user, "yes") }.not_to change { debate.reload.total_anonymous_votes }
       end
     end
+
+    it "does not create two votes when calling the method twice at the same time", :race_condition do
+      debate.update!(cached_anonymous_votes_total: 42, cached_votes_total: 100)
+      user = create(:user)
+
+      2.times.map do
+        Thread.new { debate.register_vote(user, "yes") }
+      end.each(&:join)
+
+      expect(Vote.where(voter: user, votable: debate).count).to eq 1
+      expect(debate.reload.cached_anonymous_votes_total).to eq 43
+    end
   end
 
   describe "#anonymous_votes_ratio" do

--- a/spec/models/proposal_spec.rb
+++ b/spec/models/proposal_spec.rb
@@ -249,6 +249,16 @@ describe Proposal do
 
       expect { archived_proposal.register_vote(user, "yes") }.not_to change { proposal.reload.votes_for.size }
     end
+
+    it "does not create two votes when calling the method twice at the same time", :race_condition do
+      user = create(:user, :level_two)
+
+      2.times.map do
+        Thread.new { proposal.register_vote(user, "yes") }
+      end.each(&:join)
+
+      expect(Vote.where(voter: user, votable: proposal).count).to eq 1
+    end
   end
 
   describe "#cached_votes_up" do

--- a/spec/models/signature_spec.rb
+++ b/spec/models/signature_spec.rb
@@ -168,6 +168,18 @@ describe Signature do
 
         expect(Vote.last.signature).to eq(signature)
       end
+
+      it "does not create two votes when calling the method twice at the same time", :race_condition do
+        signature = create(:signature, document_number: user.document_number)
+
+        2.times.map do
+          Thread.new { signature.assign_vote_to_user }
+        end.each(&:join)
+
+        votes = Vote.where(voter: user, votable: signature.signable)
+        expect(votes.count).to eq 1
+        expect(votes.first.signature).to eq(signature)
+      end
     end
 
     context "inexistent user" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -807,7 +807,7 @@ describe User do
       expect(Poll::Voter.where(user: user)).to match_array [v1, v2]
     end
 
-    it "does not reassign votes if the user has already voted" do
+    it "does not reassign poll voters if the user has already voted" do
       poll = create(:poll)
       user = create(:user, :level_three)
       other_user = create(:user, :level_three)
@@ -823,6 +823,42 @@ describe User do
 
       expect(Poll::Voter.where(user: user)).to match_array [voter, other_poll_voter]
       expect(Poll::Voter.where(user: other_user)).to eq []
+    end
+
+    it "does not reassign votes if the user has already voted" do
+      proposal = create(:proposal)
+      debate = create(:debate)
+      user = create(:user, :level_three)
+      other_user = create(:user, :level_three)
+
+      vote = create(:vote, voter: user, votable: proposal)
+      other_vote = create(:vote, voter: other_user, votable: proposal)
+      other_debate_vote = create(:vote, voter: other_user, votable: debate)
+
+      expect(Vote.where(voter: user)).to eq [vote]
+      expect(Vote.where(voter: other_user)).to match_array [other_vote, other_debate_vote]
+
+      user.take_votes_from(other_user)
+
+      expect(Vote.where(voter: user)).to match_array [vote, other_debate_vote]
+      expect(Vote.where(voter: other_user)).to eq []
+      expect(Vote.find_by(id: other_vote.id)).to be nil
+    end
+
+    it "updates cached vote counters when deleting duplicate votes" do
+      proposal = create(:proposal, cached_votes_up: 0)
+      user = create(:user, :level_three)
+      other_user = create(:user, :level_three)
+
+      create(:vote, voter: user, votable: proposal)
+      create(:vote, voter: other_user, votable: proposal)
+
+      expect(proposal.reload.cached_votes_up).to eq 2
+
+      user.take_votes_from(other_user)
+
+      expect(proposal.reload.cached_votes_up).to eq 1
+      expect(Vote.where(voter: user, votable: proposal).count).to eq 1
     end
   end
 

--- a/spec/system/votes_spec.rb
+++ b/spec/system/votes_spec.rb
@@ -301,7 +301,8 @@ describe "Votes" do
     debate = create(:debate)
 
     Setting["max_ratio_anon_votes_on_debates"] = 50
-    debate.update!(cached_anonymous_votes_total: 520, cached_votes_total: 1000)
+    debate.update!(cached_votes_total: 1000)
+    allow_any_instance_of(Debate).to receive(:total_anonymous_votes).and_return(520)
 
     login_as(user)
 


### PR DESCRIPTION
## References

* Fixes part of #2415
* Similar to #5532

## Objectives

* Prevent duplicate vote records
* Remove existing duplicate votes as part of the release tasks, so we can later add a unique index
* Handle vote collisions when taking votes from erased users
* Fix anonymous votes on debates not being properly updated

## Notes

This pull request follows the first steps of the plan described in [comment](https://github.com/consuldemocracy/consuldemocracy/issues/2415#issuecomment-1167424959) from #2415:

1. avoid duplicate votes in the future by locking the user when calling `vote_by`;
2. add a task to remove existing duplicate votes;
3. release a version of CONSUL so duplicate votes are removed before adding the unique index.

We can't introduce a unique index yet, otherwise, the migration introducing it could crash if there are already duplicate records in existing installations.

The unique index will be added in a later pull request, after this release has been published and the `votes:remove_duplicate_votes` task has run.

For now, this pull request uses `user.with_lock` that call `vote_by`, following the approach used previously for duplicate poll voters.

This is a temporary measure until the database can enforce uniqueness directly.

## Release notes

ℹ️  Due to a race condition in `acts_as_votable`, previous versions could create duplicate records in the `votes` table when the same user voted the same resource simultaneously.

This release prevents new duplicate votes in the main application flows and, as part of the release tasks, runs `votes:remove_duplicate_votes` to remove existing duplicate vote records.

When duplicate votes are removed, affected cached vote counters are recalculated.

A later release will add a unique index to the `votes` table to enforce this restriction at the database level. As usual, backup your database before upgrading.