### PR TITLE
Poll card questions number

### DIFF
--- a/app/components/polls/poll_component.html.erb
+++ b/app/components/polls/poll_component.html.erb
@@ -12,10 +12,13 @@
     <div class="dates"><%= dates %></div>
     <% if poll.questions.many? %>
       <ul class="margin-top">
-        <% poll.questions.sort_for_list.each do |question| %>
+        <% questions_to_list.each do |question| %>
           <li><%= question.title %></li>
         <% end %>
       </ul>
+      <% if more_questions_than_shown? %>
+        <div class="questions-count"><%= questions_count_text %></div>
+      <% end %>
     <% end %>
     <%= render Polls::GeozonesComponent.new(poll) %>
     <%= render SDG::TagListComponent.new(poll, limit: 5, linkable: false) %>

--- a/app/components/polls/poll_component.rb
+++ b/app/components/polls/poll_component.rb
@@ -11,6 +11,18 @@ class Polls::PollComponent < ApplicationComponent
       t("polls.dates", open_at: l(poll.starts_at.to_date), closed_at: l(poll.ends_at.to_date))
     end
 
+    def questions_to_list
+      poll.questions.sort_for_list.first(2)
+    end
+
+    def more_questions_than_shown?
+      poll.questions.count > 2
+    end
+
+    def questions_count_text
+      t("polls.questions_count", count: poll.questions.count)
+    end
+
     def header_text
       if poll.questions.one?
         poll.questions.first.title

--- a/config/locales/en/general.yml
+++ b/config/locales/en/general.yml
@@ -579,6 +579,9 @@ en:
   polls:
     dates: "From %{open_at} to %{closed_at}"
     final_date: "Final recounts/Results"
+    questions_count:
+      one: "This poll has 1 question."
+      other: "This poll has %{count} questions."
     form:
       vote: "Vote"
       maximum_exceeded: "you've selected %{given} answers, but the maximum you can select is %{maximum}"

--- a/config/locales/es-PE/general.yml
+++ b/config/locales/es-PE/general.yml
@@ -384,8 +384,8 @@ es-PE:
     dates: "Desde el %{open_at} hasta el %{closed_at}"
     final_date: "Recuento final/Resultados"
     questions_count:
-      one: "Esta votación tiene 1 pregunta."
-      other: "Esta votación tiene %{count} preguntas."
+      one: "Esta encuesta tiene 1 pregunta."
+      other: "Esta encuesta tiene %{count} preguntas."
     index:
       filters:
         current: "Abierto"

--- a/config/locales/es-PE/general.yml
+++ b/config/locales/es-PE/general.yml
@@ -383,6 +383,9 @@ es-PE:
   polls:
     dates: "Desde el %{open_at} hasta el %{closed_at}"
     final_date: "Recuento final/Resultados"
+    questions_count:
+      one: "Esta votación tiene 1 pregunta."
+      other: "Esta votación tiene %{count} preguntas."
     index:
       filters:
         current: "Abierto"

--- a/config/locales/es/general.yml
+++ b/config/locales/es/general.yml
@@ -580,8 +580,8 @@ es:
     dates: "Desde el %{open_at} hasta el %{closed_at}"
     final_date: "Recuento final/Resultados"
     questions_count:
-      one: "Esta votación tiene 1 pregunta."
-      other: "Esta votación tiene %{count} preguntas."
+      one: "Esta encuesta tiene 1 pregunta."
+      other: "Esta encuesta tiene %{count} preguntas."
     form:
       vote: "Votar"
       maximum_exceeded: "has seleccionado %{given} respuestas, pero el máximo que puedes seleccionar es %{maximum}"

--- a/config/locales/es/general.yml
+++ b/config/locales/es/general.yml
@@ -579,6 +579,9 @@ es:
   polls:
     dates: "Desde el %{open_at} hasta el %{closed_at}"
     final_date: "Recuento final/Resultados"
+    questions_count:
+      one: "Esta votación tiene 1 pregunta."
+      other: "Esta votación tiene %{count} preguntas."
     form:
       vote: "Votar"
       maximum_exceeded: "has seleccionado %{given} respuestas, pero el máximo que puedes seleccionar es %{maximum}"

--- a/spec/components/polls/poll_component_spec.rb
+++ b/spec/components/polls/poll_component_spec.rb
@@ -24,6 +24,34 @@ describe Polls::PollComponent do
     end
   end
 
+  describe "questions" do
+    it "shows all questions when there are 2, without a count line" do
+      poll = create(:poll)
+      create(:poll_question, poll: poll, title: "First question")
+      create(:poll_question, poll: poll, title: "Second question")
+
+      render_inline Polls::PollComponent.new(poll)
+
+      expect(page).to have_content "First question"
+      expect(page).to have_content "Second question"
+      expect(page).not_to have_content "This poll has"
+    end
+
+    it "shows only the first 2 questions plus a count when there are more than 2" do
+      poll = create(:poll)
+      create(:poll_question, poll: poll, title: "First question")
+      create(:poll_question, poll: poll, title: "Second question")
+      create(:poll_question, poll: poll, title: "Third question")
+
+      render_inline Polls::PollComponent.new(poll)
+
+      expect(page).to have_content "First question"
+      expect(page).to have_content "Second question"
+      expect(page).not_to have_content "Third question"
+      expect(page).to have_content "This poll has 3 questions."
+    end
+  end
+
   describe "geozones" do
     it "renders a list of geozones when the poll is geozone-restricted" do
       render_inline Polls::PollComponent.new(create(:poll, geozone_restricted_to: [create(:geozone)]))


### PR DESCRIPTION
## References

We received feedback regarding the poll index cards, where listing every question on the index page makes cards inconsistently long.

## Objectives

Polls with 3+ questions will now show only the first 2 questions plus a "This poll has N questions" summary line; polls with 1–2 questions are unchanged.

## Visual Changes
Before:
<img width="1412" height="633" alt="image (2)" src="https://github.com/user-attachments/assets/11e2d47a-0017-4652-b42c-65753d41e622" />

After: 
<img width="1217" height="317" alt="Screenshot 2026-09-03 at 10 53 19" src="https://github.com/user-attachments/assets/06db702d-05ae-45ad-86fd-2253fcb7bb7a" />

