### PR TITLE
Bump Delayed Job from 4.1.13 to 4.2.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -192,8 +192,10 @@ GEM
     debug (1.11.1)
       irb (~> 1.10)
       reline (>= 0.3.8)
-    delayed_job (4.1.13)
+    delayed_job (4.2.0)
       activesupport (>= 3.0, < 9.0)
+      benchmark
+      logger
     delayed_job_active_record (4.1.11)
       activerecord (>= 3.0, < 9.0)
       delayed_job (>= 3.0, < 5)


### PR DESCRIPTION
## References

* [Release notes](https://github.com/collectiveidea/delayed_job/releases)
* [Changelog](https://github.com/collectiveidea/delayed_job/blob/master/CHANGELOG.md)
* [Commits](https://github.com/collectiveidea/delayed_job/compare/v4.1.13...v4.2.0)

## Objectives

Avoid a warning we were getting when upgrading to Rails 8.1:

```
ruby/3.4.0/gems/delayed_job-4.1.13/lib/delayed/worker.rb:9: warning:
benchmark was loaded from the standard library, but will no longer be
part of the default gems starting from Ruby 4.0.0. You can add benchmark
to your Gemfile or gemspec to silence this warning.
```