### PR TITLE
Prepend UTF-8 BOM to CSV exports

### DIFF
--- a/app/models/concerns/csv_exporter.rb
+++ b/app/models/concerns/csv_exporter.rb
@@ -1,6 +1,6 @@
 module CsvExporter
   def to_csv
-    CSV.generate(headers: true) do |csv|
+    "\xEF\xBB\xBF" + CSV.generate(headers: true) do |csv|
       csv << headers
       records.each do |record|
         comments = comments_in_reading_order(record)

--- a/spec/models/budget/investment/exporter_spec.rb
+++ b/spec/models/budget/investment/exporter_spec.rb
@@ -37,7 +37,7 @@ describe Budget::Investment::Exporter do
           #{reply.author.email},#{reply.body},#{root_comment.id},2026-06-01 14:59:10
         CSV
 
-        expect(Budget::Investment::Exporter.new([investment]).to_csv).to eq csv_contents
+        expect(Budget::Investment::Exporter.new([investment]).to_csv).to eq "\xEF\xBB\xBF" + csv_contents
       end
     end
   end

--- a/spec/models/csv_exporter_spec.rb
+++ b/spec/models/csv_exporter_spec.rb
@@ -41,7 +41,7 @@ describe CsvExporter do
                                       created_at: Time.zone.local(2026, 6, 1, 15, 15, 0))
 
       csv = exporter_class.new([resource]).to_csv
-      rows = CSV.parse(csv, headers: true)
+      rows = CSV.parse(csv.delete_prefix("\xEF\xBB\xBF"), headers: true)
 
       expect(rows.by_col["Comment Content"]).to eq [
         first_root.body,
@@ -50,6 +50,28 @@ describe CsvExporter do
         second_reply.body,
         second_root.body
       ]
+    end
+  end
+
+  describe "Excel-friendly encoding" do
+    factories = [:budget_investment, :debate, :proposal]
+    let(:factory) { factories.sample }
+    let(:exporter_class) do
+      case factory
+      when :proposal
+        Proposal::Exporter
+      when :debate
+        Debate::Exporter
+      when :budget_investment
+        Budget::Investment::Exporter
+      end
+    end
+    let(:resource) { create(factory) }
+
+    it "includes a UTF-8 byte order mark so Excel detects the encoding" do
+      csv = exporter_class.new([resource]).to_csv
+
+      expect(csv.b).to start_with("\xEF\xBB\xBF".b)
     end
   end
 end

--- a/spec/models/debate/exporter_spec.rb
+++ b/spec/models/debate/exporter_spec.rb
@@ -30,7 +30,7 @@ describe Debate::Exporter do
           #{reply.id},#{reply.author.email},#{reply.body},#{root_comment.id},2026-06-01 14:59:10
         CSV
 
-        expect(Debate::Exporter.new([debate]).to_csv).to eq csv_contents
+        expect(Debate::Exporter.new([debate]).to_csv).to eq "\xEF\xBB\xBF" + csv_contents
       end
     end
   end

--- a/spec/models/proposal/exporter_spec.rb
+++ b/spec/models/proposal/exporter_spec.rb
@@ -33,7 +33,7 @@ describe Proposal::Exporter do
           #{reply.id},#{reply.author.email},#{reply.body},#{root_comment.id},2026-06-01 14:59:10
         CSV
 
-        expect(Proposal::Exporter.new([proposal]).to_csv).to eq csv_contents
+        expect(Proposal::Exporter.new([proposal]).to_csv).to eq "\xEF\xBB\xBF" + csv_contents
       end
     end
   end

--- a/spec/system/admin/budget_investments_spec.rb
+++ b/spec/system/admin/budget_investments_spec.rb
@@ -1702,7 +1702,7 @@ describe "Admin budget investments", :admin do
                      "#{second_investment.author.username},2026-06-01 14:58:20," \
                      "\"\",\"\",\"\",\"\",\"\"\n"
 
-      expect(page.body).to eq(csv_contents)
+      expect(page.body).to eq("\xEF\xBB\xBF" + csv_contents)
     end
 
     scenario "Downloading CSV file with applied filter" do

--- a/spec/system/admin/debates_spec.rb
+++ b/spec/system/admin/debates_spec.rb
@@ -58,7 +58,7 @@ describe "Admin debates", :admin do
         #{first_debate.author.email},2026-06-01 14:56:10,"","","","",""
       CSV
 
-      expect(page.body).to eq(csv_contents)
+      expect(page.body).to eq("\xEF\xBB\xBF" + csv_contents)
     end
 
     scenario "Downloading CSV file with applied filter" do

--- a/spec/system/admin/proposals_spec.rb
+++ b/spec/system/admin/proposals_spec.rb
@@ -138,7 +138,7 @@ describe "Admin proposals", :admin do
         #{first_proposal.author.email},#{first_proposal.summary},2026-06-01 14:56:10,"","","","",""
       CSV
 
-      expect(page.body).to eq(csv_contents)
+      expect(page.body).to eq("\xEF\xBB\xBF" + csv_contents)
     end
 
     scenario "Downloading CSV file with applied filter" do


### PR DESCRIPTION
## References

Fix for issue #2681 

## Objectives

Exported CSV files (Investments, Proposals, Debates) don't specify a byte order mark, so Excel (especially on Windows) fails to detect UTF-8 and shows garbled accented characters (e.g. "Investigación" → "Investigaci�n") when opened directly. This adds a UTF-8 BOM to `CsvExporter#to_csv`, so exports open correctly in Excel with no manual encoding step needed.

## Notes

The existing "comment reading order" spec parses the exported CSV directly and needed updating to `encoding: "bom|utf-8"` so it correctly strips the new BOM before comparing headers — otherwise the first header would fail to match. No deploy steps or rake tasks needed; this only affects newly generated exports.
