### PR TITLE
Make form error messages accessible when attaching files

### DIFF
--- a/.erb_lint.yml
+++ b/.erb_lint.yml
@@ -32,6 +32,7 @@ linters:
     exclude:
       - app/views/mailer/proposal_notification_digest.html.erb
       - app/views/**/*.js.erb
+      - app/views/**/*.json.erb
   NoJavascriptTagHelper:
     enabled: true
   ParserErrors:

--- a/app/assets/javascripts/attachable.js
+++ b/app/assets/javascripts/attachable.js
@@ -79,7 +79,7 @@
 
       data.wrapper = wrapper;
       data.progressBar = $(wrapper).find(".progress-bar-placeholder");
-      data.errorContainer = $(wrapper).find(".attachment-errors");
+      data.errorContainer = $(wrapper).find(".action-add");
       data.fileNameContainer = $(wrapper).find("p.file-name");
       data.destroyAttachmentLinkContainer = $(wrapper).find(".action-remove");
       data.addAttachmentLabel = $(wrapper).find(".action-add label");

--- a/app/assets/javascripts/attachable.js
+++ b/app/assets/javascripts/attachable.js
@@ -32,11 +32,10 @@
       dropzone.on("addedfile", function() {
         uploadData = App.Attachable.buildData(config.input);
         App.Attachable.clearProgressBar(uploadData);
-        App.Attachable.setProgressBar(uploadData, "uploading");
       });
 
       dropzone.on("uploadprogress", function(_file, progress) {
-        $(uploadData.progressBar).find(".loading-bar").css("width", progress + "%");
+        uploadData.progressBar.val(progress);
       });
 
       dropzone.on("success", function(_file, response) {
@@ -78,15 +77,13 @@
       wrapper = $(input).closest(".direct-upload");
 
       data.wrapper = wrapper;
-      data.progressBar = $(wrapper).find(".progress-bar-placeholder");
+      data.progressBar = $(wrapper).find("progress");
       data.errorContainer = $(wrapper).find(".action-add");
       data.fileNameContainer = $(wrapper).find("p.file-name");
       data.destroyAttachmentLinkContainer = $(wrapper).find(".action-remove");
       data.addAttachmentLabel = $(wrapper).find(".action-add label");
       data.cachedAttachmentField = $(wrapper).find("input[name$='[cached_attachment]']");
       data.titleField = $(wrapper).find("input[name$='[title]']");
-
-      $(wrapper).find(".progress-bar-placeholder").css("display", "block");
 
       return data;
     },
@@ -97,13 +94,13 @@
       $(data.errorContainer).find("small.error").remove();
     },
     clearProgressBar: function(data) {
-      $(data.progressBar).find(".loading-bar").removeClass("complete errors uploading").css("width", "0px");
+      $(data.progressBar).removeClass("complete errors").val("");
     },
     setFilename: function(data, file_name) {
       $(data.fileNameContainer).text(file_name);
     },
     setProgressBar: function(data, klass) {
-      $(data.progressBar).find(".loading-bar").addClass(klass);
+      data.progressBar.addClass(klass);
     },
     setTitleFromFile: function(data, title) {
       if ($(data.titleField).val() === "") {

--- a/app/assets/javascripts/attachable.js
+++ b/app/assets/javascripts/attachable.js
@@ -46,15 +46,19 @@
         if (config.onSuccess) {
           config.onSuccess($fieldsContainer.find("[type=file]"));
         }
+
+        $fieldsContainer.focus();
       });
 
       dropzone.on("error", function(file, response) {
         App.Attachable.setNewContent($fieldsContainer, response);
+        var new_input = $fieldsContainer.find("[type=file]");
 
         if (config.onError) {
-          config.onError($fieldsContainer.find("[type=file]"));
+          config.onError(new_input);
         }
 
+        new_input.focus();
         dropzone.removeFile(file);
       });
     },

--- a/app/assets/javascripts/attachable.js
+++ b/app/assets/javascripts/attachable.js
@@ -3,14 +3,14 @@
 
   App.Attachable = {
     setupInput: function(config) {
-      var $input, $container, uploadData, dropzone, $zone, dropzoneOptions;
+      var $input, $container, $fieldsContainer, dropzone, $progressBar, $zone, dropzoneOptions;
 
       $input = $(config.input);
+      $fieldsContainer = $input.closest(".nested-fields");
+      $progressBar = $fieldsContainer.find("progress");
       $container = $input.closest(config.attachmentContainer);
       $zone = $("<div>", { class: "hidden-dropzone-upload" });
       $container.append($zone);
-
-      uploadData = {};
 
       dropzoneOptions = {
         url: $input.data("url"),
@@ -24,94 +24,42 @@
       dropzone = new Dropzone($zone[0], dropzoneOptions);
 
       $input.on("change", function() {
-        uploadData = App.Attachable.buildData(config.input);
-        App.Attachable.setFilename(uploadData, this.files[0].name);
-        dropzone.addFile(this.files[0]);
-      });
+        var uploadUrl, title;
 
-      dropzone.on("addedfile", function() {
-        uploadData = App.Attachable.buildData(config.input);
-        App.Attachable.clearProgressBar(uploadData);
+        uploadUrl = new URL($input.data("url"), window.location.href);
+        title = $fieldsContainer.find("input[name$='[title]']").val() || "";
+        uploadUrl.searchParams.set("direct_upload[title]", title);
+
+        dropzone.options.url = uploadUrl;
+        dropzone.addFile(this.files[0]);
+
+        $progressBar.removeClass("complete errors");
       });
 
       dropzone.on("uploadprogress", function(_file, progress) {
-        uploadData.progressBar.val(progress);
+        $progressBar.val(progress);
       });
 
       dropzone.on("success", function(_file, response) {
-        var destroyAttachmentLink;
-
-        $(uploadData.cachedAttachmentField).val(response.cached_attachment);
-        App.Attachable.setTitleFromFile(uploadData, response.filename);
-        App.Attachable.setProgressBar(uploadData, "complete");
-        App.Attachable.setFilename(uploadData, response.filename);
-        App.Attachable.clearInputErrors(uploadData);
-        destroyAttachmentLink = $(response.destroy_link);
-        $(uploadData.destroyAttachmentLinkContainer).html(destroyAttachmentLink);
+        App.Attachable.setNewContent($fieldsContainer, response);
 
         if (config.onSuccess) {
-          config.onSuccess(uploadData, response);
+          config.onSuccess($fieldsContainer.find("[type=file]"));
         }
       });
 
-      dropzone.on("error", function(file, message) {
-        $(uploadData.cachedAttachmentField).val("");
-        App.Attachable.clearFilename(uploadData);
-        App.Attachable.setProgressBar(uploadData, "errors");
-        App.Attachable.clearInputErrors(uploadData);
-        App.Attachable.setInputErrors(uploadData, message.errors);
-        $(uploadData.destroyAttachmentLinkContainer).find("a.delete:not(.remove-nested)").remove();
-        $(uploadData.addAttachmentLabel).addClass("error");
+      dropzone.on("error", function(file, response) {
+        App.Attachable.setNewContent($fieldsContainer, response);
 
         if (config.onError) {
-          config.onError(uploadData);
+          config.onError($fieldsContainer.find("[type=file]"));
         }
 
         dropzone.removeFile(file);
       });
     },
-    buildData: function(input) {
-      var data, wrapper;
-
-      data = [];
-      wrapper = $(input).closest(".direct-upload");
-
-      data.wrapper = wrapper;
-      data.progressBar = $(wrapper).find("progress");
-      data.errorContainer = $(wrapper).find(".action-add");
-      data.fileNameContainer = $(wrapper).find("p.file-name");
-      data.destroyAttachmentLinkContainer = $(wrapper).find(".action-remove");
-      data.addAttachmentLabel = $(wrapper).find(".action-add label");
-      data.cachedAttachmentField = $(wrapper).find("input[name$='[cached_attachment]']");
-      data.titleField = $(wrapper).find("input[name$='[title]']");
-
-      return data;
-    },
-    clearFilename: function(data) {
-      $(data.fileNameContainer).text("");
-    },
-    clearInputErrors: function(data) {
-      $(data.errorContainer).find("small.error").remove();
-    },
-    clearProgressBar: function(data) {
-      $(data.progressBar).removeClass("complete errors").val("");
-    },
-    setFilename: function(data, file_name) {
-      $(data.fileNameContainer).text(file_name);
-    },
-    setProgressBar: function(data, klass) {
-      data.progressBar.addClass(klass);
-    },
-    setTitleFromFile: function(data, title) {
-      if ($(data.titleField).val() === "") {
-        $(data.titleField).val(title);
-      }
-    },
-    setInputErrors: function(data, errors) {
-      if (!errors) {
-        return;
-      }
-      $(data.errorContainer).append("<small class='error'>" + errors + "</small>");
+    setNewContent: function(fields_container, response) {
+      fields_container.html($(response.content).html());
     }
   };
 }).call(this);

--- a/app/assets/javascripts/documentable.js
+++ b/app/assets/javascripts/documentable.js
@@ -29,7 +29,8 @@
           if (input.lockUpload) {
             App.Documentable.showNotice();
           }
-        }
+        },
+        onError: App.Documentable.initializeDirectUploadInput
       });
     },
     lockUploads: function() {

--- a/app/assets/javascripts/imageable.js
+++ b/app/assets/javascripts/imageable.js
@@ -25,31 +25,8 @@
       App.Attachable.setupInput({
         input: input,
         attachmentContainer: ".image-attachment",
-        onSuccess: function(uploadData, response) {
-          uploadData.result = response;
-          App.Imageable.setPreview(uploadData);
-        },
-        onError: function(uploadData) {
-          App.Imageable.clearPreview(uploadData);
-        }
+        onError: App.Imageable.initializeDirectUploadInput
       });
-    },
-    clearPreview: function(data) {
-      $(data.wrapper).find(".image-preview").remove();
-    },
-
-    setPreview: function(data) {
-      var preview, image_preview;
-
-      image_preview = "<div class='small-12 column text-center image-preview'>" +
-        "<figure><img src='" + data.result.attachment_url + "' class='cached-image'></figure></div>";
-      preview = data.wrapper.find(".image-preview");
-
-      if ($(preview).length > 0) {
-        $(preview).replaceWith(image_preview);
-      } else {
-        $(image_preview).insertBefore($(data.wrapper).find(".attachment-actions"));
-      }
     },
     initializeRemoveCachedImageLinks: function() {
       $("#nested-image").on("click", "a.remove-cached-attachment", function(event) {
@@ -84,8 +61,6 @@
         }
 
         dataString = App.Imageable.imageSuggestionsParams(form, resourceType);
-        var uploadData = App.Attachable.buildData(button.closest(".image-fields.direct-upload"));
-        App.Attachable.clearInputErrors(uploadData);
         $.ajax({
           url: "/image_suggestions",
           type: "POST",
@@ -101,36 +76,25 @@
         });
       });
     },
-    attachSuggestedImageSuccess: function(responseData) {
-      var data = App.Attachable.buildData(this);
-      data.result = {
-        cached_attachment: responseData.cached_attachment,
-        filename: responseData.filename,
-        attachment_url: responseData.attachment_url,
-        destroy_link: responseData.destroy_link
-      };
-      $(data.cachedAttachmentField).val(data.result.cached_attachment);
-      App.Attachable.setTitleFromFile(data, data.result.filename);
-      App.Attachable.setFilename(data, data.result.filename);
-      App.Imageable.setPreview(data);
-      $(data.destroyAttachmentLinkContainer).html(data.result.destroy_link);
+    attachSuggestedImage: function($fieldsContainer, response) {
+      App.Attachable.setNewContent($fieldsContainer, response);
       $("#new_image_link").addClass("hide");
-      App.Attachable.clearInputErrors(data);
-    },
-    attachSuggestedImageError: function(xhr) {
-      var data = App.Attachable.buildData(this);
-      App.Attachable.clearInputErrors(data);
-      App.Attachable.setInputErrors(data, xhr.responseJSON && xhr.responseJSON.errors);
+      App.Imageable.initializeDirectUploadInput($fieldsContainer.find("[type=file]"));
     },
     initializeAttachSuggestedImage: function() {
       $("body").on("click", ".suggested-image-button", function() {
-        var imageId, resourceType, resourceId, dataString, wrapper;
+        var imageId, resourceType, resourceId, dataString, $fieldsContainer, wrapper;
         imageId = $(this).data("image-id");
         wrapper = $(this).closest(".suggested-images-wrapper");
         resourceType = wrapper.data("resource-type");
         resourceId = wrapper.data("resource-id");
+        $fieldsContainer = $(this).closest(".nested-fields");
 
-        dataString = { resource_type: resourceType };
+        dataString = {
+          resource_type: resourceType,
+          title: $fieldsContainer.find("input[name$='[title]']").val()
+        };
+
         if (resourceId) {
           dataString.resource_id = resourceId;
         }
@@ -139,9 +103,16 @@
           type: "POST",
           data: dataString,
           dataType: "json",
-          context: $(this).closest(".image-fields.direct-upload"),
-          success: App.Imageable.attachSuggestedImageSuccess,
-          error: App.Imageable.attachSuggestedImageError
+          success: function(response) {
+            App.Imageable.attachSuggestedImage($fieldsContainer, response);
+          },
+          error: function(xhr) {
+            var response = xhr.responseJSON;
+
+            if (response && response.content) {
+              App.Imageable.attachSuggestedImage($fieldsContainer, response);
+            }
+          }
         });
       });
     },

--- a/app/assets/javascripts/imageable.js
+++ b/app/assets/javascripts/imageable.js
@@ -80,6 +80,7 @@
       App.Attachable.setNewContent($fieldsContainer, response);
       $("#new_image_link").addClass("hide");
       App.Imageable.initializeDirectUploadInput($fieldsContainer.find("[type=file]"));
+      $fieldsContainer.focus();
     },
     initializeAttachSuggestedImage: function() {
       $("body").on("click", ".suggested-image-button", function() {

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -148,7 +148,8 @@ button,
   }
 }
 
-.button.hollow.error {
+.button.hollow.error,
+.button.hollow.is-invalid-label {
   border-color: $alert-border;
   color: $color-alert;
 }

--- a/app/assets/stylesheets/mixins/uploads.scss
+++ b/app/assets/stylesheets/mixins/uploads.scss
@@ -112,13 +112,15 @@
       display: none;
     }
 
-    &.complete {
-      @include progress-bar-color($success-color);
-    }
+    &[value="100"] {
+      &.complete {
+        @include progress-bar-color($success-color);
+      }
 
-    &.errors {
-      @include progress-bar-color($alert-color);
-      margin-top: calc($line-height / 2);
+      &.errors {
+        @include progress-bar-color($alert-color);
+        margin-top: calc($line-height / 2);
+      }
     }
   }
 }

--- a/app/assets/stylesheets/mixins/uploads.scss
+++ b/app/assets/stylesheets/mixins/uploads.scss
@@ -28,7 +28,7 @@
 
     .attachment-errors {
 
-      > [type=file] {
+      [type=file] {
         @include element-invisible;
 
         ~ .error {

--- a/app/assets/stylesheets/mixins/uploads.scss
+++ b/app/assets/stylesheets/mixins/uploads.scss
@@ -1,13 +1,21 @@
+@mixin progress-bar-color($color) {
+  appearance: none;
+  color: $color;
+
+  &::-webkit-progress-value {
+    background: $color;
+  }
+
+  &::-moz-progress-bar {
+    background: $color;
+  }
+}
+
 @mixin direct-uploads {
 
   .cached-image {
     max-height: rem-calc(150);
     max-width: rem-calc(150);
-  }
-
-  .progress-bar-placeholder {
-    display: none;
-    margin-bottom: $line-height;
   }
 
   .document-fields,
@@ -93,21 +101,23 @@
     }
   }
 
-  .loading-bar {
+  progress {
+    @include progress-bar-color($dark-gray);
     height: 5px;
+    margin-bottom: $line-height;
     transition: width 500ms ease-out;
-    width: 0;
+    width: 100%;
 
-    &.uploading {
-      background-color: $dark-gray;
+    &:indeterminate {
+      display: none;
     }
 
     &.complete {
-      background-color: $success-color;
+      @include progress-bar-color($success-color);
     }
 
     &.errors {
-      background-color: $alert-color;
+      @include progress-bar-color($alert-color);
       margin-top: calc($line-height / 2);
     }
   }

--- a/app/assets/stylesheets/mixins/uploads.scss
+++ b/app/assets/stylesheets/mixins/uploads.scss
@@ -26,15 +26,12 @@
       }
     }
 
-    .attachment-errors {
+    [type=file] {
+      @include element-invisible;
 
-      [type=file] {
-        @include element-invisible;
-
-        ~ .error {
-          display: inline-block;
-          margin-bottom: $line-height;
-        }
+      ~ .error {
+        display: inline-block;
+        margin-bottom: $line-height;
       }
     }
 

--- a/app/assets/stylesheets/mixins/uploads.scss
+++ b/app/assets/stylesheets/mixins/uploads.scss
@@ -12,6 +12,9 @@
 }
 
 @mixin direct-uploads {
+  .image-preview figure:has(.cached-image) {
+    height: rem-calc(150);
+  }
 
   .cached-image {
     max-height: rem-calc(150);

--- a/app/assets/stylesheets/mixins/uploads.scss
+++ b/app/assets/stylesheets/mixins/uploads.scss
@@ -79,11 +79,6 @@
     }
   }
 
-  .progress-bar {
-    background-color: $light-gray;
-    width: 100%;
-  }
-
   .file-name {
     margin-top: 0;
     padding-left: 0;
@@ -115,9 +110,5 @@
       background-color: $alert-color;
       margin-top: calc($line-height / 2);
     }
-  }
-
-  .loading-bar.no-transition {
-    transition: none;
   }
 }

--- a/app/components/attachable/fields_component.html.erb
+++ b/app/components/attachable/fields_component.html.erb
@@ -7,7 +7,7 @@
     <%= f.text_field :title %>
   </div>
 
-  <% if attachable.attachment.attached? && attachable.attachment.image? %>
+  <% if valid_image? %>
     <%= render_image(attachable, :thumb, false) %>
   <% end %>
 

--- a/app/components/attachable/fields_component.html.erb
+++ b/app/components/attachable/fields_component.html.erb
@@ -14,7 +14,7 @@
   <div class="small-12 column attachment-actions">
     <p class="file-name small-9 column"><%= file_name %></p>
 
-    <div class="small-9 column action-add attachment-errors <%= singular_name %>-attachment">
+    <div class="small-9 column action-add <%= singular_name %>-attachment">
       <%= file_field %>
       <%= suggested_images_content %>
     </div>

--- a/app/components/attachable/fields_component.html.erb
+++ b/app/components/attachable/fields_component.html.erb
@@ -16,7 +16,7 @@
 
     <div class="small-9 column action-add <%= singular_name %>-attachment">
       <%= file_field %>
-      <%= suggested_images_content %>
+      <%= content %>
     </div>
 
     <div class="small-3 column action-remove text-right">

--- a/app/components/attachable/fields_component.html.erb
+++ b/app/components/attachable/fields_component.html.erb
@@ -1,4 +1,4 @@
-<div class="<%= singular_name %>-fields direct-upload nested-fields">
+<div class="<%= singular_name %>-fields direct-upload nested-fields" tabindex="-1">
   <%= f.hidden_field :id %>
   <%= f.hidden_field :user_id, value: current_user.id %>
   <%= f.hidden_field :cached_attachment %>

--- a/app/components/attachable/fields_component.html.erb
+++ b/app/components/attachable/fields_component.html.erb
@@ -25,9 +25,7 @@
   </div>
 
   <div class="small-12 column">
-    <div class="progress-bar-placeholder">
-      <div class="loading-bar"></div>
-    </div>
+    <%= progress_bar %>
   </div>
 
   <hr>

--- a/app/components/attachable/fields_component.rb
+++ b/app/components/attachable/fields_component.rb
@@ -1,13 +1,12 @@
 class Attachable::FieldsComponent < ApplicationComponent
-  attr_reader :f, :resource_type, :resource_id, :relation_name, :suggested_images_content
+  attr_reader :f, :resource_type, :resource_id, :relation_name
   delegate :render_image, to: :helpers
 
-  def initialize(f, resource_type:, resource_id:, relation_name:, suggested_images_content: nil)
+  def initialize(f, resource_type:, resource_id:, relation_name:)
     @f = f
     @resource_type = resource_type
     @resource_id = resource_id
     @relation_name = relation_name
-    @suggested_images_content = suggested_images_content
   end
 
   private

--- a/app/components/attachable/fields_component.rb
+++ b/app/components/attachable/fields_component.rb
@@ -23,6 +23,10 @@ class Attachable::FieldsComponent < ApplicationComponent
       attachable.model_name.plural
     end
 
+    def valid_image?
+      attachable.attachment.attached? && attachable.attachment.image?
+    end
+
     def file_name
       attachable.attachment_file_name
     end

--- a/app/components/attachable/fields_component.rb
+++ b/app/components/attachable/fields_component.rb
@@ -70,4 +70,8 @@ class Attachable::FieldsComponent < ApplicationComponent
         end
       end.join(",")
     end
+
+    def progress_bar
+      tag.progress max: "100", "aria-label": t("documents.form.progress")
+    end
 end

--- a/app/components/attachable/fields_component.rb
+++ b/app/components/attachable/fields_component.rb
@@ -24,11 +24,13 @@ class Attachable::FieldsComponent < ApplicationComponent
     end
 
     def valid_image?
-      attachable.attachment.attached? && attachable.attachment.image?
+      attachable.attachment.attached? &&
+        attachable.attachment.image? &&
+        attachable.errors[:attachment].empty?
     end
 
     def file_name
-      attachable.attachment_file_name
+      attachable.attachment_file_name if attachable.errors.empty?
     end
 
     def destroy_link
@@ -72,6 +74,17 @@ class Attachable::FieldsComponent < ApplicationComponent
     end
 
     def progress_bar
-      tag.progress max: "100", "aria-label": t("documents.form.progress")
+      tag.progress max: "100",
+                   class: progress_bar_status_class,
+                   "aria-label": t("documents.form.progress"),
+                   value: ("100" if progress_bar_status_class)
+    end
+
+    def progress_bar_status_class
+      if attachable.errors[:attachment].any?
+        "errors"
+      elsif attachable.cached_attachment.present?
+        "complete"
+      end
     end
 end

--- a/app/components/direct_uploads/fields_component.html.erb
+++ b/app/components/direct_uploads/fields_component.html.erb
@@ -1,0 +1,1 @@
+<%= fields_content %>

--- a/app/components/direct_uploads/fields_component.rb
+++ b/app/components/direct_uploads/fields_component.rb
@@ -1,0 +1,52 @@
+class DirectUploads::FieldsComponent < ApplicationComponent
+  attr_reader :direct_upload
+
+  def initialize(direct_upload)
+    @direct_upload = direct_upload
+  end
+
+  private
+
+    def fields_content
+      form_for resource, url: false do |form|
+        case attachable.class.name
+        when "Document"
+          return document_fields(form)
+        when "Image"
+          return image_fields(form)
+        end
+      end
+    end
+
+    def document_fields(form)
+      form.fields_for :documents, attachable, child_index: nested_index do |documents_builder|
+        render Documents::FieldsComponent.new(documents_builder)
+      end
+    end
+
+    def image_fields(form)
+      form.fields_for image_fields_name, attachable, child_index: nested_index do |image_builder|
+        render Images::FieldsComponent.new(image_builder, imageable: resource)
+      end
+    end
+
+    def nested_index
+      SecureRandom.random_number(10**12)
+    end
+
+    def image_fields_name
+      if resource.class.reflect_on_association(:image)
+        :image
+      else
+        :images
+      end
+    end
+
+    def resource
+      direct_upload.resource
+    end
+
+    def attachable
+      direct_upload.relation
+    end
+end

--- a/app/components/images/fields_component.html.erb
+++ b/app/components/images/fields_component.html.erb
@@ -2,6 +2,7 @@
   f,
   resource_type: imageable.class.name,
   resource_id: imageable.id,
-  relation_name: "image",
-  suggested_images_content: suggested_images_content
-) %>
+  relation_name: "image"
+) do %>
+  <%= content %>
+<% end %>

--- a/app/components/images/fields_component.rb
+++ b/app/components/images/fields_component.rb
@@ -1,9 +1,8 @@
 class Images::FieldsComponent < ApplicationComponent
-  attr_reader :f, :imageable, :suggested_images_content
+  attr_reader :f, :imageable
 
-  def initialize(f, imageable:, suggested_images_content: nil)
+  def initialize(f, imageable:)
     @f = f
     @imageable = imageable
-    @suggested_images_content = suggested_images_content
   end
 end

--- a/app/components/images/image_component.html.erb
+++ b/app/components/images/image_component.html.erb
@@ -2,11 +2,11 @@
   <figure>
     <%= image_tag image.variant(version),
                   class: image_class,
-                  alt: image.title.unicode_normalize,
-                  title: image.title.unicode_normalize %>
+                  alt: image.title&.unicode_normalize,
+                  title: image.title&.unicode_normalize %>
     <% if show_caption %>
       <figcaption class="text-right">
-        <em><%= image.title.unicode_normalize %></em>
+        <em><%= image.title&.unicode_normalize %></em>
       </figcaption>
     <% end %>
   </figure>

--- a/app/components/images/image_component.html.erb
+++ b/app/components/images/image_component.html.erb
@@ -1,7 +1,7 @@
 <div id="image" class="small-12 column text-center image-preview">
   <figure>
     <%= image_tag image.variant(version),
-                  class: image_class(image),
+                  class: image_class,
                   alt: image.title.unicode_normalize,
                   title: image.title.unicode_normalize %>
     <% if show_caption %>
@@ -14,5 +14,4 @@
   <% if show_caption %>
     <hr>
   <% end %>
-
 </div>

--- a/app/components/images/image_component.rb
+++ b/app/components/images/image_component.rb
@@ -1,0 +1,15 @@
+class Images::ImageComponent < ApplicationComponent
+  attr_reader :image, :version, :show_caption
+
+  def initialize(image, version, show_caption: true)
+    @image = image
+    @version = version
+    @show_caption = show_caption
+  end
+
+  private
+
+    def image_class
+      image.persisted? ? "persisted-image" : "cached-image"
+    end
+end

--- a/app/components/images/nested_component.html.erb
+++ b/app/components/images/nested_component.html.erb
@@ -4,7 +4,9 @@
 
   <div id="nested-image">
     <%= f.fields_for image_fields do |image_builder| %>
-      <%= render Images::FieldsComponent.new(image_builder, imageable: imageable, suggested_images_content: suggested_images_content) %>
+      <%= render Images::FieldsComponent.new(image_builder, imageable: imageable) do %>
+        <%= content %>
+      <% end %>
     <% end %>
   </div>
 
@@ -15,7 +17,7 @@
                               class: "button upload-image
                                       #{"hide" if image_fields == :image && imageable.image.present?}",
                               render_options: {
-                                locals: { imageable: imageable, suggested_images_content: suggested_images_content }
+                                locals: { imageable: imageable, content: content }
                               },
                               data: {
                                 association_insertion_node: "#nested-image",

--- a/app/components/images/nested_component.rb
+++ b/app/components/images/nested_component.rb
@@ -8,10 +8,6 @@ class Images::NestedComponent < ApplicationComponent
 
   private
 
-    def suggested_images_content
-      content
-    end
-
     def imageable
       f.object
     end

--- a/app/controllers/direct_uploads_controller.rb
+++ b/app/controllers/direct_uploads_controller.rb
@@ -1,12 +1,7 @@
 class DirectUploadsController < ApplicationController
-  include DirectUploadsHelper
-  include ActionView::Helpers::UrlHelper
-
   before_action :authenticate_user!
 
   skip_authorization_check only: :create
-
-  helper_method :render_destroy_upload_link
 
   def create
     @direct_upload = DirectUpload.new(
@@ -14,13 +9,9 @@ class DirectUploadsController < ApplicationController
     )
 
     if @direct_upload.save
-      render json: { cached_attachment: @direct_upload.relation.cached_attachment,
-                     filename: @direct_upload.relation.attachment_file_name,
-                     destroy_link: render_destroy_upload_link(@direct_upload),
-                     attachment_url: polymorphic_path(@direct_upload.relation.attachment) }
+      render
     else
-      render json: { errors: @direct_upload.errors[:attachment].join(", ") },
-             status: :unprocessable_content
+      render status: :unprocessable_content
     end
   end
 
@@ -34,7 +25,7 @@ class DirectUploadsController < ApplicationController
     def allowed_params
       [
         :resource, :resource_type, :resource_id, :resource_relation,
-        :attachment, :cached_attachment, attachment_attributes: []
+        :attachment, :cached_attachment, :title, attachment_attributes: []
       ]
     end
 end

--- a/app/controllers/direct_uploads_controller.rb
+++ b/app/controllers/direct_uploads_controller.rb
@@ -13,10 +13,7 @@ class DirectUploadsController < ApplicationController
       direct_upload_params.merge(user: current_user, attachment: params[:attachment])
     )
 
-    if @direct_upload.valid?
-      @direct_upload.save_attachment
-      @direct_upload.relation.set_cached_attachment_from_attachment
-
+    if @direct_upload.save
       render json: { cached_attachment: @direct_upload.relation.cached_attachment,
                      filename: @direct_upload.relation.attachment_file_name,
                      destroy_link: render_destroy_upload_link(@direct_upload),

--- a/app/controllers/image_suggestions_controller.rb
+++ b/app/controllers/image_suggestions_controller.rb
@@ -37,10 +37,7 @@ class ImageSuggestionsController < ApplicationController
       user: current_user
     )
 
-    if @direct_upload.valid?
-      @direct_upload.save_attachment
-      @direct_upload.relation.set_cached_attachment_from_attachment
-
+    if @direct_upload.save
       render json: { cached_attachment: @direct_upload.relation.cached_attachment,
                      filename: @direct_upload.relation.attachment_file_name,
                      destroy_link: render_destroy_upload_link(@direct_upload),

--- a/app/controllers/image_suggestions_controller.rb
+++ b/app/controllers/image_suggestions_controller.rb
@@ -1,7 +1,4 @@
 class ImageSuggestionsController < ApplicationController
-  include DirectUploadsHelper
-  include ActionView::Helpers::UrlHelper
-
   before_action :authenticate_user!
   skip_authorization_check
 
@@ -34,17 +31,14 @@ class ImageSuggestionsController < ApplicationController
       resource_id: params[:resource_id],
       resource_relation: "image",
       attachment: attachment,
+      title: params[:title],
       user: current_user
     )
 
     if @direct_upload.save
-      render json: { cached_attachment: @direct_upload.relation.cached_attachment,
-                     filename: @direct_upload.relation.attachment_file_name,
-                     destroy_link: render_destroy_upload_link(@direct_upload),
-                     attachment_url: polymorphic_path(@direct_upload.relation.attachment) }
+      render "direct_uploads/create"
     else
-      render json: { errors: @direct_upload.errors[:attachment].join(", ") },
-             status: :unprocessable_content
+      render "direct_uploads/create", status: :unprocessable_content
     end
   end
 

--- a/app/helpers/direct_uploads_helper.rb
+++ b/app/helpers/direct_uploads_helper.rb
@@ -1,6 +1,0 @@
-module DirectUploadsHelper
-  def render_destroy_upload_link(direct_upload)
-    label = direct_upload.resource_relation == "image" ? "images" : "documents"
-    link_to t("#{label}.form.delete_button"), "#", class: "delete remove-cached-attachment"
-  end
-end

--- a/app/helpers/images_helper.rb
+++ b/app/helpers/images_helper.rb
@@ -5,14 +5,8 @@ module ImagesHelper
     polymorphic_url(image.variant(version))
   end
 
-  def image_class(image)
-    image.persisted? ? "persisted-image" : "cached-image"
-  end
-
   def render_image(image, version, show_caption = true)
-    render "images/image", image: image,
-                           version: (version if image.persisted?),
-                           show_caption: show_caption
+    render Images::ImageComponent.new(image, (version if image.persisted?), show_caption: show_caption)
   end
 
   def attached_background_css(path)

--- a/app/models/direct_upload.rb
+++ b/app/models/direct_upload.rb
@@ -41,6 +41,14 @@ class DirectUpload
     @relation.attachment_changes["attachment"].upload
   end
 
+  def save
+    if valid?
+      save_attachment
+      relation.set_cached_attachment_from_attachment
+      true
+    end
+  end
+
   def persisted?
     false
   end

--- a/app/models/direct_upload.rb
+++ b/app/models/direct_upload.rb
@@ -5,7 +5,7 @@ class DirectUpload
 
   attr_accessor :resource, :resource_type, :resource_id,
                 :relation, :resource_relation,
-                :attachment, :cached_attachment, :user
+                :attachment, :cached_attachment, :user, :title
 
   validates :attachment, :resource_type, :resource_relation, :user, presence: true
   validate :parent_resource_attachment_validations,
@@ -42,6 +42,8 @@ class DirectUpload
   end
 
   def save
+    @relation.title = @relation.title.presence || @relation.attachment_file_name
+
     if valid?
       save_attachment
       relation.set_cached_attachment_from_attachment
@@ -67,7 +69,8 @@ class DirectUpload
       {
         attachment: @attachment,
         cached_attachment: @cached_attachment,
-        user: @user
+        user: @user,
+        title: @title
       }
     end
 end

--- a/app/views/direct_uploads/create.json.erb
+++ b/app/views/direct_uploads/create.json.erb
@@ -1,0 +1,3 @@
+{
+  "content": "<%= j render DirectUploads::FieldsComponent.new(@direct_upload) %>"
+}

--- a/app/views/images/_image_fields.html.erb
+++ b/app/views/images/_image_fields.html.erb
@@ -1,1 +1,3 @@
-<%= render Images::FieldsComponent.new(f, imageable: imageable, suggested_images_content: suggested_images_content) %>
+<%= render Images::FieldsComponent.new(f, imageable: imageable) do %>
+  <%= content %>
+<% end %>

--- a/config/locales/en/documents.yml
+++ b/config/locales/en/documents.yml
@@ -9,6 +9,7 @@ en:
       cancel_button: Cancel
       note: "You can upload up to a maximum of %{max_documents_allowed} documents of following content types: %{accepted_content_types}, up to %{max_file_size} MB per file."
       add_new_document: Add new document
+      progress: Upload progress
     actions:
       destroy:
         notice: Document was deleted successfully.

--- a/config/locales/es/documents.yml
+++ b/config/locales/es/documents.yml
@@ -9,6 +9,7 @@ es:
       cancel_button: Cancelar
       note: "Puedes subir hasta un máximo de %{max_documents_allowed} documentos en los formatos: %{accepted_content_types}, y de hasta %{max_file_size} MB por archivo."
       add_new_document: Añadir nuevo documento
+      progress: Progreso de la subida
     actions:
       destroy:
         notice: El documento se ha eliminado correctamente.

--- a/spec/controllers/direct_uploads_controller_spec.rb
+++ b/spec/controllers/direct_uploads_controller_spec.rb
@@ -1,0 +1,36 @@
+require "rails_helper"
+
+describe DirectUploadsController do
+  render_views
+  before { sign_in create(:user) }
+
+  describe "POST create" do
+    let(:upload_params) do
+      {
+        resource_type: "Proposal",
+        resource_relation: "image",
+        title: "My Title"
+      }
+    end
+
+    it "preserves a title provided in the request" do
+      post :create, params: {
+        direct_upload: upload_params,
+        attachment: fixture_file_upload("clippy.jpg")
+      }, format: :json
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body["content"]).to include('value="My Title"')
+    end
+
+    it "uses the filename as title when none is provided" do
+      post :create, params: {
+        direct_upload: upload_params.except(:title),
+        attachment: fixture_file_upload("clippy.jpg")
+      }, format: :json
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body["content"]).to include('value="clippy.jpg"')
+    end
+  end
+end

--- a/spec/controllers/image_suggestions_controller_spec.rb
+++ b/spec/controllers/image_suggestions_controller_spec.rb
@@ -90,6 +90,8 @@ describe ImageSuggestionsController do
   end
 
   describe "POST attach" do
+    render_views
+
     let(:resource_type) { "Budget::Investment" }
     let(:photo_id) { "12345" }
     let(:uploaded_file) { fixture_file_upload("clippy.jpg") }
@@ -99,12 +101,13 @@ describe ImageSuggestionsController do
     end
 
     context "when download succeeds and DirectUpload is valid" do
-      it "returns success and JSON with attachment data" do
-        post :attach, params: { id: photo_id, resource_type: resource_type }
+      it "returns success and JSON with rendered fields" do
+        post :attach, params: { id: photo_id, resource_type: resource_type }, format: :json
 
         expect(response).to have_http_status(:ok)
         json = response.parsed_body
-        expect(json).to include("cached_attachment", "filename", "destroy_link", "attachment_url")
+        expect(json["content"]).to be_present
+        expect(json["content"]).to include("cached_attachment")
       end
     end
 
@@ -142,11 +145,11 @@ describe ImageSuggestionsController do
                                                              .and_return(fixture_file_upload("empty.pdf"))
       end
 
-      it "returns 422 with validation errors in JSON" do
-        post :attach, params: { id: photo_id, resource_type: resource_type }
+      it "returns 422 with rendered fields" do
+        post :attach, params: { id: photo_id, resource_type: resource_type }, format: :json
 
         expect(response).to have_http_status(:unprocessable_content)
-        expect(response.parsed_body["errors"]).to be_present
+        expect(response.parsed_body["content"]).to be_present
       end
     end
   end

--- a/spec/support/common_actions/attachables.rb
+++ b/spec/support/common_actions/attachables.rb
@@ -14,9 +14,9 @@ module Attachables
       attach_file input_label, path
       within ".#{field_class}-fields" do
         if success
-          expect(page).to have_css ".loading-bar.complete"
+          expect(page).to have_css "progress.complete"
         else
-          expect(page).to have_css ".loading-bar.errors"
+          expect(page).to have_css "progress.errors"
         end
       end
     end

--- a/spec/support/common_actions/attachables.rb
+++ b/spec/support/common_actions/attachables.rb
@@ -13,6 +13,8 @@ module Attachables
     within "##{wrapper_id}" do
       attach_file input_label, path
       within ".#{field_class}-fields" do
+        expect(page).to have_css "progress[value='100']"
+
         if success
           expect(page).to have_css "progress.complete"
         else

--- a/spec/system/nested_documentable_spec.rb
+++ b/spec/system/nested_documentable_spec.rb
@@ -74,7 +74,7 @@ describe "Nested documentable" do
         fill_in "Title", with: "My Title"
         attach_file "Choose document", file_fixture("empty.pdf")
 
-        expect(page).to have_css "progress.complete"
+        expect(page).to have_css "progress[value='100'].complete"
         expect(page).to have_field "Title", with: "My Title"
 
         click_link "Remove document"
@@ -102,7 +102,7 @@ describe "Nested documentable" do
 
       attach_file "Choose document", file_fixture("empty.pdf")
 
-      expect(page).to have_css "progress.complete"
+      expect(page).to have_css "progress[value='100'].complete"
       expect(cached_attachment_field.value).not_to be_empty
     end
 
@@ -151,7 +151,7 @@ describe "Nested documentable" do
         attach_file "Choose document", file_fixture("#{filename}.pdf")
 
         within all(".document-fields").last do
-          expect(page).to have_css "progress.complete"
+          expect(page).to have_css "progress[value='100'].complete"
         end
       end
 

--- a/spec/system/nested_documentable_spec.rb
+++ b/spec/system/nested_documentable_spec.rb
@@ -114,6 +114,12 @@ describe "Nested documentable" do
 
       cached_attachment_field = find("input[name$='[cached_attachment]']", visible: :hidden)
       expect(cached_attachment_field.value).to be_empty
+
+      click_button submit_button_text
+
+      within "#nested-documents .document-attachment" do
+        expect(page).to have_content "can't be blank"
+      end
     end
 
     scenario "Should show document errors after documentable submit with empty document fields" do

--- a/spec/system/nested_documentable_spec.rb
+++ b/spec/system/nested_documentable_spec.rb
@@ -74,7 +74,7 @@ describe "Nested documentable" do
         fill_in "Title", with: "My Title"
         attach_file "Choose document", file_fixture("empty.pdf")
 
-        expect(page).to have_css ".loading-bar.complete"
+        expect(page).to have_css "progress.complete"
         expect(page).to have_field "Title", with: "My Title"
 
         click_link "Remove document"
@@ -102,7 +102,7 @@ describe "Nested documentable" do
 
       attach_file "Choose document", file_fixture("empty.pdf")
 
-      expect(page).to have_css(".loading-bar.complete")
+      expect(page).to have_css "progress.complete"
       expect(cached_attachment_field.value).not_to be_empty
     end
 
@@ -151,7 +151,7 @@ describe "Nested documentable" do
         attach_file "Choose document", file_fixture("#{filename}.pdf")
 
         within all(".document-fields").last do
-          expect(page).to have_css ".loading-bar.complete"
+          expect(page).to have_css "progress.complete"
         end
       end
 

--- a/spec/system/nested_imageable_spec.rb
+++ b/spec/system/nested_imageable_spec.rb
@@ -37,14 +37,13 @@ describe "Nested imageable" do
 
     scenario "Should not update image file title after choosing a file when a title is already defined" do
       click_link "Add image"
-      input_title = find(".image-fields input[name$='[title]']")
-      fill_in input_title[:id], with: "Title"
-      attach_file "Choose image", file_fixture("clippy.jpg")
 
-      if factory == :future_poll_question_option
-        expect(find("input[id$='_title']").value).to eq "Title"
-      else
-        expect(find("##{factory}_image_attributes_title").value).to eq "Title"
+      within ".image-fields" do
+        fill_in "Title", with: "Title"
+        attach_file "Choose image", file_fixture("clippy.jpg")
+
+        expect(page).to have_css ".loading-bar.complete"
+        expect(page).to have_field "Title", with: "Title"
       end
     end
 

--- a/spec/system/nested_imageable_spec.rb
+++ b/spec/system/nested_imageable_spec.rb
@@ -65,6 +65,12 @@ describe "Nested imageable" do
       cached_attachment_field = find("input[name$='[cached_attachment]']", visible: :hidden)
 
       expect(cached_attachment_field.value).to be_empty
+
+      click_button submit_button_text
+
+      within "#nested-image .image-attachment" do
+        expect(page).to have_content "can't be blank"
+      end
     end
 
     scenario "Shows image errors after invalid submit and restores add link on cancel" do

--- a/spec/system/nested_imageable_spec.rb
+++ b/spec/system/nested_imageable_spec.rb
@@ -42,7 +42,7 @@ describe "Nested imageable" do
         fill_in "Title", with: "Title"
         attach_file "Choose image", file_fixture("clippy.jpg")
 
-        expect(page).to have_css "progress.complete"
+        expect(page).to have_css "progress[value='100'].complete"
         expect(page).to have_field "Title", with: "Title"
       end
     end
@@ -55,7 +55,7 @@ describe "Nested imageable" do
 
       attach_file "Choose image", file_fixture("clippy.jpg")
 
-      expect(page).to have_css "progress.complete"
+      expect(page).to have_css "progress[value='100'].complete"
       expect(cached_attachment_field.value).not_to be_empty
     end
 

--- a/spec/system/nested_imageable_spec.rb
+++ b/spec/system/nested_imageable_spec.rb
@@ -42,7 +42,7 @@ describe "Nested imageable" do
         fill_in "Title", with: "Title"
         attach_file "Choose image", file_fixture("clippy.jpg")
 
-        expect(page).to have_css ".loading-bar.complete"
+        expect(page).to have_css "progress.complete"
         expect(page).to have_field "Title", with: "Title"
       end
     end
@@ -55,7 +55,7 @@ describe "Nested imageable" do
 
       attach_file "Choose image", file_fixture("clippy.jpg")
 
-      expect(page).to have_css(".loading-bar.complete")
+      expect(page).to have_css "progress.complete"
       expect(cached_attachment_field.value).not_to be_empty
     end
 


### PR DESCRIPTION
## References

* Continues pull request #6440 

## Objectives

* Make sure people using screen readers know whether an attachment is invalid and why
* Remove duplication between the server-side logic and the client-side logic when attaching files
* Fix a bug when attaching invalid documents or images and then submitting the form