### PR TITLE
Fix serious Axe accessibility errors found after clicking buttons

### DIFF
--- a/app/assets/javascripts/account_menu.js
+++ b/app/assets/javascripts/account_menu.js
@@ -1,8 +1,0 @@
-(function() {
-  "use strict";
-  App.AccountMenu = {
-    initialize: function() {
-      $(".account-menu > li > form button").attr("role", "menuitem");
-    }
-  };
-}).call(this);

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -85,7 +85,6 @@
 //= require columns_selector
 //= require budget_edit_associations
 //= require budget_hide_money
-//= require account_menu
 //= require authenticity_token_refresh
 //= require_tree ./admin
 //= require_tree ./polls
@@ -150,7 +149,6 @@ var initialize_modules = function() {
   App.PollsForm.initialize();
   App.SDGRelatedListSelector.initialize();
   App.SDGManagementRelationSearch.initialize();
-  App.AccountMenu.initialize();
   App.AuthenticityTokenRefresh.initialize();
   App.CookiesConsent.initialize();
 };

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -107,6 +107,7 @@ a {
 
 a,
 button,
+summary,
 [type="button"],
 [type="submit"] {
   &:focus {

--- a/app/assets/stylesheets/layout/account_menu.scss
+++ b/app/assets/stylesheets/layout/account_menu.scss
@@ -11,19 +11,6 @@
     }
   }
 
-  .is-dropdown-submenu {
-    @extend %body-colors;
-    margin: 0;
-    margin-top: rem-calc(-12);
-    padding: 0;
-    z-index: 9;
-  }
-
-  .is-submenu-item {
-    display: block;
-    margin-bottom: 0;
-  }
-
   li {
     display: block;
     width: 100%;
@@ -33,7 +20,8 @@
     }
 
     a,
-    button {
+    button,
+    summary {
       color: inherit;
       cursor: pointer;
       line-height: inherit;
@@ -61,10 +49,26 @@
     }
   }
 
-  .has-submenu {
+  .admin-login-items {
+    details {
+      position: relative;
 
-    &.is-active a {
-      font-weight: bold;
+      &[open] {
+        summary {
+          font-weight: bold;
+        }
+      }
+
+      ul {
+        @extend %body-colors;
+        background: $dropdownmenu-submenu-background;
+        border: $dropdownmenu-border;
+        margin-top: calc($line-height / 4);
+        min-width: $dropdownmenu-min-width;
+        position: absolute;
+        top: 100%;
+        z-index: 9;
+      }
     }
   }
 }

--- a/app/components/admin/budgets/heading_mode_component.html.erb
+++ b/app/components/admin/budgets/heading_mode_component.html.erb
@@ -1,5 +1,5 @@
-<section class="reveal heading-mode" id="heading_mode" data-reveal>
-  <h1><%= t("#{i18n_namespace}.title") %></h1>
+<section class="reveal heading-mode" id="heading_mode" aria-labelledby="heading_mode_header" data-reveal>
+  <h1 id="heading_mode_header"><%= t("#{i18n_namespace}.title") %></h1>
 
   <% modes.each do |mode| %>
     <section class="<%= mode %>-heading-option">

--- a/app/components/admin/site_customization/images/table_actions_component.html.erb
+++ b/app/components/admin/site_customization/images/table_actions_component.html.erb
@@ -1,7 +1,7 @@
 <div class="site-customization-images-table-actions">
   <%= form_for([:admin, image], html: { id: "edit_#{dom_id(image)}" }) do |f| %>
     <div>
-      <%= image_tag image.image if image.persisted_attachment? %>
+      <%= image_tag image.image, alt: image.name if image.persisted_attachment? %>
       <%= f.file_field :image,
                        label: false,
                        "aria-label": image.name,

--- a/app/components/attachable/fields_component.rb
+++ b/app/components/attachable/fields_component.rb
@@ -54,6 +54,7 @@ class Attachable::FieldsComponent < ApplicationComponent
       f.file_field :attachment,
                    label_options: { class: "button hollow #{klass}" },
                    accept: accepted_content_types_extensions,
+                   class: klass,
                    data: { url: direct_upload_path }
     end
 

--- a/app/components/attachable/fields_component.rb
+++ b/app/components/attachable/fields_component.rb
@@ -50,7 +50,7 @@ class Attachable::FieldsComponent < ApplicationComponent
     end
 
     def file_field
-      klass = attachable.persisted? || attachable.cached_attachment.present? ? " hide" : ""
+      klass = attachable.persisted? || attachable.cached_attachment.present? ? "hide" : ""
       f.file_field :attachment,
                    label_options: { class: "button hollow #{klass}" },
                    accept: accepted_content_types_extensions,

--- a/app/components/layout/account_menu_component.html.erb
+++ b/app/components/layout/account_menu_component.html.erb
@@ -1,4 +1,4 @@
-<ul class="account-menu menu" data-responsive-menu="medium-dropdown">
+<ul class="account-menu menu">
   <%= render Layout::AdminLoginItemsComponent.new(user) %>
   <%= render Layout::NotificationItemComponent.new(user) %>
   <%= render Layout::LoginItemsComponent.new(user) %>

--- a/app/components/layout/admin_login_items_component.html.erb
+++ b/app/components/layout/admin_login_items_component.html.erb
@@ -1,4 +1,8 @@
-<li class="has-submenu">
-  <%= link_to t("layouts.header.administration_menu"), "#", rel: "nofollow", class: "hide-for-small-only" %>
-  <%= link_list(*admin_links, class: "submenu menu", data: { submenu: true }) %>
+<li class="admin-login-items">
+  <details class="hide-for-small-only">
+    <summary><%= t("layouts.header.administration_menu") %></summary>
+    <%= link_list(*admin_links, class: "submenu menu") %>
+  </details>
+
+  <%= link_list(*admin_links, class: "submenu menu show-for-small-only") %>
 </li>

--- a/app/views/admin/valuator_groups/show.html.erb
+++ b/app/views/admin/valuator_groups/show.html.erb
@@ -2,12 +2,12 @@
 
 <h2><%= t("admin.valuator_groups.show.title", group: @group.name) %></h2>
 
-<ul id="valuators">
-  <% if @group.valuators.any? %>
+<% if @group.valuators.any? %>
+  <ul id="valuators">
     <%= render partial: "valuator", collection: @group.valuators %>
-  <% else %>
-    <div class="callout primary">
-      <%= t("admin.valuator_groups.show.no_valuators") %>
-    </div>
-  <% end %>
-</ul>
+  </ul>
+<% else %>
+  <div class="callout primary">
+    <%= t("admin.valuator_groups.show.no_valuators") %>
+  </div>
+<% end %>

--- a/spec/components/layout/admin_login_items_component_spec.rb
+++ b/spec/components/layout/admin_login_items_component_spec.rb
@@ -29,7 +29,7 @@ describe Layout::AdminLoginItemsComponent do
 
     render_inline Layout::AdminLoginItemsComponent.new(user)
 
-    expect(page).to have_link "Menu"
+    expect(page).to have_css "summary", exact_text: "Menu"
 
     page.find("ul") do |menu|
       expect(menu).to have_link "Administration"
@@ -46,7 +46,7 @@ describe Layout::AdminLoginItemsComponent do
 
     render_inline Layout::AdminLoginItemsComponent.new(user)
 
-    expect(page).to have_link "Menu"
+    expect(page).to have_css "summary", exact_text: "Menu"
 
     page.find("ul") do |menu|
       expect(menu).to have_link "Moderation"
@@ -59,7 +59,7 @@ describe Layout::AdminLoginItemsComponent do
 
     render_inline Layout::AdminLoginItemsComponent.new(user)
 
-    expect(page).to have_link "Menu"
+    expect(page).to have_css "summary", exact_text: "Menu"
 
     page.find("ul") do |menu|
       expect(menu).to have_link "Valuation"
@@ -72,7 +72,7 @@ describe Layout::AdminLoginItemsComponent do
 
     render_inline Layout::AdminLoginItemsComponent.new(user)
 
-    expect(page).to have_link "Menu"
+    expect(page).to have_css "summary", exact_text: "Menu"
 
     page.find("ul") do |menu|
       expect(menu).to have_link "Management"
@@ -85,7 +85,7 @@ describe Layout::AdminLoginItemsComponent do
 
     render_inline Layout::AdminLoginItemsComponent.new(user)
 
-    expect(page).to have_link "Menu"
+    expect(page).to have_css "summary", exact_text: "Menu"
 
     page.find("ul") do |menu|
       expect(menu).to have_link "SDG content"
@@ -99,7 +99,7 @@ describe Layout::AdminLoginItemsComponent do
 
     render_inline Layout::AdminLoginItemsComponent.new(user)
 
-    expect(page).to have_link "Menu"
+    expect(page).to have_css "summary", exact_text: "Menu"
 
     page.find("ul") do |menu|
       expect(menu).to have_link "Administration"
@@ -115,7 +115,7 @@ describe Layout::AdminLoginItemsComponent do
 
     render_inline Layout::AdminLoginItemsComponent.new(user)
 
-    expect(page).to have_link "Menu"
+    expect(page).to have_css "summary", exact_text: "Menu"
 
     page.find("ul") do |menu|
       expect(menu).to have_link "Polling officers"
@@ -130,7 +130,7 @@ describe Layout::AdminLoginItemsComponent do
 
     render_inline Layout::AdminLoginItemsComponent.new(user)
 
-    expect(page).to have_link "Menu"
+    expect(page).to have_css "summary", exact_text: "Menu"
 
     page.find("ul") do |menu|
       expect(menu).to have_link "Moderation"

--- a/spec/support/common_actions.rb
+++ b/spec/support/common_actions.rb
@@ -19,6 +19,7 @@ module CommonActions
   include Translations
   include Users
   include Verifications
+  include WindowSizeHelper
 
   def app_host
     "#{Capybara.app_host}:#{app_port}"
@@ -26,6 +27,10 @@ module CommonActions
 
   def app_port
     Capybara::Server.ports.values.last
+  end
+
+  def click_summary(text = nil, **)
+    find("summary", exact_text: text, **).click
   end
 
   def fill_in_signup_form(email = "manuela@consul.dev", password = "judgementday")

--- a/spec/support/common_actions/window_size_helper.rb
+++ b/spec/support/common_actions/window_size_helper.rb
@@ -1,0 +1,13 @@
+module WindowSizeHelper
+  def with_window_size(width, height, &block)
+    original_size = Capybara.current_window.size
+    Capybara.current_window.resize_to(width, height)
+    block.call
+  ensure
+    Capybara.current_window.resize_to(*original_size)
+  end
+
+  def with_small_window(&)
+    with_window_size(320, 640, &)
+  end
+end

--- a/spec/system/admin_spec.rb
+++ b/spec/system/admin_spec.rb
@@ -64,7 +64,7 @@ describe "Admin" do
   scenario "Access as administrator is authorized", :admin do
     visit root_path
 
-    click_link "Menu"
+    click_summary "Menu"
     click_link "Administration"
 
     expect(page).to have_current_path(admin_root_path)
@@ -101,6 +101,24 @@ describe "Admin" do
       click_button "Menu"
 
       expect(page).to have_link "My account"
+    end
+
+    scenario "shows admin links when resizing the window" do
+      visit admin_root_path
+
+      click_summary "Menu"
+
+      expect(page).to have_link "Administration"
+
+      with_small_window do
+        expect(page).to have_button "Menu"
+        expect(page).not_to have_css "summary", text: "Menu"
+        expect(page).not_to have_link "Administration"
+
+        click_button "Menu"
+
+        expect(page).to have_link "Administration"
+      end
     end
   end
 end

--- a/spec/system/budget_polls/ballot_sheets_spec.rb
+++ b/spec/system/budget_polls/ballot_sheets_spec.rb
@@ -18,7 +18,7 @@ describe "Poll budget ballot sheets" do
     scenario "Budget polls are visible" do
       visit root_path
 
-      click_link "Menu"
+      click_summary "Menu"
       click_link "Polling officers"
 
       within("#side_menu") do

--- a/spec/system/budgets/votes_spec.rb
+++ b/spec/system/budgets/votes_spec.rb
@@ -195,9 +195,12 @@ describe "Votes" do
 
       scenario "Confirm message shows the right text" do
         visit budget_investments_path(budget, heading_id: new_york.id)
-        click_button "Support"
 
-        expect(page.driver.send(:find_modal).text).to match "You can only support investments in 2 districts."
+        accept_confirm(/You can only support investments in 2 districts./) do
+          click_button "Support"
+        end
+
+        expect(page).to have_content "Investment supported successfully"
       end
 
       scenario "Do not show confirm message if user can vote in all headings" do

--- a/spec/system/moderation_spec.rb
+++ b/spec/system/moderation_spec.rb
@@ -30,7 +30,7 @@ describe "Moderation" do
 
         login_as(user)
         visit root_path
-        click_link "Menu"
+        click_summary "Menu"
         click_link "Moderation"
 
         expect(page).to have_current_path moderation_root_path

--- a/spec/system/officing/results_spec.rb
+++ b/spec/system/officing/results_spec.rb
@@ -27,7 +27,7 @@ describe "Officing Results", :with_frozen_time do
     not_allowed_poll_3 = create(:poll, officers: [poll_officer])
 
     visit root_path
-    click_link "Menu"
+    click_summary "Menu"
     click_link "Polling officers"
 
     expect(page).to have_content("Poll officing")

--- a/spec/system/officing_spec.rb
+++ b/spec/system/officing_spec.rb
@@ -75,7 +75,7 @@ describe "Poll Officing" do
     login_as(user)
     visit root_path
 
-    click_link "Menu"
+    click_summary "Menu"
     click_link "Polling officers"
 
     expect(page).to have_current_path(officing_root_path)
@@ -87,7 +87,7 @@ describe "Poll Officing" do
     login_as(user)
     visit root_path
 
-    click_link "Menu"
+    click_summary "Menu"
     click_link "Polling officers"
 
     expect(page).to have_current_path(officing_root_path)

--- a/spec/system/sdg_management_spec.rb
+++ b/spec/system/sdg_management_spec.rb
@@ -32,7 +32,7 @@ describe "SDGManagement" do
       login_as(user)
       visit root_path
 
-      click_link "Menu"
+      click_summary "Menu"
       click_link "SDG content"
 
       expect(page).to have_current_path(sdg_management_root_path)

--- a/spec/system/valuation_spec.rb
+++ b/spec/system/valuation_spec.rb
@@ -64,7 +64,7 @@ describe "Valuation" do
       login_as(user)
 
       visit root_path
-      click_link "Menu"
+      click_summary "Menu"
       click_link "Valuation"
 
       expect(page).to have_current_path(valuation_root_path)
@@ -80,7 +80,7 @@ describe "Valuation" do
       login_as(user)
 
       visit root_path
-      click_link "Menu"
+      click_summary "Menu"
       click_link "Valuation"
 
       expect(page).to have_current_path(valuation_root_path)


### PR DESCRIPTION
## References

* Continues pull request #6144.

## Objectives

* Make sure people using screen readers properly hear the dialog to create a new budget.
* Use valid HTML in the list of valuators when there are no valuators.
* Make sure people using screen readers can't interact with unlabeled, visually-hidden fields.
* Make sure administrators using screen readers can hear the title of site customization images after attaching them.
* Make the login items menu more accessible and robust. 

## Notes

Back in pull request #6144, we were using axe in our [axe_accessibility_tests branch](https://github.com/consuldemocracy/consuldemocracy/tree/axe_accessibility_tests) to test what accessibility when visiting a page or clicking a link. However, back then we weren't testing what happened after clicking buttons.

Now, the axe_accessibility_tests branch uses the [capybara_accessibility_audit gem](https://github.com/thoughtbot/capybara_accessibility_audit), so we can test accessibility after clicking buttons as well. Thanks to that, we've found new accessibility issues.