### PR TITLE
Remove legacy Paperclip columns from site customization images

### DIFF
--- a/db/migrate/20260828184039_remove_paperclip_columns_from_site_customization_images.rb
+++ b/db/migrate/20260828184039_remove_paperclip_columns_from_site_customization_images.rb
@@ -1,0 +1,10 @@
+class RemovePaperclipColumnsFromSiteCustomizationImages < ActiveRecord::Migration[8.0]
+  def change
+    change_table :site_customization_images do |t|
+      t.remove :image_file_name, type: :string
+      t.remove :image_content_type, type: :string
+      t.remove :image_file_size, type: :bigint
+      t.remove :image_updated_at, type: :datetime
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_07_29_120000) do
+ActiveRecord::Schema[8.0].define(version: 2026_08_28_184039) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -1477,10 +1477,6 @@ ActiveRecord::Schema[8.0].define(version: 2026_07_29_120000) do
 
   create_table "site_customization_images", id: :serial, force: :cascade do |t|
     t.string "name", null: false
-    t.string "image_file_name"
-    t.string "image_content_type"
-    t.bigint "image_file_size"
-    t.datetime "image_updated_at", precision: nil
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
     t.index ["name"], name: "index_site_customization_images_on_name", unique: true


### PR DESCRIPTION
## References

* We removed other legacy paperclip columns in pull request #5281, but forgot to remove these ones.
* We haven't used these columns since pull request #4600, and every Consul Democracy installation has been using Active Storage since version 1.5.0.

## Objectives

* Remove columns that haven't been used for years.