### PR TITLE
Fix image suggestions button alignment after failed upload

### DIFF
--- a/app/assets/javascripts/attachable.js
+++ b/app/assets/javascripts/attachable.js
@@ -63,7 +63,7 @@
       });
     },
     setNewContent: function(fields_container, response) {
-      fields_container.html($(response.content).html());
+      fields_container.html($(response.content).html()).find("progress").val(100);
     }
   };
 }).call(this);

--- a/app/assets/stylesheets/mixins/uploads.scss
+++ b/app/assets/stylesheets/mixins/uploads.scss
@@ -26,6 +26,9 @@
 
     .document-attachment,
     .image-attachment {
+      column-gap: 0.7ch;
+      display: flex;
+      flex-wrap: wrap;
       padding-left: 0;
 
       p {
@@ -35,6 +38,10 @@
       &:focus-within label {
         @include focus-outline;
       }
+
+      .suggested-images-wrapper {
+        flex-grow: 1;
+      }
     }
 
     [type=file] {
@@ -43,15 +50,6 @@
       ~ .error {
         display: inline-block;
         margin-bottom: $line-height;
-      }
-    }
-
-    .suggested-images-container,
-    .suggested-images-wrapper {
-      display: inline;
-
-      .help-text {
-        margin-bottom: 1rem;
       }
     }
 
@@ -70,6 +68,7 @@
     .suggested-images {
       @include dynamic-grid($min-column-width: clamp(3rem, 40%, 10rem));
       list-style: none;
+      margin-top: 1rem;
 
       button {
         min-width: 1rem;
@@ -79,10 +78,6 @@
         min-height: rem-calc(120);
         object-fit: cover;
       }
-    }
-
-    .image-attachment:has(label.button.error) .suggested-images-wrapper {
-      display: none;
     }
 
     .image-attachment:has(label.button:not(.error)) .js-suggest-image.error {

--- a/app/components/attachable/fields_component.html.erb
+++ b/app/components/attachable/fields_component.html.erb
@@ -15,7 +15,9 @@
     <p class="file-name small-9 column"><%= file_name %></p>
 
     <div class="small-9 column action-add <%= singular_name %>-attachment">
-      <%= file_field %>
+      <div>
+        <%= file_field %>
+      </div>
       <%= content %>
     </div>
 

--- a/app/components/attachable/fields_component.rb
+++ b/app/components/attachable/fields_component.rb
@@ -76,8 +76,7 @@ class Attachable::FieldsComponent < ApplicationComponent
     def progress_bar
       tag.progress max: "100",
                    class: progress_bar_status_class,
-                   "aria-label": t("documents.form.progress"),
-                   value: ("100" if progress_bar_status_class)
+                   "aria-label": t("documents.form.progress")
     end
 
     def progress_bar_status_class

--- a/app/components/image_suggestions/suggestions_component.html.erb
+++ b/app/components/image_suggestions/suggestions_component.html.erb
@@ -6,7 +6,7 @@
     </button>
   <% end %>
   <% if images.any? %>
-    <p class="help-text mb-2"><%= t("images.form.pick_an_image") %></p>
+    <p class="help-text"><%= t("images.form.pick_an_image") %></p>
     <ul class="suggested-images">
       <% images.each_with_index do |image, index| %>
         <li>

--- a/app/views/image_suggestions/create.js.erb
+++ b/app/views/image_suggestions/create.js.erb
@@ -1,8 +1,10 @@
 $(".suggested-images-container").replaceWith("<%= j render(ImageSuggestions::SuggestionsComponent.new(@suggestions)) %>");
 
 var imageFields = $(".suggested-images-wrapper").closest(".image-fields.direct-upload");
+var attachField = imageFields.find(".image-attachment > :first-child");
+
 if (imageFields.find(".suggested-image-button").length > 0) {
-  imageFields.find("label.button").addClass("hide");
+  attachField.addClass("hide");
 } else {
-  imageFields.find("label.button").removeClass("hide");
+  attachField.removeClass("hide");
 }

--- a/spec/system/nested_documentable_spec.rb
+++ b/spec/system/nested_documentable_spec.rb
@@ -120,6 +120,10 @@ describe "Nested documentable" do
       within "#nested-documents .document-attachment" do
         expect(page).to have_content "can't be blank"
       end
+
+      within "#nested-documents .document-fields" do
+        expect(page).to have_css "progress", visible: :hidden
+      end
     end
 
     scenario "Should show document errors after documentable submit with empty document fields" do

--- a/spec/system/nested_imageable_spec.rb
+++ b/spec/system/nested_imageable_spec.rb
@@ -71,6 +71,10 @@ describe "Nested imageable" do
       within "#nested-image .image-attachment" do
         expect(page).to have_content "can't be blank"
       end
+
+      within "#nested-image .image-fields" do
+        expect(page).to have_css "progress", visible: :hidden
+      end
     end
 
     scenario "Shows image errors after invalid submit and restores add link on cancel" do


### PR DESCRIPTION
## References
Related PR's: [#6190](https://github.com/consuldemocracy/consuldemocracy/pull/6190) and [#6325](https://github.com/consuldemocracy/consuldemocracy/pull/6325)

## Objectives

- Fix the attachment action row layout on validation errors so Choose and Suggest stay on one line, Cancel stays on the right, and the error appears below.