### PR TITLE
Update Debian local installation instructions for Trixie

### DIFF
--- a/docs/en/installation/debian.md
+++ b/docs/en/installation/debian.md
@@ -1,4 +1,4 @@
-# Configuration for development and test environments (Debian GNU/Linux 12 - Bookworm)
+# Configuration for development and test environments (Debian GNU/Linux 13 - Trixie)
 
 ## Superuser
 
@@ -55,10 +55,10 @@ source ~/.bashrc
 
 ## CMake and pkg-config
 
-In order to compile some of the project dependencies, we need CMake and pkg-config:
+In order to compile some of the project dependencies, we need CMake, pkg-config and libzstd-dev:
 
 ```bash
-sudo apt install cmake pkg-config
+sudo apt install cmake pkg-config libzstd-dev
 ```
 
 ## Node.js version manager

--- a/docs/es/installation/debian.md
+++ b/docs/es/installation/debian.md
@@ -1,4 +1,4 @@
-# Configuración para los entornos de desarrollo y pruebas (Debian GNU/Linux 12 - Bookworm)
+# Configuración para los entornos de desarrollo y pruebas (Debian GNU/Linux 13 - Trixie)
 
 ## Superusuario
 
@@ -55,10 +55,10 @@ source ~/.bashrc
 
 ## CMake y pkg-config
 
-Para compilar algunas de las dependencias del proyecto, necesitamos CMake y pkg-config:
+Para compilar algunas de las dependencias del proyecto, necesitamos CMake, pkg-config y libzstd-dev:
 
 ```bash
-sudo apt install cmake pkg-config
+sudo apt install cmake pkg-config libzstd-dev
 ```
 
 ## Gestor de versiones de Node.js


### PR DESCRIPTION
## References
* Aligns local installation docs with the Dockerfile, which already installs `chromium-driver` since #5859
* Related to Debian Trixie support in the Dockerfile (#6284)
* `rugged` build issues on Trixie: libgit2/rugged#990

## Objectives
* Update the Debian local installation instructions for Debian 13 (Trixie)
* Install `libzstd-dev`, which is required to compile the `rugged` gem during `bundle install` on Trixie

## Notes
* `libzstd-dev` was validated on a Debian Trixie VM: without it, `bundle install` fails when compiling `rugged` (a dependency of Pronto in the `:development` group); with it, installation succeeds.
