### PR TITLE
Add groups to dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,13 +7,58 @@ updates:
   open-pull-requests-limit: 50
   labels:
     - "dependencies"
+  groups:
+    capybara:
+      patterns:
+        - "capybara"
+        - "selenium-webdriver"
+    caxlsx:
+      patterns:
+        - "caxlsx"
+        - "caxlsx_rails"
+    rubocop:
+      patterns:
+        - "rubocop"
+        - "rubocop-*"
+    sass:
+      patterns:
+        - "sassc-embedded"
+        - "sassc-rails"
+    simplecov:
+      patterns:
+        - "simplecov"
+        - "simplecov-lcov"
+    sprockets:
+      patterns:
+        - "sprockets"
+        - "sprockets-rails"
 - package-ecosystem: npm
   directory: "/"
   schedule:
     interval: monthly
   open-pull-requests-limit: 50
+  groups:
+    leaflet:
+      patterns:
+        - "leaflet"
+        - "leaflet.*"
+    eslint:
+      patterns:
+        - "@eslint*"
+        - "eslint"
+        - "globals"
+    stylelint:
+      patterns:
+        - "postcss-scss"
+        - "stylelint"
+        - "stylelint-*"
+        - "@stylistic*"
 - package-ecosystem: "github-actions"
   directory: "/"
   schedule:
     interval: monthly
   open-pull-requests-limit: 50
+  groups:
+    actions:
+      patterns:
+        - "*"


### PR DESCRIPTION
## Objectives

* Make it easier to manage dependabot pull requests

## Notes

The main criterion we're using is that we're grouping dependencies that provide the same feature and that are unlikely to break independently. For instance, we aren't grouping pronto dependencies together because it's possible that pronto-stylelint works after the upgrade but pronto-rubocop doesn't.

We're making an exception with github-actions. Those ones have never broken anything, so updating them together doesn't seem too dangerous.

We might use different criteria in the future, once we see the advantages and disadvantages of this approach.